### PR TITLE
Update API URLs to use HTTPS for improved security

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -13,7 +13,7 @@ The authentication system provides:
 ## API Endpoints
 
 ### Sign Up
-- **URL**: `POST http://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-instance.org:8080/api/v1/users/sign-up`
+- **URL**: `POST https://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-instance.org/api/v1/users/sign-up`
 - **Request Body**:
   ```json
   {
@@ -34,7 +34,7 @@ The authentication system provides:
   ```
 
 ### Sign In
-- **URL**: `POST http://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-instance.org:8080/api/v1/users/login`
+- **URL**: `POST https://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-instance.org/api/v1/users/login`
 - **Request Body**:
   ```json
   {
@@ -57,7 +57,7 @@ The authentication system provides:
   ```
 
 ### Token Refresh
-- **URL**: `POST http://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-instance.org:8080/api/v1/users/access-token/by-refresh-token`
+- **URL**: `POST https://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-instance.org/api/v1/users/access-token/by-refresh-token`
 - **Request Body**:
   ```json
   {
@@ -235,7 +235,7 @@ function TokenManagement() {
 ### Backend URL
 The backend URL is configured in `src/services/auth.ts`:
 ```typescript
-private static readonly LOCAL_API_BASE_URL = 'http://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-instance.org:8080';
+private static readonly LOCAL_API_BASE_URL = 'https://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-instance.org';
 ```
 
 ### Token Storage
@@ -269,7 +269,7 @@ The system provides comprehensive error handling:
 
 To test the authentication system:
 
-1. Ensure your backend server is running on `http://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-instance.org:8080`
+1. Ensure your backend server is running on `https://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-instance.org`
 2. Use the sign-up form to create a new account
 3. Use the sign-in form to authenticate
 4. Check the browser's developer tools to see stored tokens

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,7 +3,7 @@ import { FlowData } from '../types/flow';
 import { ApiResponse, Vsum, VsumDetails } from '../types/vsum';
 
 class ApiService {
-  private readonly baseURL = 'http://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-instance.org:8080';
+  private readonly baseURL = 'https://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-instance.org';
 
   /**
    * Extract error message from response text

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -44,8 +44,8 @@ export interface User {
 }
 
 export class AuthService {
-  private static readonly API_BASE_URL = 'http://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-instance.org:8080';
-  private static readonly LOCAL_API_BASE_URL = 'http://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-instance.org:8080';
+  private static readonly API_BASE_URL = 'https://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-instance.org';
+  private static readonly LOCAL_API_BASE_URL = 'https://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-instance.org';
   private static readonly CLIENT_ID = 'exit-normal-customer-mobile-app';
   private static readonly GRANT_TYPE = 'password';
 


### PR DESCRIPTION
This pull request updates all API endpoint URLs and related configuration from HTTP to HTTPS, ensuring secure communication throughout the authentication system and API services. This change affects both documentation and code, improving security and consistency.

**Security and configuration updates:**

* Updated all authentication API endpoint URLs in `AUTHENTICATION.md` to use HTTPS instead of HTTP, including Sign Up, Sign In, and Token Refresh endpoints. [[1]](diffhunk://#diff-c6527cadc7c471b3839f9c5961e2936f932556849f764869273e78c5639cc9feL16-R16) [[2]](diffhunk://#diff-c6527cadc7c471b3839f9c5961e2936f932556849f764869273e78c5639cc9feL37-R37) [[3]](diffhunk://#diff-c6527cadc7c471b3839f9c5961e2936f932556849f764869273e78c5639cc9feL60-R60)
* Changed backend server instructions and example URLs in `AUTHENTICATION.md` to use HTTPS.
* Updated API base URLs in both `src/services/auth.ts` and `src/services/api.ts` to use HTTPS, ensuring all service requests are sent securely. [[1]](diffhunk://#diff-1e4285f62959d16bf21c21ca382130a7ef3675bcc812a0a100e8fd06251be758L47-R48) [[2]](diffhunk://#diff-0e184ea1c8a349adddc149579c2624e138ff629253721c460c28db1a33119533L6-R6) [[3]](diffhunk://#diff-c6527cadc7c471b3839f9c5961e2936f932556849f764869273e78c5639cc9feL238-R238)