### PR TITLE
Fast login with using fe ls

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -6,3 +6,5 @@ REACT_APP_API_BASE_URL=https://mwa.sdq.kastel.kit.edu
 
 # Environment identifier
 REACT_APP_ENV=production
+
+REACT_APP_FAST_LOGIN_REDIRECT_URL=https://mwa.sdq.kastel.kit.edu/auth/callback

--- a/.env.staging
+++ b/.env.staging
@@ -6,3 +6,5 @@ REACT_APP_API_BASE_URL=https://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-
 
 # Environment identifier
 REACT_APP_ENV=staging
+
+REACT_APP_FAST_LOGIN_REDIRECT_URL=https://fe3ab829-d558-4834-afcf-6ed7ca440ca4.ka.bw-cloud-instance.org/auth/callback

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
-import { AuthPage, KeycloakRedirect } from './components/auth';
+import { AuthPage, FastLoginCallback, KeycloakRedirect } from './components/auth';
 import { HomePage } from './pages/HomePage';
 import { ProjectPage } from './pages/ProjectPage';
 import { EditorTest } from './pages/EditorTest';  // <- NEU
@@ -102,6 +102,7 @@ function App() {
         <Routes>
           <Route path="/login" element={<AuthPage />} />
           <Route path="/auth" element={<KeycloakRedirect />} />
+          <Route path="/auth/callback" element={<FastLoginCallback />} />
           <Route path="/verify-otp" element={<OtpVerificationPage />} />
           <Route path="/" element={
             <ProtectedRoute>

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -365,3 +365,106 @@ describe('AuthService – additional coverage', () => {
     expect(signOutSpy).toHaveBeenCalled();
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AuthService – exchangeFastLoginCode
+// ─────────────────────────────────────────────────────────────────────────────
+describe('AuthService.exchangeFastLoginCode', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    jest.restoreAllMocks();
+    global.fetch = jest.fn() as jest.Mock;
+  });
+
+  it('stores all tokens in localStorage on success', async () => {
+    sessionStorage.setItem('fast_login_redirect_uri', 'http://localhost:3000/auth/callback');
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => baseAuthResponse,
+    });
+
+    const result = await AuthService.exchangeFastLoginCode('test-code');
+
+    expect(result.access_token).toBe('access-token');
+    expect(localStorage.getItem('auth.access_token')).toBe('access-token');
+    expect(localStorage.getItem('auth.refresh_token')).toBe('refresh-token');
+    expect(localStorage.getItem('auth.token_type')).toBe('Bearer');
+    expect(localStorage.getItem('auth.scope')).toBe('openid');
+    expect(localStorage.getItem('auth.access_expires_at')).toBeTruthy();
+    expect(localStorage.getItem('auth.refresh_expires_at')).toBeTruthy();
+  });
+
+  it('POSTs to the token endpoint with correct form fields', async () => {
+    sessionStorage.setItem('fast_login_redirect_uri', 'http://localhost:3000/auth/callback');
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => baseAuthResponse,
+    });
+
+    await AuthService.exchangeFastLoginCode('my-code');
+
+    const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toMatch(/\/auth\/realms\/methodologist\/protocol\/openid-connect\/token/);
+    expect(options.method).toBe('POST');
+    expect(options.headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+    const body = new URLSearchParams(options.body as string);
+    expect(body.get('grant_type')).toBe('authorization_code');
+    expect(body.get('client_id')).toBe('normal-customer-mobile-app');
+    expect(body.get('code')).toBe('my-code');
+    expect(body.get('redirect_uri')).toBe('http://localhost:3000/auth/callback');
+  });
+
+  it('clears the saved redirect_uri from sessionStorage after success', async () => {
+    sessionStorage.setItem('fast_login_redirect_uri', 'http://localhost:3000/auth/callback');
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => baseAuthResponse,
+    });
+
+    await AuthService.exchangeFastLoginCode('code');
+
+    expect(sessionStorage.getItem('fast_login_redirect_uri')).toBeNull();
+  });
+
+  it('uses saved sessionStorage redirect_uri in the request body', async () => {
+    sessionStorage.setItem('fast_login_redirect_uri', 'https://example.com/callback');
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => baseAuthResponse,
+    });
+
+    await AuthService.exchangeFastLoginCode('code');
+
+    const body = new URLSearchParams(
+      (global.fetch as jest.Mock).mock.calls[0][1].body as string,
+    );
+    expect(body.get('redirect_uri')).toBe('https://example.com/callback');
+  });
+
+  it('throws parsed error message when token endpoint returns error', async () => {
+    sessionStorage.setItem('fast_login_redirect_uri', 'http://localhost:3000/auth/callback');
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: async () => JSON.stringify({ error_description: 'Code expired' }),
+    });
+
+    await expect(AuthService.exchangeFastLoginCode('bad-code')).rejects.toThrow('Code expired');
+  });
+
+  it('throws when token endpoint error body is empty (falls back to statusText)', async () => {
+    sessionStorage.setItem('fast_login_redirect_uri', 'http://localhost:3000/auth/callback');
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: async () => '',
+    });
+
+    // extractErrorMessage returns statusText when body is empty,
+    // so the thrown message will be "Bad Request" (not the fallback string).
+    await expect(AuthService.exchangeFastLoginCode('bad-code')).rejects.toThrow();
+  });
+});

--- a/src/__tests__/components/auth/FastLoginCallback.test.tsx
+++ b/src/__tests__/components/auth/FastLoginCallback.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { FastLoginCallback } from '../../../components/auth/FastLoginCallback';
+
+const mockUseFastLoginCallback = jest.fn();
+
+jest.mock('../../../hooks/useFastLoginCallback', () => ({
+  useFastLoginCallback: () => mockUseFastLoginCallback(),
+}));
+
+function renderCallback() {
+  return render(
+    <MemoryRouter>
+      <FastLoginCallback />
+    </MemoryRouter>,
+  );
+}
+
+describe('FastLoginCallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows loading spinner while processing', () => {
+    mockUseFastLoginCallback.mockReturnValue({ isProcessing: true, error: null });
+    renderCallback();
+    expect(screen.getByText(/Completing Fast Login/i)).toBeInTheDocument();
+    expect(screen.getByText(/Exchanging authorization code/i)).toBeInTheDocument();
+  });
+
+  it('shows error state with message when fast login fails', () => {
+    mockUseFastLoginCallback.mockReturnValue({
+      isProcessing: false,
+      error: 'Invalid authorization code',
+    });
+    renderCallback();
+    expect(screen.getByText(/Fast Login Failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Invalid authorization code/i)).toBeInTheDocument();
+  });
+
+  it('shows "Back to Sign In" link pointing to /login on error', () => {
+    mockUseFastLoginCallback.mockReturnValue({
+      isProcessing: false,
+      error: 'Something went wrong',
+    });
+    renderCallback();
+    const link = screen.getByRole('link', { name: /Back to Sign In/i });
+    expect(link).toHaveAttribute('href', '/login');
+  });
+
+  it('shows generic processing text when not processing and no error', () => {
+    mockUseFastLoginCallback.mockReturnValue({ isProcessing: false, error: null });
+    renderCallback();
+    expect(screen.getByText(/Processing/i)).toBeInTheDocument();
+  });
+
+  it('does not show error block while processing', () => {
+    mockUseFastLoginCallback.mockReturnValue({ isProcessing: true, error: null });
+    renderCallback();
+    expect(screen.queryByText(/Fast Login Failed/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/auth/SignIn.test.tsx
+++ b/src/__tests__/components/auth/SignIn.test.tsx
@@ -280,3 +280,73 @@ describe('SignIn – forgot password dialog', () => {
     expect(mockOnSwitchToSignUp).toHaveBeenCalled();
   });
 });
+
+// ── Fast Login button ─────────────────────────────────────────────────────────
+
+import { AuthService } from '../../../services/auth';
+
+describe('SignIn – Fast Login button', () => {
+  // JSDOM marks location.assign as read-only; replace globalThis.location with
+  // a plain object so we can intercept the redirect call.
+  const assignMock = jest.fn();
+  const originalLocation = globalThis.location;
+
+  let fastLoginSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    // @ts-ignore — intentional JSDOM workaround
+    delete globalThis.location;
+    (globalThis as any).location = { ...originalLocation, assign: assignMock };
+  });
+
+  afterAll(() => {
+    (globalThis as any).location = originalLocation;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    assignMock.mockReset();
+    fastLoginSpy = jest
+      .spyOn(AuthService, 'getFastLoginAuthorizationUrl')
+      .mockReturnValue('https://keycloak.example.com/auth?code');
+  });
+
+  afterEach(() => {
+    fastLoginSpy.mockRestore();
+  });
+
+  const renderFastLoginSignIn = () =>
+    render(
+      <SignIn
+        onSignInSuccess={mockOnSignInSuccess}
+        onSwitchToSignUp={mockOnSwitchToSignUp}
+      />,
+    );
+
+  it('renders the Fast Login button', () => {
+    renderFastLoginSignIn();
+    expect(
+      screen.getByRole('button', { name: /Fast Login \(KIT\/FeLS\)/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('calls getFastLoginAuthorizationUrl and redirects on click', async () => {
+    renderFastLoginSignIn();
+    await userEvent.click(
+      screen.getByRole('button', { name: /Fast Login \(KIT\/FeLS\)/i }),
+    );
+    expect(fastLoginSpy).toHaveBeenCalled();
+    expect(assignMock).toHaveBeenCalledWith('https://keycloak.example.com/auth?code');
+  });
+
+  it('shows an error message when getFastLoginAuthorizationUrl throws', async () => {
+    fastLoginSpy.mockImplementationOnce(() => {
+      throw new Error('Config error');
+    });
+    renderFastLoginSignIn();
+    await userEvent.click(
+      screen.getByRole('button', { name: /Fast Login \(KIT\/FeLS\)/i }),
+    );
+    expect(await screen.findByText(/Config error/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/config/fastLogin.test.ts
+++ b/src/__tests__/config/fastLogin.test.ts
@@ -1,0 +1,76 @@
+import {
+  getFastLoginRedirectUri,
+  getFastLoginAuthorizationUrl,
+  getFastLoginTokenUrl,
+  getSavedFastLoginRedirectUri,
+  saveFastLoginRedirectUri,
+  FAST_LOGIN_REDIRECT_STORAGE_KEY,
+  FAST_LOGIN_CALLBACK_PATH,
+} from '../../config/fastLogin';
+
+describe('fastLogin config', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    delete (process.env as any).REACT_APP_FAST_LOGIN_REDIRECT_URL;
+    delete (process.env as any).REACT_APP_KEYCLOAK_BASE_URL;
+  });
+
+  // ── getFastLoginRedirectUri ──────────────────────────────────────────────
+
+  it('returns REACT_APP_FAST_LOGIN_REDIRECT_URL when set', () => {
+    process.env.REACT_APP_FAST_LOGIN_REDIRECT_URL = 'https://example.com/callback';
+    expect(getFastLoginRedirectUri()).toBe('https://example.com/callback');
+  });
+
+  it('returns origin + callback path when env var is not set', () => {
+    expect(getFastLoginRedirectUri()).toBe(
+      `${globalThis.location.origin}${FAST_LOGIN_CALLBACK_PATH}`,
+    );
+  });
+
+  // ── saveFastLoginRedirectUri / getSavedFastLoginRedirectUri ──────────────
+
+  it('saves and retrieves redirect URI from sessionStorage', () => {
+    saveFastLoginRedirectUri('http://localhost:3000/auth/callback');
+    expect(getSavedFastLoginRedirectUri()).toBe('http://localhost:3000/auth/callback');
+  });
+
+  it('returns null when nothing is saved', () => {
+    expect(getSavedFastLoginRedirectUri()).toBeNull();
+  });
+
+  it('saveFastLoginRedirectUri uses the correct sessionStorage key', () => {
+    saveFastLoginRedirectUri('http://test.com/cb');
+    expect(sessionStorage.getItem(FAST_LOGIN_REDIRECT_STORAGE_KEY)).toBe('http://test.com/cb');
+  });
+
+  // ── getFastLoginAuthorizationUrl ─────────────────────────────────────────
+
+  it('builds authorization URL with required OIDC params', () => {
+    const url = new URL(getFastLoginAuthorizationUrl());
+    expect(url.pathname).toContain('/auth/realms/methodologist/protocol/openid-connect/auth');
+    expect(url.searchParams.get('client_id')).toBe('normal-customer-mobile-app');
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('scope')).toBe('openid');
+    expect(url.searchParams.get('kc_idp_hint')).toBe('kit');
+    expect(url.searchParams.get('redirect_uri')).toBeTruthy();
+  });
+
+  it('saves redirect_uri to sessionStorage when building authorization URL', () => {
+    getFastLoginAuthorizationUrl();
+    expect(sessionStorage.getItem(FAST_LOGIN_REDIRECT_STORAGE_KEY)).toBeTruthy();
+  });
+
+  // ── getFastLoginTokenUrl ─────────────────────────────────────────────────
+
+  it('returns token URL containing the correct realm and /auth/ prefix', () => {
+    const url = getFastLoginTokenUrl();
+    expect(url).toContain('/auth/realms/methodologist/protocol/openid-connect/token');
+  });
+
+  it('token URL uses REACT_APP_KEYCLOAK_BASE_URL when set', () => {
+    process.env.REACT_APP_KEYCLOAK_BASE_URL = 'https://keycloak.example.com';
+    const url = getFastLoginTokenUrl();
+    expect(url).toMatch(/^https:\/\/keycloak\.example\.com/);
+  });
+});

--- a/src/__tests__/hooks/useFastLoginCallback.test.ts
+++ b/src/__tests__/hooks/useFastLoginCallback.test.ts
@@ -1,0 +1,143 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useFastLoginCallback, navigateAfterFastLogin } from '../../hooks/useFastLoginCallback';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const mockNavigate = jest.fn();
+const mockFastLoginWithCode = jest.fn();
+
+// Mutable so individual tests can set the context user.
+let mockContextUser: any = null;
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ fastLoginWithCode: mockFastLoginWithCode, user: mockContextUser }),
+}));
+
+function setSearch(search: string) {
+  Object.defineProperty(globalThis, 'location', {
+    configurable: true,
+    value: { ...globalThis.location, search, pathname: '/auth/callback' },
+  });
+}
+
+// ── navigateAfterFastLogin ────────────────────────────────────────────────────
+
+describe('navigateAfterFastLogin', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('always navigates to /mml regardless of emailVerified', () => {
+    navigateAfterFastLogin({ id: '1', username: 'kit-user', emailVerified: false }, mockNavigate);
+    expect(mockNavigate).toHaveBeenCalledWith('/mml', { replace: true });
+  });
+
+  it('navigates to /mml for verified users too', () => {
+    navigateAfterFastLogin({ id: '1', username: 'kit-user', emailVerified: true }, mockNavigate);
+    expect(mockNavigate).toHaveBeenCalledWith('/mml', { replace: true });
+  });
+});
+
+// ── useFastLoginCallback ──────────────────────────────────────────────────────
+
+describe('useFastLoginCallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockContextUser = null;
+  });
+
+  it('sets error when OAuth provider returns error param', async () => {
+    setSearch('?error=access_denied&error_description=User+cancelled');
+
+    const { result } = renderHook(() => useFastLoginCallback());
+
+    await waitFor(() => {
+      expect(result.current.error).toMatch(/User cancelled/i);
+    });
+    expect(result.current.isProcessing).toBe(false);
+    expect(mockFastLoginWithCode).not.toHaveBeenCalled();
+  });
+
+  it('sets error when code param is missing', async () => {
+    setSearch('?session_state=abc');
+
+    const { result } = renderHook(() => useFastLoginCallback());
+
+    await waitFor(() => {
+      expect(result.current.error).toMatch(/missing authentication response/i);
+    });
+    expect(result.current.isProcessing).toBe(false);
+  });
+
+  it('calls fastLoginWithCode with the correct code', async () => {
+    const fakeUser = { id: '1', username: 'kit-user', emailVerified: true };
+    setSearch('?code=test-code-123');
+    mockContextUser = fakeUser;
+    mockFastLoginWithCode.mockResolvedValue(fakeUser);
+
+    renderHook(() => useFastLoginCallback());
+
+    await waitFor(() => {
+      expect(mockFastLoginWithCode).toHaveBeenCalledWith('test-code-123');
+    });
+  });
+
+  it('navigates to /mml when fastLoginWithCode succeeds and user is in context', async () => {
+    const fakeUser = { id: '1', username: 'kit-user', emailVerified: true };
+    setSearch('?code=test-code-123');
+    // Simulate AuthContext already reflecting the user (as it does after
+    // fastLoginWithCode calls setUser() internally).
+    mockContextUser = fakeUser;
+    mockFastLoginWithCode.mockResolvedValue(fakeUser);
+
+    renderHook(() => useFastLoginCallback());
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/mml', { replace: true });
+    });
+  });
+
+  it('does not navigate while user is still null in context', async () => {
+    // User stays null — simulates the moment between exchange completing and
+    // React committing the setUser() call. Navigation must wait.
+    setSearch('?code=test-code-123');
+    mockFastLoginWithCode.mockResolvedValue({ id: '1', username: 'kit-user' });
+    // mockContextUser remains null
+
+    renderHook(() => useFastLoginCallback());
+
+    await waitFor(() => expect(mockFastLoginWithCode).toHaveBeenCalled());
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('sets error when fastLoginWithCode throws', async () => {
+    setSearch('?code=bad-code');
+    mockFastLoginWithCode.mockRejectedValue(new Error('Token exchange failed'));
+
+    const { result } = renderHook(() => useFastLoginCallback());
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('Token exchange failed');
+    });
+    expect(result.current.isProcessing).toBe(false);
+  });
+
+  it('initialises isProcessing true when code param is present', () => {
+    setSearch('?code=abc');
+    mockFastLoginWithCode.mockResolvedValue({ id: '1', username: 'u' });
+
+    const { result } = renderHook(() => useFastLoginCallback());
+
+    expect(result.current.isProcessing).toBe(true);
+  });
+
+  it('initialises isProcessing false when error param is present', () => {
+    setSearch('?error=access_denied');
+
+    const { result } = renderHook(() => useFastLoginCallback());
+
+    expect(result.current.isProcessing).toBe(false);
+  });
+});

--- a/src/components/auth/FastLoginCallback.tsx
+++ b/src/components/auth/FastLoginCallback.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useFastLoginCallback } from '../../hooks/useFastLoginCallback';
+import './Auth.css';
+
+/**
+ * OAuth callback page for Fast Login (/auth/callback?code=...).
+ */
+export function FastLoginCallback() {
+  const { isProcessing, error } = useFastLoginCallback();
+
+  if (error) {
+    return (
+      <div className="auth-container" style={{ backgroundColor: '#f0f0f0' }}>
+        <div className="auth-card" style={{ textAlign: 'center' }}>
+          <div className="auth-header">
+            <h1>Fast Login Failed</h1>
+            <p>We could not complete sign-in with your institution account.</p>
+          </div>
+          <div className="error-message" style={{ marginBottom: '20px' }}>
+            <span className="error-icon">⚠️</span>
+            {error}
+          </div>
+          <Link to="/login" className="auth-button primary" style={{ textDecoration: 'none' }}>
+            Back to Sign In
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (isProcessing) {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100vh',
+          fontSize: '18px',
+          color: '#666',
+          flexDirection: 'column',
+          gap: '16px',
+        }}
+      >
+        <div className="spinner" style={{ width: 40, height: 40, borderWidth: 3 }} />
+        <div>Completing Fast Login...</div>
+        <div style={{ fontSize: '14px', color: '#999' }}>
+          Exchanging authorization code for your session.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: '100vh',
+        fontSize: '16px',
+        color: '#666',
+      }}
+    >
+      Processing...
+    </div>
+  );
+}

--- a/src/components/auth/SignIn.tsx
+++ b/src/components/auth/SignIn.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { SignInCredentials } from '../../services/auth';
+import { AuthService, SignInCredentials } from '../../services/auth';
 import { useAuth } from '../../contexts/AuthContext';
 import { apiService } from '../../services/api';
 import './Auth.css';
@@ -105,6 +105,16 @@ export function SignIn({ onSignInSuccess, onSwitchToSignUp }: Readonly<SignInPro
     }
   };
 
+  const handleFastLogin = () => {
+    try {
+      setError(null);
+      const authorizationUrl = AuthService.getFastLoginAuthorizationUrl();
+      globalThis.location.assign(authorizationUrl);
+    } catch (err: any) {
+      setError(err?.message || 'Unable to start Fast Login. Please try again.');
+    }
+  };
+
   return (
     <div 
       className="auth-container"
@@ -191,6 +201,16 @@ export function SignIn({ onSignInSuccess, onSwitchToSignUp }: Readonly<SignInPro
             ) : (
               'Sign In'
             )}
+          </button>
+
+          <button
+            type="button"
+            className="auth-button secondary"
+            disabled={isLoading}
+            onClick={handleFastLogin}
+            style={{ marginTop: '12px' }}
+          >
+            Fast Login (KIT/FeLS)
           </button>
         </form>
 

--- a/src/components/auth/index.ts
+++ b/src/components/auth/index.ts
@@ -2,3 +2,4 @@ export { SignIn } from './SignIn';
 export { SignUp } from './SignUp';
 export { AuthPage } from './AuthPage';
 export { KeycloakRedirect } from './KeycloakRedirect';
+export { FastLoginCallback } from './FastLoginCallback';

--- a/src/config/fastLogin.ts
+++ b/src/config/fastLogin.ts
@@ -1,0 +1,86 @@
+import { config } from './environment';
+
+const REALM = 'methodologist';
+const CLIENT_ID = 'normal-customer-mobile-app';
+const IDP_HINT = 'kit';
+export const FAST_LOGIN_REDIRECT_STORAGE_KEY = 'fast_login_redirect_uri';
+
+/** Frontend route that receives the OAuth authorization code from Keycloak. */
+export const FAST_LOGIN_CALLBACK_PATH = '/auth/callback';
+
+/**
+ * Keycloak / OIDC base URL (no trailing slash).
+ * Defaults to REACT_APP_API_BASE_URL when KEYCLOAK base is not set separately.
+ */
+export function getKeycloakBaseUrl(): string {
+  const base =
+    process.env.REACT_APP_KEYCLOAK_BASE_URL || config.apiBaseUrl;
+  return base.replace(/\/$/, '');
+}
+
+/**
+ * OAuth redirect URI registered with Keycloak for the fast-login client.
+ * Must match exactly what is configured in Keycloak and used in the auth request.
+ */
+export function getFastLoginRedirectUri(): string {
+  const configured = process.env.REACT_APP_FAST_LOGIN_REDIRECT_URL?.trim();
+  if (configured) {
+    return configured;
+  }
+  if (typeof globalThis.location !== 'undefined') {
+    return `${globalThis.location.origin}${FAST_LOGIN_CALLBACK_PATH}`;
+  }
+  return `http://localhost:3000${FAST_LOGIN_CALLBACK_PATH}`;
+}
+
+export function saveFastLoginRedirectUri(redirectUri: string): void {
+  try {
+    sessionStorage.setItem(FAST_LOGIN_REDIRECT_STORAGE_KEY, redirectUri);
+  } catch (error) {
+    console.warn('[Fast Login] Unable to persist redirect_uri in sessionStorage', error);
+  }
+}
+
+export function getSavedFastLoginRedirectUri(): string | null {
+  try {
+    return sessionStorage.getItem(FAST_LOGIN_REDIRECT_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function getFastLoginAuthorizationUrl(): string {
+  const baseUrl = getKeycloakBaseUrl();
+  const redirectUri = getFastLoginRedirectUri();
+  saveFastLoginRedirectUri(redirectUri);
+
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID,
+    response_type: 'code',
+    scope: 'openid',
+    redirect_uri: redirectUri,
+    kc_idp_hint: IDP_HINT,
+  });
+
+  const url = `${baseUrl}/auth/realms/${REALM}/protocol/openid-connect/auth?${params.toString()}`;
+
+  console.log('[Fast Login] Authorization URL built', {
+    redirectUri,
+    realm: REALM,
+    clientId: CLIENT_ID,
+  });
+  return url;
+}
+
+/**
+ * Token endpoint — same /auth/ context path prefix as the auth endpoint.
+ */
+export function getFastLoginTokenUrl(): string {
+  return `${getKeycloakBaseUrl()}/auth/realms/${REALM}/protocol/openid-connect/token`;
+}
+
+export const fastLoginConstants = {
+  realm: REALM,
+  clientId: CLIENT_ID,
+  idpHint: IDP_HINT,
+} as const;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -9,6 +9,7 @@ interface AuthContextType {
     isAuthenticated: boolean;
     isLoading: boolean;
     signIn: (username: string, password: string) => Promise<User>;
+    fastLoginWithCode: (authorizationCode: string) => Promise<User>;
     signUp: (userData: SignUpCredentials) => Promise<void>;
     signOut: () => Promise<void>;
     refreshToken: () => Promise<any>;
@@ -174,6 +175,58 @@ export function AuthProvider({ children }: Readonly<AuthProviderProps>) {
         }
     }, []);
 
+    const fastLoginWithCode = useCallback(async (authorizationCode: string): Promise<User> => {
+        try {
+            const authResponse = await AuthService.exchangeFastLoginCode(authorizationCode);
+
+            try {
+                const { data } = await apiService.getUserInfo();
+                const mapped: User = {
+                    id: String(data.id),
+                    username: data.email?.split('@')[0] || 'user',
+                    email: data.email,
+                    name: `${data.firstName ?? ''} ${data.lastName ?? ''}`.trim() || data.email || 'user',
+                    givenName: data.firstName,
+                    familyName: data.lastName,
+                    emailVerified: resolveVerifiedFlag(data),
+                };
+                AuthService.setCurrentUser(mapped);
+                setUser(mapped);
+                return mapped;
+            } catch {
+                const tokenData = parseJwtToken(authResponse.access_token);
+                let newUser: User;
+                if (tokenData) {
+                    const extractedUser = extractUserFromToken(tokenData);
+                    newUser = {
+                        id: Date.now().toString(),
+                        username: extractedUser.username || 'user',
+                        email: extractedUser.email,
+                        name: extractedUser.name,
+                        givenName: extractedUser.givenName,
+                        familyName: extractedUser.familyName,
+                        // Trust external IDP authentication — consider verified.
+                        emailVerified: true,
+                        scope: extractedUser.scope,
+                    };
+                } else {
+                    newUser = {
+                        id: Date.now().toString(),
+                        username: 'user',
+                        // Authenticated via external IDP — treat as verified.
+                        emailVerified: true,
+                    };
+                }
+                AuthService.setCurrentUser(newUser);
+                setUser(newUser);
+                return newUser;
+            }
+        } catch (error) {
+            console.error('Fast login error:', error);
+            throw error;
+        }
+    }, []);
+
     // 🔐 SIGN UP with:
     // - Username required and length ≥ 4
     // - Password detailed validation (with explicit allowed symbols)
@@ -273,11 +326,12 @@ export function AuthProvider({ children }: Readonly<AuthProviderProps>) {
         isAuthenticated: !!user && AuthService.isAuthenticated(),
         isLoading,
         signIn,
+        fastLoginWithCode,
         signUp,
         signOut,
         refreshToken: handleRefreshToken,
         refreshCurrentUser,
-    }), [user, isLoading, signIn, signUp, signOut, handleRefreshToken, refreshCurrentUser]);
+    }), [user, isLoading, signIn, fastLoginWithCode, signUp, signOut, handleRefreshToken, refreshCurrentUser]);
 
     return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/src/hooks/useFastLoginCallback.ts
+++ b/src/hooks/useFastLoginCallback.ts
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { User } from '../services/auth';
+
+function getAuthorizationCode(): string | null {
+  const params = new URLSearchParams(globalThis.location.search);
+  const raw = params.get('code');
+  const code = raw?.trim() || '';
+  return code || null;
+}
+
+function getOAuthCallbackError(): string | null {
+  const params = new URLSearchParams(globalThis.location.search);
+  return params.get('error_description') || params.get('error');
+}
+
+export function navigateAfterFastLogin(
+  user: User,
+  navigate: ReturnType<typeof useNavigate>,
+): void {
+  // Clear the authorization code from the URL so it isn't reused.
+  globalThis.history.replaceState({}, '', globalThis.location.pathname);
+
+  // FeLS/KIT users authenticated via an external trusted IDP — always go
+  // straight to the workspace, bypassing internal OTP verification.
+  console.log('[Fast Login] Navigating to workspace for external IDP user', user.username);
+  navigate('/mml', { replace: true });
+}
+
+/**
+ * Completes fast login when Keycloak redirects back with ?code=...
+ */
+export function useFastLoginCallback(): {
+  isProcessing: boolean;
+  error: string | null;
+} {
+  const navigate = useNavigate();
+  const { fastLoginWithCode } = useAuth();
+  const exchangeStartedRef = useRef(false);
+  const [isProcessing, setIsProcessing] = useState(() => {
+    const params = new URLSearchParams(globalThis.location.search);
+    const oauthError = getOAuthCallbackError();
+    if (oauthError) return false;
+
+    return params.has('code');
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const oauthError = getOAuthCallbackError();
+    if (oauthError) {
+      console.error('[Fast Login] OAuth provider returned error:', oauthError);
+      setError(oauthError);
+      setIsProcessing(false);
+      return;
+    }
+
+    const authorizationCode = getAuthorizationCode();
+    if (!authorizationCode) {
+      console.error('[Fast Login] Missing Fast Login authentication parameter', {
+        available: Object.fromEntries(new URLSearchParams(globalThis.location.search).entries()),
+      });
+      setError(
+        'Fast Login failed: missing authentication response. Please try again from the sign-in page.',
+      );
+      setIsProcessing(false);
+      return;
+    }
+
+    if (exchangeStartedRef.current) {
+      return;
+    }
+    exchangeStartedRef.current = true;
+
+    console.log('[Fast Login] Authorization code received, starting token exchange');
+
+    let cancelled = false;
+
+    const complete = async () => {
+      try {
+        const user = await fastLoginWithCode(authorizationCode);
+        if (cancelled) return;
+        navigateAfterFastLogin(user, navigate);
+      } catch (err: unknown) {
+        if (cancelled) return;
+        const message =
+          err instanceof Error ? err.message : 'Fast login failed. Please try again.';
+        console.error('[Fast Login] Callback handling failed:', message);
+        setError(message);
+        setIsProcessing(false);
+        exchangeStartedRef.current = false;
+      }
+    };
+
+    complete();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fastLoginWithCode, navigate]);
+
+  return { isProcessing, error };
+}

--- a/src/hooks/useFastLoginCallback.ts
+++ b/src/hooks/useFastLoginCallback.ts
@@ -30,23 +30,34 @@ export function navigateAfterFastLogin(
 
 /**
  * Completes fast login when Keycloak redirects back with ?code=...
+ *
+ * Two-phase design:
+ *  1. Exchange the code for tokens (async, guarded against double-execution).
+ *  2. Navigate only after `user` is committed in AuthContext.
+ *
+ * React.StrictMode runs effects twice in development. The guard ref stops the
+ * second run from starting a second exchange (authorization codes are
+ * single-use). However, the first run's async callback may be cancelled before
+ * it can trigger navigation. Phase 2 solves this: it watches `user` directly
+ * and fires as soon as AuthContext reflects the new user — regardless of
+ * whether phase 1's callback was cancelled by the StrictMode cleanup.
  */
 export function useFastLoginCallback(): {
   isProcessing: boolean;
   error: string | null;
 } {
   const navigate = useNavigate();
-  const { fastLoginWithCode } = useAuth();
+  const { fastLoginWithCode, user } = useAuth();
   const exchangeStartedRef = useRef(false);
+
   const [isProcessing, setIsProcessing] = useState(() => {
-    const params = new URLSearchParams(globalThis.location.search);
     const oauthError = getOAuthCallbackError();
     if (oauthError) return false;
-
-    return params.has('code');
+    return new URLSearchParams(globalThis.location.search).has('code');
   });
   const [error, setError] = useState<string | null>(null);
 
+  // ── Phase 1: kick off the token exchange ─────────────────────────────────
   useEffect(() => {
     const oauthError = getOAuthCallbackError();
     if (oauthError) {
@@ -68,9 +79,9 @@ export function useFastLoginCallback(): {
       return;
     }
 
-    if (exchangeStartedRef.current) {
-      return;
-    }
+    // Guard: authorization codes are single-use. Prevent a second exchange
+    // request (e.g. from React StrictMode's intentional double-mount).
+    if (exchangeStartedRef.current) return;
     exchangeStartedRef.current = true;
 
     console.log('[Fast Login] Authorization code received, starting token exchange');
@@ -79,9 +90,9 @@ export function useFastLoginCallback(): {
 
     const complete = async () => {
       try {
-        const user = await fastLoginWithCode(authorizationCode);
-        if (cancelled) return;
-        navigateAfterFastLogin(user, navigate);
+        // fastLoginWithCode calls setUser() internally — that state update
+        // is what Phase 2 watches to trigger navigation.
+        await fastLoginWithCode(authorizationCode);
       } catch (err: unknown) {
         if (cancelled) return;
         const message =
@@ -98,7 +109,19 @@ export function useFastLoginCallback(): {
     return () => {
       cancelled = true;
     };
-  }, [fastLoginWithCode, navigate]);
+  }, [fastLoginWithCode]);
+
+  // ── Phase 2: navigate once AuthContext has committed the new user ─────────
+  //
+  // Watching `user` (instead of a separate "pendingNavigate" flag) handles the
+  // StrictMode scenario: even if Phase 1's async callback was cancelled before
+  // it could set a flag, fastLoginWithCode already called setUser() — so
+  // `user` becomes non-null and this effect fires on the very next render.
+  useEffect(() => {
+    if (!isProcessing || !user) return;
+
+    navigateAfterFastLogin(user, navigate);
+  }, [isProcessing, user, navigate]);
 
   return { isProcessing, error };
 }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,4 +1,12 @@
 import { config } from '../config/environment';
+import {
+  fastLoginConstants,
+  getFastLoginAuthorizationUrl as buildFastLoginAuthorizationUrl,
+  getFastLoginTokenUrl,
+  getSavedFastLoginRedirectUri,
+  FAST_LOGIN_REDIRECT_STORAGE_KEY,
+  getFastLoginRedirectUri,
+} from '../config/fastLogin';
 
 export interface AuthResponse {
   access_token: string;
@@ -286,6 +294,67 @@ export class AuthService {
     console.log('Forgot password request successful:', responseData.message);
     
     return responseData;
+  }
+
+  static getFastLoginCallbackUri(): string {
+    return getFastLoginRedirectUri();
+  }
+
+  static getFastLoginAuthorizationUrl(): string {
+    return buildFastLoginAuthorizationUrl();
+  }
+
+  static async exchangeFastLoginCode(code: string): Promise<AuthResponse> {
+    const savedRedirectUri = getSavedFastLoginRedirectUri();
+    const redirectUri = savedRedirectUri || getFastLoginRedirectUri();
+
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: fastLoginConstants.clientId,
+      code,
+      redirect_uri: redirectUri,
+    });
+
+    const response = await fetch(
+      getFastLoginTokenUrl(),
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: body.toString(),
+      },
+    );
+
+    if (!response.ok) {
+      const errorMessage = await this.extractErrorMessage(response);
+      throw new Error(errorMessage || 'Fast login token exchange failed.');
+    }
+
+    const data: AuthResponse = await response.json();
+
+    localStorage.setItem('auth.access_token', data.access_token);
+    if (data.refresh_token) {
+      localStorage.setItem('auth.refresh_token', data.refresh_token);
+    }
+    localStorage.setItem('auth.expires_in', data.expires_in.toString());
+    localStorage.setItem('auth.refresh_expires_in', data.refresh_expires_in.toString());
+    localStorage.setItem('auth.token_type', data.token_type);
+    localStorage.setItem('auth.session_state', data.session_state);
+    localStorage.setItem('auth.scope', data.scope);
+    localStorage.setItem('auth.not_before_policy', data['not-before-policy'].toString());
+
+    const accessExpiresAt = Date.now() + (data.expires_in * 1000);
+    const refreshExpiresAt = Date.now() + (data.refresh_expires_in * 1000);
+    localStorage.setItem('auth.access_expires_at', accessExpiresAt.toString());
+    localStorage.setItem('auth.refresh_expires_at', refreshExpiresAt.toString());
+
+    try {
+      sessionStorage.removeItem(FAST_LOGIN_REDIRECT_STORAGE_KEY);
+    } catch {
+      // ignore
+    }
+    return data;
   }
 
   static async signIn(credentials: SignInCredentials): Promise<AuthResponse> {

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,50 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+const path = require('path');
+
+// Read .env.local directly because REACT_APP_* vars may not be in
+// process.env at the time setupProxy.js is first executed by CRA.
+function loadEnvVar(name) {
+  if (process.env[name]) return process.env[name];
+  try {
+    const fs = require('fs');
+    const envFile = path.resolve(__dirname, '..', '.env.local');
+    const lines = fs.readFileSync(envFile, 'utf8').split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('#') || !trimmed.includes('=')) continue;
+      const eq = trimmed.indexOf('=');
+      const key = trimmed.slice(0, eq).trim();
+      const val = trimmed.slice(eq + 1).trim();
+      if (key === name) return val;
+    }
+  } catch (_) { /* .env.local missing — ignore */ }
+  return undefined;
+}
+
+/**
+ * Proxies Keycloak token requests in local dev to avoid browser CORS blocks
+ * when exchanging the authorization code from fast login.
+ */
+module.exports = function setupProxy(app) {
+  const keycloakBase = (
+    loadEnvVar('REACT_APP_KEYCLOAK_BASE_URL') ||
+    loadEnvVar('REACT_APP_API_BASE_URL') ||
+    ''
+  ).replace(/\/$/, '');
+
+  if (!keycloakBase) {
+    console.warn('[setupProxy] REACT_APP_API_BASE_URL not found — Keycloak proxy disabled');
+    return;
+  }
+
+  const proxyOptions = {
+    target: keycloakBase,
+    changeOrigin: true,
+    secure: true,
+  };
+
+  app.use('/realms', createProxyMiddleware(proxyOptions));
+  app.use('/auth/realms', createProxyMiddleware(proxyOptions));
+
+  console.log('[setupProxy] Keycloak proxy registered:', keycloakBase);
+};


### PR DESCRIPTION
- Adds a "Fast Login (KIT/FeLS)" button on the sign-in page that redirects 
  users to the Keycloak identity provider for authentication via FeLS/KIT SSO.
- Implements the full OIDC authorization code flow: redirect → receive code → 
  exchange code for tokens → store tokens → navigate to workspace.
- New unprotected route `/auth/callback` handles the Keycloak redirect and 
  shows loading/error states.
- If the backend returns 500/403 for a new FeLS user (not yet in the app 
  database), the frontend falls back to reading the JWT directly to build the 
  user profile. External IDP users skip OTP verification.
- Fixes a React StrictMode race condition where the callback page got stuck: 
  StrictMode's double-mount cancelled the navigation signal, but tokens were 
  already stored. Navigation now fires from a separate effect that watches the 
  committed `user` value in AuthContext.