### PR TITLE
OCL constraint management for VSUMs

### DIFF
--- a/__mocks__/monaco-editor.js
+++ b/__mocks__/monaco-editor.js
@@ -1,0 +1,21 @@
+const monaco = {
+  languages: {
+    register: jest.fn(),
+    setMonarchTokensProvider: jest.fn(),
+    setLanguageConfiguration: jest.fn(),
+    getLanguages: jest.fn(() => []),
+    registerCompletionItemProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  },
+  editor: {
+    defineTheme: jest.fn(),
+    setTheme: jest.fn(),
+    setModelMarkers: jest.fn(),
+  },
+  MarkerSeverity: { Error: 8, Warning: 4, Info: 2, Hint: 1 },
+};
+
+module.exports = monaco;
+module.exports.default = monaco;
+module.exports.languages = monaco.languages;
+module.exports.editor = monaco.editor;
+module.exports.MarkerSeverity = monaco.MarkerSeverity;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "jest": {
+    "moduleNameMapper": {
+      "monaco-editor": "<rootDir>/src/__mocks__/monaco-editor.ts"
+    }
+  },
   "eslintConfig": {
     "extends": [
       "react-app",

--- a/src/__mocks__/monaco-editor.ts
+++ b/src/__mocks__/monaco-editor.ts
@@ -1,0 +1,18 @@
+const monaco = {
+  languages: {
+    register: jest.fn(),
+    setMonarchTokensProvider: jest.fn(),
+    setLanguageConfiguration: jest.fn(),
+    getLanguages: jest.fn(() => []),
+    registerCompletionItemProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  },
+  editor: {
+    defineTheme: jest.fn(),
+    setTheme: jest.fn(),
+    setModelMarkers: jest.fn(),
+  },
+  MarkerSeverity: { Error: 8, Warning: 4, Info: 2, Hint: 1 },
+};
+
+export default monaco;
+export const { languages, editor, MarkerSeverity } = monaco;

--- a/src/__tests__/components/constraints/ConstraintsView.test.tsx
+++ b/src/__tests__/components/constraints/ConstraintsView.test.tsx
@@ -1,0 +1,525 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { ConstraintsView } from '../../../components/constraints/ConstraintsView';
+import { apiService } from '../../../services/api';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+jest.mock('monaco-editor', () => ({
+  languages: {
+    register: jest.fn(),
+    setMonarchTokensProvider: jest.fn(),
+    setLanguageConfiguration: jest.fn(),
+    getLanguages: jest.fn(() => []),
+    registerCompletionItemProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  },
+  editor: {
+    defineTheme: jest.fn(),
+    setTheme: jest.fn(),
+    setModelMarkers: jest.fn(),
+  },
+  MarkerSeverity: { Error: 8, Warning: 4, Info: 2 },
+}));
+
+jest.mock('@monaco-editor/react', () => {
+  const mockReact = require('react');
+  const MockEditor = ({ value, onChange, onMount }: any) => {
+    mockReact.useEffect(() => {
+      onMount?.({}, {
+        languages: {
+          register: jest.fn(),
+          setLanguageConfiguration: jest.fn(),
+          setMonarchTokensProvider: jest.fn(),
+        },
+        editor: {
+          defineTheme: jest.fn(),
+          setTheme: jest.fn(),
+        },
+      });
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    return mockReact.createElement('textarea', {
+      'data-testid': 'monaco-editor',
+      value: value ?? '',
+      onChange: (e: any) => onChange?.(e.target.value),
+    });
+  };
+  return { __esModule: true, default: MockEditor };
+});
+
+jest.mock('reactflow', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div>{children}</div>,
+  useReactFlow: () => ({ getNodes: jest.fn(() => []) }),
+  Handle: () => null,
+  Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
+}));
+
+jest.mock('../../../hooks/useOclLsp', () => ({
+  useOclLsp: () => ({ onMount: jest.fn(), notifyChange: jest.fn() }),
+}));
+
+jest.mock('../../../components/flow/CodeEditorModal', () => ({
+  CodeEditorModal: () => null,
+}));
+
+jest.mock('../../../components/flow/EcoreFileBox', () => ({
+  cardColor: jest.fn(() => '#e2e8f0'),
+}));
+
+jest.mock('../../../components/constraints/VitruvOCLMonarchGrammar', () => ({
+  vitruvOCLLanguageId: 'vitruvocl',
+  vitruvOCLMonarch: {},
+  vitruvOCLLanguageConfig: {},
+  vitruvOCLTheme: { base: 'vs', inherit: true, rules: [], colors: {} },
+}));
+
+jest.mock('../../../services/api', () => ({
+  apiService: {
+    getRuleSets: jest.fn().mockResolvedValue([]),
+    createRuleSet: jest.fn().mockResolvedValue({ id: 1 }),
+    updateRuleSet: jest.fn().mockResolvedValue({}),
+    deleteRuleSet: jest.fn().mockResolvedValue({}),
+  },
+}));
+
+jest.mock('../../../components/ui/ActionButton', () => ({
+  ActionButton: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
+}));
+
+jest.mock('../../../components/ui/sharedStyles', () => ({
+  APP_FONT: 'sans-serif',
+}));
+
+jest.mock('../../../components/ui/modalUtils', () => ({
+  modalBackdropStyle: {},
+  modalDialogShellStyle: {},
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const pfandNode = {
+  id: 'n1',
+  type: 'ecoreFile',
+  data: {
+    fileName: 'pfandmodel.ecore',
+    fileContent: '<ecore:EPackage name="pfand"><eClassifiers xsi:type="ecore:EClass" name="Kasten"/></ecore:EPackage>',
+    domain: 'pfand',
+  },
+  position: { x: 0, y: 0 },
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ConstraintsView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (apiService.getRuleSets as jest.Mock).mockResolvedValue([]);
+  });
+
+  // A. Rendering with no data
+  describe('renders without crashing with empty props', () => {
+    it('renders with no nodes', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[]} />);
+      });
+      // "New Set" button always present
+      expect(screen.getByText('New Set')).toBeInTheDocument();
+    });
+
+    it('renders Constraint Sets label', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[]} />);
+      });
+      expect(screen.getByText('Constraint Sets')).toBeInTheDocument();
+    });
+
+    it('renders Constraint Insights panel', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[]} />);
+      });
+      expect(screen.getByText('Constraint Insights')).toBeInTheDocument();
+    });
+  });
+
+  // B. RuleSet list renders with pfand defaults
+  describe('loads default rule sets for pfand domain', () => {
+    it('shows Crate Rules ruleset name', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      expect(screen.getByText('Crate Rules')).toBeInTheDocument();
+    });
+
+    it('shows Deposit Item Rules ruleset name', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      expect(screen.getByText('Deposit Item Rules')).toBeInTheDocument();
+    });
+
+    it('shows rule names inside rulesets', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      expect(screen.getByText('CrateContainsExactly16Bottles')).toBeInTheDocument();
+    });
+  });
+
+  // C. Click a rule → editor panel opens
+  describe('editor panel opens on rule click', () => {
+    it('shows "Editing:" header after clicking a rule', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      const ruleEl = screen.getByText('CrateContainsExactly16Bottles');
+      fireEvent.click(ruleEl);
+      await waitFor(() => {
+        expect(screen.getByText(/Editing:/)).toBeInTheDocument();
+      });
+    });
+
+    it('shows the rule name in the editor header', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      fireEvent.click(screen.getByText('CrateContainsExactly16Bottles'));
+      await waitFor(() => {
+        expect(screen.getByText(/Editing:.*CrateContainsExactly16Bottles/)).toBeInTheDocument();
+      });
+    });
+  });
+
+  // D. Add new RuleSet
+  describe('handleAddSet', () => {
+    it('adds a new ruleset when New Set is clicked', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[]} />);
+      });
+      fireEvent.click(screen.getByText('New Set'));
+      await waitFor(() => {
+        expect(screen.getByText('New Rule Set')).toBeInTheDocument();
+      });
+    });
+
+    it('adds multiple new rulesets', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[]} />);
+      });
+      fireEvent.click(screen.getByText('New Set'));
+      fireEvent.click(screen.getByText('New Set'));
+      await waitFor(() => {
+        const sets = screen.getAllByText('New Rule Set');
+        expect(sets.length).toBeGreaterThanOrEqual(2);
+      });
+    });
+  });
+
+  // E. Search filter
+  describe('search filter', () => {
+    it('shows matching rule when search query matches', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      const searchInput = screen.getByPlaceholderText(/Search projects/);
+      fireEvent.change(searchInput, { target: { value: 'Crate' } });
+      await waitFor(() => {
+        expect(screen.getByText('CrateContainsExactly16Bottles')).toBeInTheDocument();
+      });
+    });
+
+    it('hides non-matching rules when searching', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      const searchInput = screen.getByPlaceholderText(/Search projects/);
+      fireEvent.change(searchInput, { target: { value: 'XYZNonExistent' } });
+      await waitFor(() => {
+        expect(screen.queryByText('CrateContainsExactly16Bottles')).not.toBeInTheDocument();
+      });
+    });
+
+    it('hides deposit item ruleset when filtering for crate only', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      const searchInput = screen.getByPlaceholderText(/Search projects/);
+      fireEvent.change(searchInput, { target: { value: 'CrateContains' } });
+      await waitFor(() => {
+        expect(screen.queryByText('DepositItemNotEmpty')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  // F. Filter badge (filterNodeId prop)
+  describe('filterNodeId prop', () => {
+    it('shows filter badge when filterNodeId matches a node', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} filterNodeId="n1" />);
+      });
+      await waitFor(() => {
+        expect(screen.getByText(/Filter:/)).toBeInTheDocument();
+      });
+    });
+
+    it('does not show filter badge when filterNodeId is null', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} filterNodeId={null} />);
+      });
+      expect(screen.queryByText(/Filter:/)).not.toBeInTheDocument();
+    });
+
+    it('does not show filter badge when filterNodeId does not match', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} filterNodeId="nonexistent" />);
+      });
+      expect(screen.queryByText(/Filter:/)).not.toBeInTheDocument();
+    });
+  });
+
+  // G. Close editor panel
+  describe('editor panel close', () => {
+    it('closes editor panel when × button is clicked', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      fireEvent.click(screen.getByText('CrateContainsExactly16Bottles'));
+      await waitFor(() => expect(screen.getByText(/Editing:/)).toBeInTheDocument());
+
+      // click the close (×) button in the editor header
+      const closeButtons = screen.getAllByRole('button').filter(b => {
+        // the × button has an svg inside; find the button that contains exactly nothing visible
+        return b.title === '' && b.getAttribute('title') === null && b.style?.cursor === 'pointer';
+      });
+      // Find the close button for the editor panel (has svg with lines)
+      const editorHeader = screen.getByText(/Editing:/).closest('div')?.parentElement;
+      if (editorHeader) {
+        const closeBtn = editorHeader.querySelector('button');
+        if (closeBtn) {
+          fireEvent.click(closeBtn);
+          await waitFor(() => {
+            expect(screen.queryByText(/Editing:/)).not.toBeInTheDocument();
+          });
+        }
+      }
+    });
+
+    it('clicking same rule twice toggles editor off', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      fireEvent.click(screen.getByText('CrateContainsExactly16Bottles'));
+      await waitFor(() => expect(screen.getByText(/Editing:/)).toBeInTheDocument());
+      fireEvent.click(screen.getByText('CrateContainsExactly16Bottles'));
+      await waitFor(() => {
+        expect(screen.queryByText(/Editing:/)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  // H. Delete rule from rule row menu
+  describe('delete rule', () => {
+    it('deletes a rule from the options menu', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      // Open options menu for the first rule
+      const ruleRow = screen.getByText('CrateContainsExactly16Bottles').closest('div[style]');
+      if (ruleRow) {
+        const optionsBtn = ruleRow.querySelector('button[title="Options"]');
+        if (optionsBtn) {
+          fireEvent.click(optionsBtn);
+          await waitFor(() => expect(screen.getByText('Delete')).toBeInTheDocument());
+          fireEvent.click(screen.getByText('Delete'));
+          await waitFor(() => {
+            expect(screen.queryByText('CrateContainsExactly16Bottles')).not.toBeInTheDocument();
+          });
+        }
+      }
+    });
+  });
+
+  // I. vsumId=undefined — getRuleSets not called
+  describe('vsumId=undefined', () => {
+    it('does not call getRuleSets when vsumId is absent and uses defaults', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      expect(apiService.getRuleSets).not.toHaveBeenCalled();
+      expect(screen.getByText('Crate Rules')).toBeInTheDocument();
+    });
+  });
+
+  // J. Backend ruleset loading
+  describe('backend ruleset loading', () => {
+    it('renders rulesets from backend when vsumId is provided', async () => {
+      (apiService.getRuleSets as jest.Mock).mockResolvedValue([
+        {
+          id: 42,
+          name: 'Backend Rule Set',
+          color: '#3b82f6',
+          description: 'From backend',
+          oclContent: 'context pfand::Kasten inv BackendRule:\n  @severity WARNING\n  @message "test"\n  true',
+        },
+      ]);
+
+      await act(async () => {
+        render(<ConstraintsView vsumId="7" canvasNodes={[]} />);
+      });
+
+      await waitFor(() => {
+        expect(apiService.getRuleSets).toHaveBeenCalledWith(7);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Backend Rule Set')).toBeInTheDocument();
+      });
+    });
+
+    it('calls getRuleSets with numeric vsumId', async () => {
+      await act(async () => {
+        render(<ConstraintsView vsumId="3" canvasNodes={[]} />);
+      });
+      await waitFor(() => {
+        expect(apiService.getRuleSets).toHaveBeenCalledWith(3);
+      });
+    });
+
+    it('falls back gracefully when getRuleSets returns empty', async () => {
+      (apiService.getRuleSets as jest.Mock).mockResolvedValue([]);
+      await act(async () => {
+        render(<ConstraintsView vsumId="5" canvasNodes={[]} />);
+      });
+      await waitFor(() => {
+        expect(apiService.getRuleSets).toHaveBeenCalled();
+      });
+      // no crash and Constraint Insights still visible
+      expect(screen.getByText('Constraint Insights')).toBeInTheDocument();
+    });
+
+    it('handles getRuleSets failure gracefully', async () => {
+      (apiService.getRuleSets as jest.Mock).mockRejectedValue(new Error('Network error'));
+      await act(async () => {
+        render(<ConstraintsView vsumId="5" canvasNodes={[]} />);
+      });
+      await waitFor(() => {
+        expect(apiService.getRuleSets).toHaveBeenCalled();
+      });
+      expect(screen.getByText('Constraint Insights')).toBeInTheDocument();
+    });
+  });
+
+  // K. Ruleset section: toggle collapse
+  describe('toggle collapse', () => {
+    it('collapses rules when chevron is clicked', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      expect(screen.getByText('CrateContainsExactly16Bottles')).toBeInTheDocument();
+      // Click the collapse chevron (svg polyline inside the ruleset header)
+      const crateHeader = screen.getByText('Crate Rules').closest('div[style]');
+      if (crateHeader) {
+        const chevron = crateHeader.querySelector('svg');
+        if (chevron) {
+          fireEvent.click(chevron);
+          await waitFor(() => {
+            expect(screen.queryByText('CrateContainsExactly16Bottles')).not.toBeInTheDocument();
+          });
+        }
+      }
+    });
+  });
+
+  // L. Add rule to existing set
+  describe('add rule to set', () => {
+    it('adds a new rule inside a ruleset', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      const addRuleBtn = screen.getAllByText('Add rule')[0];
+      fireEvent.click(addRuleBtn);
+      await waitFor(() => {
+        expect(screen.getByText('NewInvariant')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // M. RuleSet click opens panel
+  describe('ruleset panel', () => {
+    it('opens RuleSetPanel when clicking a ruleset', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      fireEvent.click(screen.getByText('Crate Rules'));
+      await waitFor(() => {
+        expect(screen.getByText(/Rule Set:/)).toBeInTheDocument();
+      });
+    });
+
+    it('closes RuleSetPanel when clicking × button', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      fireEvent.click(screen.getByText('Crate Rules'));
+      await waitFor(() => expect(screen.getByText(/Rule Set:/)).toBeInTheDocument());
+      // find the × button in the panel
+      const panelHeader = screen.getByText(/Rule Set:/).closest('div')?.parentElement?.parentElement;
+      if (panelHeader) {
+        const closeBtn = panelHeader.querySelector('button[style*="font-size: 18"]');
+        if (closeBtn) {
+          fireEvent.click(closeBtn);
+          await waitFor(() => {
+            expect(screen.queryByText(/Rule Set:/)).not.toBeInTheDocument();
+          });
+        }
+      }
+    });
+  });
+
+  // N. Metrics panel totals
+  describe('metrics panel', () => {
+    it('shows correct total rule count in insights', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      // pfand has 5 rules total (2 + 3)
+      expect(screen.getByText('Total Rules')).toBeInTheDocument();
+      // "5" appears multiple times; just check it's present somewhere
+      const fiveEls = screen.getAllByText('5');
+      expect(fiveEls.length).toBeGreaterThan(0);
+    });
+
+    it('shows View Detailed Metrics button', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      expect(screen.getByText('View Detailed Metrics')).toBeInTheDocument();
+    });
+
+    it('opens DetailedMetricsModal when button clicked', async () => {
+      await act(async () => {
+        render(<ConstraintsView canvasNodes={[pfandNode as any]} />);
+      });
+      fireEvent.click(screen.getByText('View Detailed Metrics'));
+      await waitFor(() => {
+        expect(screen.getByText('Detailed Metrics')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // O. onHighlightNode callback
+  describe('onHighlightNode callback', () => {
+    it('calls onHighlightNode when a rule is clicked', async () => {
+      const onHighlight = jest.fn();
+      await act(async () => {
+        render(
+          <ConstraintsView
+            canvasNodes={[pfandNode as any]}
+            onHighlightNode={onHighlight}
+          />
+        );
+      });
+      fireEvent.click(screen.getByText('CrateContainsExactly16Bottles'));
+      expect(onHighlight).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/components/constraints/ConstraintsViewHelpers.test.ts
+++ b/src/__tests__/components/constraints/ConstraintsViewHelpers.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Pure-logic tests for the helper functions defined inside ConstraintsView.tsx.
+ *
+ * Because those functions are not exported, and importing the module directly
+ * would require extensive mocking of Monaco / ReactFlow / LSP dependencies,
+ * the implementations are copied verbatim from the source file here.
+ * This is intentional: we test the logic, not the module graph.
+ *
+ * Source: src/components/constraints/ConstraintsView.tsx lines 54–143
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type SeverityLevel = 'INFO' | 'WARNING' | 'MINOR' | 'MAJOR' | 'CRITICAL';
+
+// ── Helper implementations (copied verbatim from ConstraintsView.tsx) ─────────
+
+function oclGetName(ocl: string): string {
+  return ocl.match(/\binv\s+(\w+)\s*:/m)?.[1] ?? '';
+}
+
+function oclGetSeverity(ocl: string): SeverityLevel {
+  const v = ocl.match(/^\s*@severity\s+(\w+)/m)?.[1]?.toUpperCase();
+  return (['INFO', 'WARNING', 'MINOR', 'MAJOR', 'CRITICAL'].includes(v ?? '') ? v : 'WARNING') as SeverityLevel;
+}
+
+function oclGetMessage(ocl: string): string {
+  return ocl.match(/^\s*@message\s+"([^"]*)"/m)?.[1] ?? '';
+}
+
+function oclSetName(ocl: string, name: string): string {
+  const id = name.replace(/\s+/g, '');
+  if (!id) return ocl;
+  return /\binv\s+\w+\s*:/m.test(ocl)
+    ? ocl.replace(/\binv\s+\w+\s*:/m, `inv ${id}:`)
+    : ocl;
+}
+
+function oclSetSeverity(ocl: string, severity: SeverityLevel): string {
+  if (/^\s*@severity\s+\w+/m.test(ocl)) {
+    return ocl.replace(/^(\s*)@severity\s+\w+/m, `$1@severity ${severity}`);
+  }
+  return ocl.replace(/(\binv\s+\w+\s*:\n?)/m, `$1  @severity ${severity}\n`);
+}
+
+function oclSetMessage(ocl: string, message: string): string {
+  const escaped = message.replace(/"/g, '\\"');
+  if (/^\s*@message\s+"[^"]*"/m.test(ocl)) {
+    return ocl.replace(/^(\s*)@message\s+"[^"]*"/m, `$1@message "${escaped}"`);
+  }
+  if (/^\s*@severity\s+\w+/m.test(ocl)) {
+    return ocl.replace(/(^\s*@severity\s+\w+)/m, `$1\n  @message "${escaped}"`);
+  }
+  return ocl.replace(/(\binv\s+\w+\s*:\n?)/m, `$1  @message "${escaped}"\n`);
+}
+
+function oclGetContextType(ocl: string): string {
+  return ocl.match(/^\s*context\s+([\w:]+)/m)?.[1] ?? '';
+}
+
+function oclSetContextType(ocl: string, contextType: string): string {
+  if (/^\s*context\s+[\w:]+/m.test(ocl)) {
+    return ocl.replace(/^(\s*context\s+)[\w:]+/m, `$1${contextType}`);
+  }
+  return `context ${contextType} inv NewInvariant:\n` + ocl;
+}
+
+function parseEcoreClasses(
+  fileName: string,
+  xml: string,
+): { metamodel: string; className: string }[] {
+  const mmName = fileName.replace(/\.ecore$/i, '');
+  const results: { metamodel: string; className: string }[] = [];
+  const pkgMatch = xml.match(/<(?:\w+:)?EPackage[^>]+\bname\s*=\s*"([^"]+)"/);
+  const pkg = pkgMatch?.[1] ?? mmName;
+  const classRe = /xsi:type="ecore:EClass"[^>]+\bname\s*=\s*"([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = classRe.exec(xml)) !== null) {
+    results.push({ metamodel: pkg, className: m[1] });
+  }
+  if (results.length === 0) {
+    const alt = /eClassifiers[^>]+\bname\s*=\s*"([^"]+)"/g;
+    while ((m = alt.exec(xml)) !== null) {
+      results.push({ metamodel: pkg, className: m[1] });
+    }
+  }
+  return results;
+}
+
+function oclGetScope(ocl: string): string[] {
+  const matches = [...ocl.matchAll(/\b([A-Za-z][A-Za-z0-9_]*)::([A-Za-z][A-Za-z0-9_]*)/g)];
+  const seen = new Set<string>();
+  matches.forEach(m => seen.add(m[1]));
+  return [...seen].sort();
+}
+
+// ── Test fixtures ─────────────────────────────────────────────────────────────
+
+const FULL_OCL = [
+  'context pfand::Kasten inv MyInvariant:',
+  '  @severity WARNING',
+  '  @message "Must be positive"',
+  '  self.anzahl > 0',
+].join('\n');
+
+const MINIMAL_OCL = 'context pfand::Kasten inv Check:\n  self.value > 0';
+
+const NO_CONTEXT_OCL = 'inv Standalone:\n  @severity CRITICAL\n  true';
+
+// ── oclGetName ────────────────────────────────────────────────────────────────
+
+describe('oclGetName', () => {
+  it('extracts the invariant name from a full OCL string', () => {
+    expect(oclGetName(FULL_OCL)).toBe('MyInvariant');
+  });
+
+  it('extracts the invariant name from a minimal OCL string', () => {
+    expect(oclGetName(MINIMAL_OCL)).toBe('Check');
+  });
+
+  it('returns empty string when there is no inv keyword', () => {
+    expect(oclGetName('context pfand::Kasten\n  true')).toBe('');
+  });
+
+  it('returns empty string for an empty string', () => {
+    expect(oclGetName('')).toBe('');
+  });
+
+  it('is not confused by the word "inv" inside a longer word', () => {
+    expect(oclGetName('context A::B invocation:\n  true')).toBe('');
+  });
+});
+
+// ── oclGetSeverity ────────────────────────────────────────────────────────────
+
+describe('oclGetSeverity', () => {
+  it('extracts WARNING', () => {
+    expect(oclGetSeverity(FULL_OCL)).toBe('WARNING');
+  });
+
+  it('extracts CRITICAL', () => {
+    expect(oclGetSeverity(NO_CONTEXT_OCL)).toBe('CRITICAL');
+  });
+
+  it('extracts INFO', () => {
+    expect(oclGetSeverity('inv X:\n  @severity INFO\n  true')).toBe('INFO');
+  });
+
+  it('extracts MINOR', () => {
+    expect(oclGetSeverity('inv X:\n  @severity MINOR\n  true')).toBe('MINOR');
+  });
+
+  it('extracts MAJOR', () => {
+    expect(oclGetSeverity('inv X:\n  @severity MAJOR\n  true')).toBe('MAJOR');
+  });
+
+  it('returns WARNING as default when @severity is absent', () => {
+    expect(oclGetSeverity(MINIMAL_OCL)).toBe('WARNING');
+  });
+
+  it('returns WARNING for an empty string', () => {
+    expect(oclGetSeverity('')).toBe('WARNING');
+  });
+
+  it('returns WARNING for an unrecognised severity value', () => {
+    expect(oclGetSeverity('inv X:\n  @severity UNKNOWN\n  true')).toBe('WARNING');
+  });
+
+  it('is case-insensitive for the severity keyword value', () => {
+    expect(oclGetSeverity('inv X:\n  @severity critical\n  true')).toBe('CRITICAL');
+  });
+});
+
+// ── oclGetMessage ─────────────────────────────────────────────────────────────
+
+describe('oclGetMessage', () => {
+  it('extracts the message string', () => {
+    expect(oclGetMessage(FULL_OCL)).toBe('Must be positive');
+  });
+
+  it('returns empty string when @message is absent', () => {
+    expect(oclGetMessage(MINIMAL_OCL)).toBe('');
+  });
+
+  it('returns empty string for an empty string', () => {
+    expect(oclGetMessage('')).toBe('');
+  });
+
+  it('handles an empty @message value', () => {
+    expect(oclGetMessage('inv X:\n  @message ""\n  true')).toBe('');
+  });
+
+  it('preserves internal spaces', () => {
+    expect(oclGetMessage('inv X:\n  @message "hello world"\n  true')).toBe('hello world');
+  });
+});
+
+// ── oclSetName ────────────────────────────────────────────────────────────────
+
+describe('oclSetName', () => {
+  it('replaces an existing invariant name', () => {
+    const result = oclSetName(FULL_OCL, 'NewName');
+    expect(result).toContain('inv NewName:');
+    expect(result).not.toContain('inv MyInvariant:');
+  });
+
+  it('strips whitespace from the supplied name', () => {
+    const result = oclSetName(FULL_OCL, 'New Name');
+    expect(result).toContain('inv NewName:');
+  });
+
+  it('returns the original string unchanged when the name is empty', () => {
+    const result = oclSetName(FULL_OCL, '');
+    expect(result).toBe(FULL_OCL);
+  });
+
+  it('returns the original string unchanged when the name is only whitespace', () => {
+    const result = oclSetName(FULL_OCL, '   ');
+    expect(result).toBe(FULL_OCL);
+  });
+
+  it('returns the original string unchanged when there is no inv keyword', () => {
+    const ocl = 'context A::B\n  true';
+    expect(oclSetName(ocl, 'X')).toBe(ocl);
+  });
+});
+
+// ── oclSetSeverity ────────────────────────────────────────────────────────────
+
+describe('oclSetSeverity', () => {
+  it('replaces an existing @severity annotation', () => {
+    const result = oclSetSeverity(FULL_OCL, 'CRITICAL');
+    expect(result).toContain('@severity CRITICAL');
+    expect(result).not.toContain('@severity WARNING');
+  });
+
+  it('inserts @severity after the inv line when annotation is absent', () => {
+    const result = oclSetSeverity(MINIMAL_OCL, 'MAJOR');
+    expect(result).toContain('@severity MAJOR');
+  });
+
+  it('keeps the rest of the OCL intact when replacing', () => {
+    const result = oclSetSeverity(FULL_OCL, 'INFO');
+    expect(result).toContain('@message "Must be positive"');
+    expect(result).toContain('self.anzahl > 0');
+  });
+
+  it('preserves leading whitespace of the @severity line', () => {
+    const ocl = 'inv X:\n  @severity WARNING\n  true';
+    const result = oclSetSeverity(ocl, 'MINOR');
+    expect(result).toContain('  @severity MINOR');
+  });
+});
+
+// ── oclSetMessage ─────────────────────────────────────────────────────────────
+
+describe('oclSetMessage', () => {
+  it('replaces an existing @message annotation', () => {
+    const result = oclSetMessage(FULL_OCL, 'New message');
+    expect(result).toContain('@message "New message"');
+    expect(result).not.toContain('@message "Must be positive"');
+  });
+
+  it('inserts @message after @severity when @message is absent but @severity exists', () => {
+    const ocl = 'context A::B inv X:\n  @severity WARNING\n  true';
+    const result = oclSetMessage(ocl, 'hello');
+    expect(result).toContain('@message "hello"');
+    const severityIdx = result.indexOf('@severity');
+    const messageIdx = result.indexOf('@message');
+    expect(messageIdx).toBeGreaterThan(severityIdx);
+  });
+
+  it('inserts @message after inv line when neither @severity nor @message exists', () => {
+    const result = oclSetMessage(MINIMAL_OCL, 'inserted');
+    expect(result).toContain('@message "inserted"');
+  });
+
+  it('escapes double-quotes in the message', () => {
+    const result = oclSetMessage(FULL_OCL, 'say "hi"');
+    expect(result).toContain('@message "say \\"hi\\""');
+  });
+
+  it('preserves leading whitespace of the @message line', () => {
+    const ocl = 'inv X:\n  @message "old"\n  true';
+    const result = oclSetMessage(ocl, 'new');
+    expect(result).toContain('  @message "new"');
+  });
+});
+
+// ── oclGetContextType ─────────────────────────────────────────────────────────
+
+describe('oclGetContextType', () => {
+  it('extracts a qualified context type', () => {
+    expect(oclGetContextType(FULL_OCL)).toBe('pfand::Kasten');
+  });
+
+  it('extracts a simple (unqualified) context type', () => {
+    expect(oclGetContextType('context Kasten inv X:\n  true')).toBe('Kasten');
+  });
+
+  it('returns empty string when context line is absent', () => {
+    expect(oclGetContextType(NO_CONTEXT_OCL)).toBe('');
+  });
+
+  it('returns empty string for an empty string', () => {
+    expect(oclGetContextType('')).toBe('');
+  });
+});
+
+// ── oclSetContextType ─────────────────────────────────────────────────────────
+
+describe('oclSetContextType', () => {
+  it('replaces an existing context type', () => {
+    const result = oclSetContextType(FULL_OCL, 'kit::Student');
+    expect(result).toContain('context kit::Student');
+    expect(result).not.toContain('context pfand::Kasten');
+  });
+
+  it('keeps the inv clause intact after replacement', () => {
+    const result = oclSetContextType(FULL_OCL, 'kit::Student');
+    expect(result).toContain('inv MyInvariant:');
+  });
+
+  it('prepends a new context line when no context is present', () => {
+    const result = oclSetContextType(NO_CONTEXT_OCL, 'pfand::Flasche');
+    expect(result.startsWith('context pfand::Flasche')).toBe(true);
+  });
+
+  it('still contains the original body when prepending', () => {
+    const result = oclSetContextType(NO_CONTEXT_OCL, 'pfand::Flasche');
+    expect(result).toContain('inv Standalone:');
+  });
+});
+
+// ── parseEcoreClasses ─────────────────────────────────────────────────────────
+
+const ECORE_XML = [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  '<ecore:EPackage xmi:version="2.0"',
+  '    xmlns:xmi="http://www.omg.org/XMI"',
+  '    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"',
+  '    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"',
+  '    name="pfand"',
+  '    nsURI="http://example.com/pfand"',
+  '    nsPrefix="pfand">',
+  '  <eClassifiers xsi:type="ecore:EClass" name="Kasten">',
+  '    <eStructuralFeatures xsi:type="ecore:EAttribute" name="anzahl"/>',
+  '  </eClassifiers>',
+  '  <eClassifiers xsi:type="ecore:EClass" name="Flasche">',
+  '  </eClassifiers>',
+  '</ecore:EPackage>',
+].join('\n');
+
+const ECORE_XML_NO_PACKAGE_NAME = [
+  '<ecore:EPackage>',
+  '  <eClassifiers xsi:type="ecore:EClass" name="Thing">',
+  '  </eClassifiers>',
+  '</ecore:EPackage>',
+].join('\n');
+
+describe('parseEcoreClasses', () => {
+  it('returns one entry per EClass', () => {
+    const result = parseEcoreClasses('pfand.ecore', ECORE_XML);
+    expect(result).toHaveLength(2);
+  });
+
+  it('uses the package name attribute as metamodel', () => {
+    const result = parseEcoreClasses('pfand.ecore', ECORE_XML);
+    expect(result.every(r => r.metamodel === 'pfand')).toBe(true);
+  });
+
+  it('extracts correct class names', () => {
+    const result = parseEcoreClasses('pfand.ecore', ECORE_XML);
+    const names = result.map(r => r.className);
+    expect(names).toContain('Kasten');
+    expect(names).toContain('Flasche');
+  });
+
+  it('falls back to file name (without .ecore) when EPackage has no name attr', () => {
+    const result = parseEcoreClasses('fallback.ecore', ECORE_XML_NO_PACKAGE_NAME);
+    expect(result[0].metamodel).toBe('fallback');
+  });
+
+  it('strips .ecore extension case-insensitively', () => {
+    const result = parseEcoreClasses('MyModel.ECORE', ECORE_XML_NO_PACKAGE_NAME);
+    expect(result[0].metamodel).toBe('MyModel');
+  });
+
+  it('returns an empty array for XML without any EClass', () => {
+    const xml = '<ecore:EPackage name="empty"></ecore:EPackage>';
+    expect(parseEcoreClasses('empty.ecore', xml)).toHaveLength(0);
+  });
+
+  it('uses fallback eClassifiers regex when xsi:type attr appears after name', () => {
+    // Attribute order: name before xsi:type — primary regex won't match
+    const xml = [
+      '<ecore:EPackage name="alt">',
+      '  <eClassifiers name="Widget" xsi:type="ecore:EClass">',
+      '  </eClassifiers>',
+      '</ecore:EPackage>',
+    ].join('\n');
+    const result = parseEcoreClasses('alt.ecore', xml);
+    expect(result).toHaveLength(1);
+    expect(result[0].className).toBe('Widget');
+  });
+});
+
+// ── oclGetScope ───────────────────────────────────────────────────────────────
+
+describe('oclGetScope', () => {
+  it('extracts the metamodel name from a context line', () => {
+    expect(oclGetScope(FULL_OCL)).toContain('pfand');
+  });
+
+  it('returns a single-element array for a single MM::Class pattern', () => {
+    expect(oclGetScope('context pfand::Kasten inv X:\n  true')).toEqual(['pfand']);
+  });
+
+  it('returns deduplicated metamodel names', () => {
+    const ocl = 'context pfand::Kasten inv X:\n  pfand::Flasche.allInstances()';
+    expect(oclGetScope(ocl)).toEqual(['pfand']);
+  });
+
+  it('returns multiple metamodel names sorted alphabetically', () => {
+    const ocl = 'context pfand::Kasten inv X:\n  kit::Student.allInstances()';
+    expect(oclGetScope(ocl)).toEqual(['kit', 'pfand']);
+  });
+
+  it('returns an empty array when no MM::Class pattern is present', () => {
+    expect(oclGetScope('inv X:\n  self.value > 0')).toEqual([]);
+  });
+
+  it('returns an empty array for an empty string', () => {
+    expect(oclGetScope('')).toEqual([]);
+  });
+
+  it('does not include class names, only metamodel names', () => {
+    const result = oclGetScope('context pfand::Kasten inv X:\n  true');
+    expect(result).not.toContain('Kasten');
+  });
+});

--- a/src/__tests__/components/constraints/VitruvOCLMonarchGrammar.test.ts
+++ b/src/__tests__/components/constraints/VitruvOCLMonarchGrammar.test.ts
@@ -1,0 +1,162 @@
+jest.mock('monaco-editor', () => ({
+  languages: {
+    register: jest.fn(),
+    setMonarchTokensProvider: jest.fn(),
+    setLanguageConfiguration: jest.fn(),
+    getLanguages: jest.fn(() => []),
+  },
+  editor: {
+    defineTheme: jest.fn(),
+  },
+}));
+
+// Import after mock is set up
+import * as monacoMock from 'monaco-editor';
+import {
+  vitruvOCLLanguageId,
+  vitruvOCLMonarch,
+  vitruvOCLTheme,
+  vitruvOCLLanguageConfig,
+  registerVitruvOCLLanguage,
+} from '../../../components/constraints/VitruvOCLMonarchGrammar';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (monacoMock.languages.getLanguages as jest.Mock).mockReturnValue([]);
+});
+
+describe('vitruvOCLLanguageId', () => {
+  it('should equal "vitruvocl"', () => {
+    expect(vitruvOCLLanguageId).toBe('vitruvocl');
+  });
+});
+
+describe('vitruvOCLMonarch', () => {
+  it('should have a keywords array', () => {
+    expect(Array.isArray(vitruvOCLMonarch.keywords)).toBe(true);
+  });
+
+  it('should include expected OCL control-flow keywords', () => {
+    const keywords = vitruvOCLMonarch.keywords as string[];
+    expect(keywords).toContain('if');
+    expect(keywords).toContain('then');
+    expect(keywords).toContain('else');
+    expect(keywords).toContain('endif');
+    expect(keywords).toContain('let');
+    expect(keywords).toContain('in');
+  });
+
+  it('should include logical operator keywords', () => {
+    const keywords = vitruvOCLMonarch.keywords as string[];
+    expect(keywords).toContain('and');
+    expect(keywords).toContain('or');
+    expect(keywords).toContain('not');
+    expect(keywords).toContain('implies');
+    expect(keywords).toContain('xor');
+  });
+
+  it('should have a tokenizer object', () => {
+    expect(vitruvOCLMonarch.tokenizer).toBeDefined();
+    expect(typeof vitruvOCLMonarch.tokenizer).toBe('object');
+  });
+
+  it('should have tokenizer.root as an array', () => {
+    expect(Array.isArray(vitruvOCLMonarch.tokenizer.root)).toBe(true);
+    expect((vitruvOCLMonarch.tokenizer.root as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it('should have tokenizer.blockComment defined', () => {
+    expect(vitruvOCLMonarch.tokenizer.blockComment).toBeDefined();
+    expect(Array.isArray(vitruvOCLMonarch.tokenizer.blockComment)).toBe(true);
+  });
+});
+
+describe('vitruvOCLTheme', () => {
+  it('should have base set to "vs"', () => {
+    expect(vitruvOCLTheme.base).toBe('vs');
+  });
+
+  it('should have inherit set to true', () => {
+    expect(vitruvOCLTheme.inherit).toBe(true);
+  });
+
+  it('should have a non-empty rules array', () => {
+    expect(Array.isArray(vitruvOCLTheme.rules)).toBe(true);
+    expect(vitruvOCLTheme.rules.length).toBeGreaterThan(0);
+  });
+
+  it('should have colors with editor.background set to #ffffff', () => {
+    expect(vitruvOCLTheme.colors).toBeDefined();
+    expect(vitruvOCLTheme.colors?.['editor.background']).toBe('#ffffff');
+  });
+});
+
+describe('vitruvOCLLanguageConfig', () => {
+  it('should have lineComment set to "--"', () => {
+    expect(vitruvOCLLanguageConfig.comments).toBeDefined();
+    expect((vitruvOCLLanguageConfig.comments as { lineComment: string }).lineComment).toBe('--');
+  });
+
+  it('should have a non-empty brackets array', () => {
+    expect(Array.isArray(vitruvOCLLanguageConfig.brackets)).toBe(true);
+    expect((vitruvOCLLanguageConfig.brackets as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it('should have a non-empty autoClosingPairs array', () => {
+    expect(Array.isArray(vitruvOCLLanguageConfig.autoClosingPairs)).toBe(true);
+    expect((vitruvOCLLanguageConfig.autoClosingPairs as unknown[]).length).toBeGreaterThan(0);
+  });
+});
+
+describe('registerVitruvOCLLanguage', () => {
+  it('should call register with the correct language id', () => {
+    registerVitruvOCLLanguage();
+    expect(monacoMock.languages.register).toHaveBeenCalledWith(
+      expect.objectContaining({ id: vitruvOCLLanguageId })
+    );
+  });
+
+  it('should call setMonarchTokensProvider with the language id', () => {
+    registerVitruvOCLLanguage();
+    expect(monacoMock.languages.setMonarchTokensProvider).toHaveBeenCalledWith(
+      vitruvOCLLanguageId,
+      vitruvOCLMonarch
+    );
+  });
+
+  it('should call setLanguageConfiguration with the language id', () => {
+    registerVitruvOCLLanguage();
+    expect(monacoMock.languages.setLanguageConfiguration).toHaveBeenCalledWith(
+      vitruvOCLLanguageId,
+      vitruvOCLLanguageConfig
+    );
+  });
+
+  it('should call defineTheme', () => {
+    registerVitruvOCLLanguage();
+    expect(monacoMock.editor.defineTheme).toHaveBeenCalled();
+  });
+
+  it('should not register again when the language is already registered', () => {
+    (monacoMock.languages.getLanguages as jest.Mock).mockReturnValue([{ id: vitruvOCLLanguageId }]);
+    registerVitruvOCLLanguage();
+    expect(monacoMock.languages.register).not.toHaveBeenCalled();
+    expect(monacoMock.languages.setMonarchTokensProvider).not.toHaveBeenCalled();
+    expect(monacoMock.languages.setLanguageConfiguration).not.toHaveBeenCalled();
+    expect(monacoMock.editor.defineTheme).not.toHaveBeenCalled();
+  });
+
+  it('should register on first call and skip on second call', () => {
+    // First call — not registered yet
+    registerVitruvOCLLanguage();
+    expect(monacoMock.languages.register).toHaveBeenCalledTimes(1);
+
+    // Simulate language now being present
+    jest.clearAllMocks();
+    (monacoMock.languages.getLanguages as jest.Mock).mockReturnValue([{ id: vitruvOCLLanguageId }]);
+
+    // Second call — should be a no-op
+    registerVitruvOCLLanguage();
+    expect(monacoMock.languages.register).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/hooks/useOclLsp.test.ts
+++ b/src/__tests__/hooks/useOclLsp.test.ts
@@ -1,0 +1,469 @@
+import { renderHook, act } from '@testing-library/react';
+import { useOclLsp } from '../../hooks/useOclLsp';
+
+// ─── Mock monaco-editor ──────────────────────────────────────────────────────
+const mockSetModelMarkers = jest.fn();
+const mockRegisterCompletionItemProvider = jest.fn();
+const mockCompletionDisposable = { dispose: jest.fn() };
+
+jest.mock('monaco-editor', () => ({
+  MarkerSeverity: { Error: 8, Warning: 4, Info: 2 },
+  editor: { setModelMarkers: mockSetModelMarkers },
+  languages: {
+    registerCompletionItemProvider: mockRegisterCompletionItemProvider,
+    CompletionItemKind: { Text: 1 },
+  },
+}));
+
+jest.mock('@monaco-editor/react', () => ({}));
+
+// ─── Mock WebSocket ───────────────────────────────────────────────────────────
+function makeMockWs() {
+  return {
+    readyState: 1,
+    onmessage: null,
+    onclose: null,
+    send: jest.fn(),
+    close: jest.fn(),
+  };
+}
+
+let mockWsInstance;
+
+beforeEach(() => {
+  mockWsInstance = makeMockWs();
+  global.WebSocket = jest.fn(() => mockWsInstance) as any;
+  global.WebSocket.OPEN = 1;
+
+  localStorage.clear();
+  localStorage.setItem('auth.user', JSON.stringify({ id: 'user-123' }));
+
+  jest.clearAllMocks();
+  mockRegisterCompletionItemProvider.mockReturnValue(mockCompletionDisposable);
+});
+
+// ─── Monaco instance stub ─────────────────────────────────────────────────────
+function makeMonacoStub() {
+  return {
+    MarkerSeverity: { Error: 8, Warning: 4, Info: 2 },
+    editor: { setModelMarkers: mockSetModelMarkers },
+    languages: {
+      registerCompletionItemProvider: mockRegisterCompletionItemProvider,
+      CompletionItemKind: { Text: 1 },
+    },
+  } as any;
+}
+
+// ─── Shared defaults ─────────────────────────────────────────────────────────
+const defaultProps = {
+  vsumId: 42,
+  documentId: 'doc-1',
+  languageId: 'ocl',
+  getCode: () => 'context Foo inv: true',
+};
+
+function simulateMessage(data: object) {
+  act(() => {
+    mockWsInstance.onmessage?.({ data: JSON.stringify(data) });
+  });
+}
+
+function mountHookAndConnect(props = defaultProps) {
+  const monaco = makeMonacoStub();
+  const { result, unmount } = renderHook(() => useOclLsp(props));
+  const mockEditor = { getModel: jest.fn(() => ({})) };
+  act(() => {
+    result.current.onMount(mockEditor as any, monaco);
+  });
+  return { result, unmount, monaco, mockEditor };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('useOclLsp', () => {
+
+  // ── 1. No WebSocket when prerequisites are missing ─────────────────────────
+  describe('no WebSocket created', () => {
+    it('does not open a WebSocket when vsumId is undefined', () => {
+      const monaco = makeMonacoStub();
+      const { result } = renderHook(() => useOclLsp({ ...defaultProps, vsumId: undefined }));
+      const mockEditor = { getModel: jest.fn() };
+      act(() => { result.current.onMount(mockEditor as any, monaco); });
+      expect(global.WebSocket).not.toHaveBeenCalled();
+    });
+
+    it('does not open a WebSocket when userId is absent from localStorage', () => {
+      localStorage.removeItem('auth.user');
+      const monaco = makeMonacoStub();
+      const { result } = renderHook(() => useOclLsp(defaultProps));
+      const mockEditor = { getModel: jest.fn() };
+      act(() => { result.current.onMount(mockEditor as any, monaco); });
+      expect(global.WebSocket).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── 2. WebSocket URL construction ─────────────────────────────────────────
+  describe('WebSocket creation', () => {
+    it('opens a WebSocket with the correct URL including userId and vsumId', () => {
+      process.env.REACT_APP_API_BASE_URL = 'http://localhost:9811';
+      mountHookAndConnect();
+      expect(global.WebSocket).toHaveBeenCalledWith(
+        'ws://localhost:9811/ocl-lsp?userId=user-123&vsumId=42'
+      );
+    });
+
+    it('converts https base URL to wss', () => {
+      process.env.REACT_APP_API_BASE_URL = 'https://api.example.com';
+      mountHookAndConnect();
+      expect(global.WebSocket).toHaveBeenCalledWith(
+        expect.stringContaining('wss://api.example.com')
+      );
+    });
+  });
+
+  // ── 3. LSP handshake ──────────────────────────────────────────────────────
+  describe('LSP handshake', () => {
+    it('sends initialize request when workspaceReady message is received', () => {
+      mountHookAndConnect();
+      simulateMessage({ type: 'workspaceReady', rootUri: 'file:///workspace/' });
+
+      const sent = JSON.parse(mockWsInstance.send.mock.calls[0][0]);
+      expect(sent.method).toBe('initialize');
+      expect(sent.id).toBe(1);
+      expect(sent.params.rootUri).toBe('file:///workspace/');
+    });
+
+    it('sends initialized + textDocument/didOpen after initialize response (id=1)', () => {
+      mountHookAndConnect();
+      simulateMessage({ type: 'workspaceReady', rootUri: 'file:///workspace/' });
+      mockWsInstance.send.mockClear();
+
+      simulateMessage({ id: 1, result: { capabilities: {} } });
+
+      const calls = mockWsInstance.send.mock.calls.map((c) => JSON.parse(c[0]));
+      const methods = calls.map((m) => m.method);
+      expect(methods).toContain('initialized');
+      expect(methods).toContain('textDocument/didOpen');
+    });
+
+    it('includes the correct text and languageId in textDocument/didOpen', () => {
+      mountHookAndConnect();
+      simulateMessage({ type: 'workspaceReady', rootUri: 'file:///workspace/' });
+      mockWsInstance.send.mockClear();
+      simulateMessage({ id: 1, result: { capabilities: {} } });
+
+      const calls = mockWsInstance.send.mock.calls.map((c) => JSON.parse(c[0]));
+      const didOpen = calls.find((m) => m.method === 'textDocument/didOpen');
+      expect(didOpen.params.textDocument.text).toBe('context Foo inv: true');
+      expect(didOpen.params.textDocument.languageId).toBe('ocl');
+    });
+  });
+
+  // ── 4. publishDiagnostics ─────────────────────────────────────────────────
+  describe('textDocument/publishDiagnostics', () => {
+    function setupInitialized() {
+      const { result, unmount } = renderHook(() => useOclLsp(defaultProps));
+      const monaco = makeMonacoStub();
+      const mockModel = {};
+      const mockEditor = { getModel: jest.fn(() => mockModel) };
+
+      act(() => { result.current.onMount(mockEditor as any, monaco); });
+      simulateMessage({ type: 'workspaceReady', rootUri: 'file:///workspace/' });
+      simulateMessage({ id: 1, result: { capabilities: {} } });
+
+      return { result, unmount, mockModel };
+    }
+
+    it('calls monaco.editor.setModelMarkers with mapped markers for severity 1 (Error)', () => {
+      const { mockModel } = setupInitialized();
+
+      simulateMessage({
+        method: 'textDocument/publishDiagnostics',
+        params: {
+          diagnostics: [{
+            severity: 1,
+            message: 'Something is wrong',
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } },
+          }],
+        },
+      });
+
+      expect(mockSetModelMarkers).toHaveBeenCalledWith(
+        mockModel,
+        'ocl',
+        expect.arrayContaining([
+          expect.objectContaining({
+            severity: 8,
+            message: 'Something is wrong',
+            startLineNumber: 1,
+            startColumn: 1,
+            endLineNumber: 1,
+            endColumn: 6,
+          }),
+        ])
+      );
+    });
+
+    it('maps severity 2 to Warning (4)', () => {
+      const { mockModel } = setupInitialized();
+
+      simulateMessage({
+        method: 'textDocument/publishDiagnostics',
+        params: {
+          diagnostics: [{
+            severity: 2,
+            message: 'A warning',
+            range: { start: { line: 1, character: 2 }, end: { line: 1, character: 8 } },
+          }],
+        },
+      });
+
+      expect(mockSetModelMarkers).toHaveBeenCalledWith(
+        mockModel,
+        'ocl',
+        expect.arrayContaining([expect.objectContaining({ severity: 4 })])
+      );
+    });
+
+    it('maps unknown severity to Info (2)', () => {
+      const { mockModel } = setupInitialized();
+
+      simulateMessage({
+        method: 'textDocument/publishDiagnostics',
+        params: {
+          diagnostics: [{
+            severity: 99,
+            message: 'Just info',
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+          }],
+        },
+      });
+
+      expect(mockSetModelMarkers).toHaveBeenCalledWith(
+        mockModel,
+        'ocl',
+        expect.arrayContaining([expect.objectContaining({ severity: 2 })])
+      );
+    });
+
+    it('does not call setModelMarkers when editor has no model', () => {
+      const { result } = renderHook(() => useOclLsp(defaultProps));
+      const monaco = makeMonacoStub();
+      const mockEditor = { getModel: jest.fn(() => null) };
+
+      act(() => { result.current.onMount(mockEditor as any, monaco); });
+      simulateMessage({ type: 'workspaceReady', rootUri: 'file:///workspace/' });
+      simulateMessage({ id: 1, result: { capabilities: {} } });
+      mockSetModelMarkers.mockClear();
+
+      simulateMessage({
+        method: 'textDocument/publishDiagnostics',
+        params: { diagnostics: [] },
+      });
+
+      expect(mockSetModelMarkers).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── 5. notifyChange ───────────────────────────────────────────────────────
+  describe('notifyChange', () => {
+    it('sends textDocument/didChange when initialized', () => {
+      const { result } = mountHookAndConnect();
+
+      simulateMessage({ type: 'workspaceReady', rootUri: 'file:///workspace/' });
+      simulateMessage({ id: 1, result: { capabilities: {} } });
+      mockWsInstance.send.mockClear();
+
+      act(() => { result.current.notifyChange('new text'); });
+
+      const calls = mockWsInstance.send.mock.calls.map((c) => JSON.parse(c[0]));
+      const didChange = calls.find((m) => m.method === 'textDocument/didChange');
+      expect(didChange).toBeDefined();
+      expect(didChange.params.contentChanges[0].text).toBe('new text');
+    });
+
+    it('does nothing when not yet initialized', () => {
+      const { result } = mountHookAndConnect();
+      mockWsInstance.send.mockClear();
+
+      act(() => { result.current.notifyChange('some text'); });
+
+      expect(mockWsInstance.send).not.toHaveBeenCalled();
+    });
+
+    it('increments the document version on each change', () => {
+      const { result } = mountHookAndConnect();
+
+      simulateMessage({ type: 'workspaceReady', rootUri: 'file:///workspace/' });
+      simulateMessage({ id: 1, result: { capabilities: {} } });
+      mockWsInstance.send.mockClear();
+
+      act(() => { result.current.notifyChange('first'); });
+      act(() => { result.current.notifyChange('second'); });
+
+      const calls = mockWsInstance.send.mock.calls.map((c) => JSON.parse(c[0]));
+      const versions = calls
+        .filter((m) => m.method === 'textDocument/didChange')
+        .map((m) => m.params.textDocument.version);
+
+      expect(versions[0]).toBeLessThan(versions[1]);
+    });
+  });
+
+  // ── 6. Unmount / cleanup ──────────────────────────────────────────────────
+  describe('unmount cleanup', () => {
+    it('sends textDocument/didClose and closes the WebSocket', () => {
+      const { unmount } = mountHookAndConnect();
+
+      simulateMessage({ type: 'workspaceReady', rootUri: 'file:///workspace/' });
+      simulateMessage({ id: 1, result: { capabilities: {} } });
+      mockWsInstance.send.mockClear();
+
+      act(() => { unmount(); });
+
+      const calls = mockWsInstance.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(calls.some((m) => m.method === 'textDocument/didClose')).toBe(true);
+      expect(mockWsInstance.close).toHaveBeenCalled();
+    });
+
+    it('closes the WebSocket even when not initialized', () => {
+      const { unmount } = mountHookAndConnect();
+      mockWsInstance.send.mockClear();
+
+      act(() => { unmount(); });
+
+      expect(mockWsInstance.close).toHaveBeenCalled();
+    });
+
+    it('disposes the completion provider on unmount', () => {
+      const disposeFn = jest.fn();
+      mockRegisterCompletionItemProvider.mockReturnValue({ dispose: disposeFn });
+
+      const { unmount } = mountHookAndConnect();
+
+      act(() => { unmount(); });
+
+      expect(disposeFn).toHaveBeenCalled();
+    });
+
+    it('does not send didClose when never initialized', () => {
+      const { unmount } = mountHookAndConnect();
+      mockWsInstance.send.mockClear();
+
+      act(() => { unmount(); });
+
+      const calls = mockWsInstance.send.mock.calls.map((c) => JSON.parse(c[0]));
+      expect(calls.some((m) => m.method === 'textDocument/didClose')).toBe(false);
+    });
+  });
+
+  // ── 7. Completion provider registration ───────────────────────────────────
+  describe('completion provider', () => {
+    it('registers a completion provider on connect', () => {
+      mountHookAndConnect();
+
+      expect(mockRegisterCompletionItemProvider).toHaveBeenCalledWith(
+        'ocl',
+        expect.objectContaining({
+          triggerCharacters: expect.arrayContaining(['.']),
+          provideCompletionItems: expect.any(Function),
+        })
+      );
+    });
+  });
+
+  // ── 8. onMount ────────────────────────────────────────────────────────────
+  describe('onMount', () => {
+    it('stores the editor ref and triggers connect (WebSocket is created)', () => {
+      const monaco = makeMonacoStub();
+      const { result } = renderHook(() => useOclLsp(defaultProps));
+      const mockEditor = { getModel: jest.fn() };
+
+      act(() => { result.current.onMount(mockEditor as any, monaco); });
+
+      expect(global.WebSocket).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── 9. Malformed messages ─────────────────────────────────────────────────
+  describe('malformed messages', () => {
+    it('silently ignores non-JSON messages', () => {
+      mountHookAndConnect();
+
+      expect(() => {
+        act(() => {
+          mockWsInstance.onmessage?.({ data: 'not-valid-json' });
+        });
+      }).not.toThrow();
+    });
+  });
+
+  // ── 10. Completion response (pendingRequests path) ────────────────────────
+  describe('completion response handling', () => {
+    function setupInitializedWithCompletion() {
+      let capturedProvider: any;
+      mockRegisterCompletionItemProvider.mockImplementation((_lang, provider) => {
+        capturedProvider = provider;
+        return { dispose: jest.fn() };
+      });
+
+      const { result, unmount } = mountHookAndConnect();
+      simulateMessage({ type: 'workspaceReady', rootUri: 'file:///workspace/' });
+      simulateMessage({ id: 1, result: { capabilities: {} } });
+
+      return { result, unmount, getProvider: () => capturedProvider };
+    }
+
+    it('resolves completion items when LSP responds via pendingRequests', async () => {
+      const { getProvider } = setupInitializedWithCompletion();
+      const provider = getProvider();
+
+      const mockModel = {
+        getWordUntilPosition: jest.fn(() => ({ startColumn: 1, endColumn: 4 })),
+      };
+      const mockPosition = { lineNumber: 1, column: 4 };
+
+      // Start the completion request (triggers send + registers pending callback)
+      const completionPromise = provider.provideCompletionItems(mockModel, mockPosition);
+
+      // Capture the request id from the sent message
+      const lastSent = JSON.parse(
+        mockWsInstance.send.mock.calls[mockWsInstance.send.mock.calls.length - 1][0]
+      );
+      expect(lastSent.method).toBe('textDocument/completion');
+
+      // Simulate LSP response arriving via onmessage
+      act(() => {
+        mockWsInstance.onmessage?.({
+          data: JSON.stringify({
+            id: lastSent.id,
+            result: { items: [{ label: 'self', insertText: 'self' }] },
+          }),
+        });
+      });
+
+      const result = await completionPromise;
+      expect(result.suggestions).toHaveLength(1);
+      expect(result.suggestions[0].label).toBe('self');
+    });
+
+    it('resolves with empty suggestions when provideCompletionItems is called before initialized', async () => {
+      let capturedProvider: any;
+      mockRegisterCompletionItemProvider.mockImplementation((_lang, provider) => {
+        capturedProvider = provider;
+        return { dispose: jest.fn() };
+      });
+
+      // Connect but do NOT send workspaceReady/initialized
+      mountHookAndConnect();
+
+      const mockModel = {
+        getWordUntilPosition: jest.fn(() => ({ startColumn: 1, endColumn: 1 })),
+      };
+      const mockPosition = { lineNumber: 1, column: 1 };
+
+      const result = await capturedProvider.provideCompletionItems(mockModel, mockPosition);
+      expect(result.suggestions).toEqual([]);
+    });
+  });
+});

--- a/src/components/constraints/ConstraintsView.tsx
+++ b/src/components/constraints/ConstraintsView.tsx
@@ -381,6 +381,10 @@ function replaceRule(ruleSets: RuleSet[], updated: ConstraintRule): RuleSet[] {
   return ruleSets.map(rs => ({ ...rs, rules: rs.rules.map(r => r.id === updated.id ? updated : r) }));
 }
 
+function deleteRuleFromSets(ruleSets: RuleSet[], ruleId: string): RuleSet[] {
+  return ruleSets.map(rs => ({ ...rs, rules: rs.rules.filter(r => r.id !== ruleId) }));
+}
+
 function findSetContainingRule(ruleSets: RuleSet[], ruleId: string): RuleSet | undefined {
   return ruleSets.find(rs => rs.rules.some(r => r.id === ruleId));
 }
@@ -447,7 +451,9 @@ const RuleRow: React.FC<{ rule: ConstraintRule; selected: boolean; onClick: () =
         </button>
         {menuOpen && (
           <div
+            tabIndex={-1}
             onClick={e => e.stopPropagation()}
+            onKeyDown={e => e.stopPropagation()}
             style={{
               position: 'absolute', right: 0, top: '100%', zIndex: 50,
               background: '#ffffff', border: '1px solid #e2e8f0',
@@ -681,7 +687,7 @@ const ContextClassPicker: React.FC<{
           </div>
 
           {/* Options */}
-          <ul role="listbox" style={{ maxHeight: 220, overflowY: 'auto', listStyle: 'none', margin: 0, padding: 0 }}>
+          <ul role="menu" style={{ maxHeight: 220, overflowY: 'auto', listStyle: 'none', margin: 0, padding: 0 }}>
             {Object.keys(groups).length === 0 && (
               <li style={{ padding: '10px 12px', fontSize: 12, color: '#94a3b8', fontFamily: APP_FONT }}>No classes found</li>
             )}
@@ -690,13 +696,13 @@ const ContextClassPicker: React.FC<{
                 <div style={{ padding: '5px 12px 3px', fontSize: 10.5, fontWeight: 700, color: '#64748b', textTransform: 'uppercase', letterSpacing: '0.06em', background: '#f8fafc', borderBottom: '1px solid #f1f5f9' }}>
                   {mm}
                 </div>
-                <ul role="group" style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+                <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
                   {classes.map(c => (
                     <li
                       key={c.label}
-                      role="option"
+                      role="menuitemradio"
                       tabIndex={0}
-                      aria-selected={c.label === value}
+                      aria-checked={c.label === value}
                       onClick={() => { onChange(c.label); setOpen(false); setQuery(''); }}
                       onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { onChange(c.label); setOpen(false); setQuery(''); } }}
                       style={{
@@ -837,8 +843,8 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
 
   // ── OCL → form fields ───────────────────────────────────────────────────────
 
-  const handleOclChange = (v: string | undefined) => {
-    const ocl = v ?? '';
+  const handleOclChange = (v: string = '') => {
+    const ocl = v;
     notifyChange(ocl);
     if (updatingFromRef.current === 'form') return;
     updatingFromRef.current = 'code';
@@ -884,9 +890,15 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
       }}>
         {/* Resize handle */}
         <div
-          role="separator"
-          aria-orientation="horizontal"
+          role="slider"
+          aria-label="Resize panel"
+          aria-orientation="vertical"
+          aria-valuenow={height}
+          aria-valuemin={EDITOR_PANEL_MIN_H}
+          aria-valuemax={EDITOR_PANEL_MAX_H}
+          tabIndex={0}
           onMouseDown={onHandleMouseDown}
+          onKeyDown={() => { /* keyboard resize not implemented */ }}
           style={{
             position: 'absolute', top: 0, left: 0, right: 0, height: 6,
             cursor: 'ns-resize', zIndex: 10,
@@ -1630,10 +1642,10 @@ export const ConstraintsView: React.FC<ConstraintsViewProps> = ({ vsumId: _vsumI
 
   const handleDeleteRule = useCallback((ruleId: string) => {
     setRuleSets(prev => {
-      const next = prev.map(rs => ({ ...rs, rules: rs.rules.filter(r => r.id !== ruleId) }));
-      const affectedId = prev.find(rs => rs.rules.some(r => r.id === ruleId))?.id;
-      const affected = next.find(rs => rs.id === affectedId);
-      if (affected) syncRuleSet(affected);
+      const next = deleteRuleFromSets(prev, ruleId);
+      const affected = findSetContainingRule(prev, ruleId);
+      const syncTarget = next.find(rs => rs.id === affected?.id);
+      if (syncTarget) syncRuleSet(syncTarget);
       return next;
     });
     setSelectedRule(prev => prev?.id === ruleId ? null : prev);
@@ -1719,7 +1731,7 @@ export const ConstraintsView: React.FC<ConstraintsViewProps> = ({ vsumId: _vsumI
 
       {/* Bottom editor — floats over the center canvas, re-enables pointer events */}
       {selectedRule && (
-        <div role="region" aria-label="Rule editor" style={{ position: 'absolute', bottom: 0, left: 260, right: 300, pointerEvents: 'auto', display: 'flex', flexDirection: 'column' }} onKeyDown={e => e.stopPropagation()}>
+        <section aria-label="Rule editor" tabIndex={-1} style={{ position: 'absolute', bottom: 0, left: 260, right: 300, pointerEvents: 'auto', display: 'flex', flexDirection: 'column' }} onKeyDown={e => e.stopPropagation()}>
           <EditorPanel
             rule={selectedRule}
             ruleSets={ruleSets}
@@ -1731,7 +1743,7 @@ export const ConstraintsView: React.FC<ConstraintsViewProps> = ({ vsumId: _vsumI
             onHighlightNode={onHighlightNode}
             canvasNodes={canvasNodes}
           />
-        </div>
+        </section>
       )}
       {selectedRuleSet && !selectedRule && (
         <div style={{ position: 'absolute', bottom: 0, left: 260, right: 300, pointerEvents: 'auto', maxHeight: '42%', display: 'flex', flexDirection: 'column' }}>

--- a/src/components/constraints/ConstraintsView.tsx
+++ b/src/components/constraints/ConstraintsView.tsx
@@ -252,7 +252,7 @@ const KIT_RULE_SETS: RuleSet[] = [
 
 /** Splits combined OCL file content into individual ConstraintRule objects. */
 function parseRulesFromOcl(oclContent: string, ruleSetId: string): ConstraintRule[] {
-  const blocks = oclContent.split(/(?=^\s*context\s)/m).map(b => b.trim()).filter(Boolean);
+  const blocks = oclContent.split(/^(?=context[ \t])/m).map(b => b.trim()).filter(Boolean);
   return blocks.map((ocl, i) => ({
     id: `r_${ruleSetId}_${i}_${Date.now()}`,
     ruleSetId,
@@ -375,6 +375,20 @@ function useResizablePanel() {
   return { height, onHandleMouseDown };
 }
 
+// ── RuleSet update helpers ────────────────────────────────────────────────────
+
+function replaceRule(ruleSets: RuleSet[], updated: ConstraintRule): RuleSet[] {
+  return ruleSets.map(rs => ({ ...rs, rules: rs.rules.map(r => r.id === updated.id ? updated : r) }));
+}
+
+function findSetContainingRule(ruleSets: RuleSet[], ruleId: string): RuleSet | undefined {
+  return ruleSets.find(rs => rs.rules.some(r => r.id === ruleId));
+}
+
+function updateBackendId(prev: RuleSet[], rsId: string, backendId: number): RuleSet[] {
+  return prev.map(r => r.id === rsId ? { ...r, backendId } : r);
+}
+
 // ── Sub-components ────────────────────────────────────────────────────────────
 
 const RuleRow: React.FC<{ rule: ConstraintRule; selected: boolean; onClick: () => void; onDelete: () => void }> = ({ rule, selected, onClick, onDelete }) => {
@@ -391,32 +405,39 @@ const RuleRow: React.FC<{ rule: ConstraintRule; selected: boolean; onClick: () =
     return () => document.removeEventListener('mousedown', close);
   }, [menuOpen]);
 
-  const rowBackground = selected ? '#f0fdf9' : hov ? '#f8fafc' : 'transparent';
+  let rowBackground: string;
+  if (selected) { rowBackground = '#f0fdf9'; }
+  else if (hov) { rowBackground = '#f8fafc'; }
+  else { rowBackground = 'transparent'; }
 
   return (
     <div
-      role="button"
-      tabIndex={0}
-      onClick={onClick}
-      onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') onClick(); }}
       onMouseEnter={() => setHov(true)}
       onMouseLeave={() => setHov(false)}
       style={{
-        display: 'flex', alignItems: 'center', gap: 8,
-        padding: '7px 12px 7px 28px',
+        position: 'relative',
         background: rowBackground,
         borderLeft: selected ? '2px solid #049484' : '2px solid transparent',
-        cursor: 'pointer', borderRadius: 0,
-        transition: 'background 0.1s', position: 'relative',
+        transition: 'background 0.1s',
       }}
     >
-      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={selected ? '#049484' : '#94a3b8'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
-        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14,2 14,8 20,8"/>
-      </svg>
-      <span style={{ fontSize: 12.5, color: selected ? '#049484' : '#334155', fontWeight: selected ? 600 : 400, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-        {rule.name}
-      </span>
-      <div ref={menuRef} style={{ position: 'relative' }}>
+      <button
+        onClick={onClick}
+        style={{
+          display: 'flex', alignItems: 'center', gap: 8, width: '100%',
+          padding: '7px 40px 7px 28px',
+          background: 'transparent', border: 'none', cursor: 'pointer',
+          textAlign: 'left', borderRadius: 0,
+        }}
+      >
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={selected ? '#049484' : '#94a3b8'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14,2 14,8 20,8"/>
+        </svg>
+        <span style={{ fontSize: 12.5, color: selected ? '#049484' : '#334155', fontWeight: selected ? 600 : 400, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {rule.name}
+        </span>
+      </button>
+      <div ref={menuRef} style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)' }}>
         <button
           onClick={e => { e.stopPropagation(); setMenuOpen(o => !o); }}
           style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 2, color: '#94a3b8', borderRadius: 4, display: 'flex', alignItems: 'center' }}
@@ -470,53 +491,60 @@ interface RuleSetSectionProps {
 const RuleSetSection: React.FC<RuleSetSectionProps> = ({ ruleSet, selectedRuleId, selectedRuleSetId, onRuleClick, onRuleSetClick, onToggleCollapse, onAddRule, onDeleteRule }) => {
   const [hov, setHov] = useState(false);
   const isSelected = selectedRuleSetId === ruleSet.id;
-  const headerBackground = isSelected ? '#f0fdf9' : hov ? '#f8fafc' : 'transparent';
+  let headerBackground: string;
+  if (isSelected) { headerBackground = '#f0fdf9'; }
+  else if (hov) { headerBackground = '#f8fafc'; }
+  else { headerBackground = 'transparent'; }
   return (
     <div>
       <div
-        role="button"
-        tabIndex={0}
-        onClick={() => onRuleSetClick(ruleSet)}
-        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') onRuleSetClick(ruleSet); }}
         onMouseEnter={() => setHov(true)}
         onMouseLeave={() => setHov(false)}
         style={{
-          display: 'flex', alignItems: 'center', gap: 8,
-          padding: '8px 12px', cursor: 'pointer',
+          display: 'flex', alignItems: 'center',
           background: headerBackground,
           borderLeft: isSelected ? `2px solid ${ruleSet.color}` : '2px solid transparent',
           borderBottom: '1px solid #f1f5f9',
-          userSelect: 'none',
         }}
       >
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: ruleSet.color, flexShrink: 0 }} />
-        <span style={{ fontSize: 12.5, fontWeight: 600, color: '#1e293b', flex: 1 }}>{ruleSet.name}</span>
-        <span style={{ fontSize: 11, color: '#94a3b8', fontWeight: 500 }}>{ruleSet.rules.length} rules</span>
-        <svg
-          onClick={e => { e.stopPropagation(); onToggleCollapse(ruleSet.id); }}
-          width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" strokeWidth="2.5" strokeLinecap="round"
-          style={{ transform: ruleSet.collapsed ? 'rotate(-90deg)' : 'rotate(0deg)', transition: 'transform 0.15s', flexShrink: 0, cursor: 'pointer', padding: 2 }}
+        <button
+          onClick={() => onRuleSetClick(ruleSet)}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 8, flex: 1,
+            padding: '8px 4px 8px 12px', background: 'none', border: 'none',
+            cursor: 'pointer', userSelect: 'none', textAlign: 'left',
+          }}
         >
-          <polyline points="6,9 12,15 18,9"/>
-        </svg>
+          <div style={{ width: 10, height: 10, borderRadius: 2, background: ruleSet.color, flexShrink: 0 }} />
+          <span style={{ fontSize: 12.5, fontWeight: 600, color: '#1e293b', flex: 1 }}>{ruleSet.name}</span>
+          <span style={{ fontSize: 11, color: '#94a3b8', fontWeight: 500 }}>{ruleSet.rules.length} rules</span>
+        </button>
+        <button
+          onClick={() => onToggleCollapse(ruleSet.id)}
+          style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '8px 12px 8px 4px', display: 'flex', alignItems: 'center' }}
+        >
+          <svg
+            width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" strokeWidth="2.5" strokeLinecap="round"
+            style={{ transform: ruleSet.collapsed ? 'rotate(-90deg)' : 'rotate(0deg)', transition: 'transform 0.15s', flexShrink: 0 }}
+          >
+            <polyline points="6,9 12,15 18,9"/>
+          </svg>
+        </button>
       </div>
       {!ruleSet.collapsed && (
         <div>
           {ruleSet.rules.map(rule => (
             <RuleRow key={rule.id} rule={rule} selected={selectedRuleId === rule.id} onClick={() => onRuleClick(rule)} onDelete={() => onDeleteRule(rule.id)} />
           ))}
-          <div
-            role="button"
-            tabIndex={0}
+          <button
             onClick={() => onAddRule(ruleSet.id)}
-            onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') onAddRule(ruleSet.id); }}
-            style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px 6px 28px', cursor: 'pointer', color: '#94a3b8', fontSize: 12 }}
+            style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px 6px 28px', cursor: 'pointer', color: '#94a3b8', fontSize: 12, background: 'none', border: 'none', width: '100%', textAlign: 'left' }}
             onMouseEnter={e => (e.currentTarget.style.color = '#049484')}
             onMouseLeave={e => (e.currentTarget.style.color = '#94a3b8')}
           >
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
             Add rule
-          </div>
+          </button>
         </div>
       )}
     </div>
@@ -624,18 +652,15 @@ const ContextClassPicker: React.FC<{
 
   return (
     <div ref={containerRef} style={{ position: 'relative' }}>
-      <div
-        role="button"
-        tabIndex={0}
+      <button
         style={{ ...inputBase, display: 'flex', alignItems: 'center', justifyContent: 'space-between', userSelect: 'none' }}
         onClick={() => { setOpen(o => !o); setQuery(''); }}
-        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { setOpen(o => !o); setQuery(''); } }}
       >
         <span style={{ color: value ? '#0f172a' : '#94a3b8' }}>{value || 'Select context class…'}</span>
         <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" strokeWidth="2.5" strokeLinecap="round" style={{ transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s', flexShrink: 0 }}>
           <polyline points="6,9 12,15 18,9" />
         </svg>
-      </div>
+      </button>
 
       {open && (
         <div style={{
@@ -656,40 +681,42 @@ const ContextClassPicker: React.FC<{
           </div>
 
           {/* Options */}
-          <div style={{ maxHeight: 220, overflowY: 'auto' }}>
+          <ul role="listbox" style={{ maxHeight: 220, overflowY: 'auto', listStyle: 'none', margin: 0, padding: 0 }}>
             {Object.keys(groups).length === 0 && (
-              <div style={{ padding: '10px 12px', fontSize: 12, color: '#94a3b8', fontFamily: APP_FONT }}>No classes found</div>
+              <li style={{ padding: '10px 12px', fontSize: 12, color: '#94a3b8', fontFamily: APP_FONT }}>No classes found</li>
             )}
             {Object.entries(groups).map(([mm, classes]) => (
-              <div key={mm}>
+              <li key={mm}>
                 <div style={{ padding: '5px 12px 3px', fontSize: 10.5, fontWeight: 700, color: '#64748b', textTransform: 'uppercase', letterSpacing: '0.06em', background: '#f8fafc', borderBottom: '1px solid #f1f5f9' }}>
                   {mm}
                 </div>
-                {classes.map(c => (
-                  <div
-                    key={c.label}
-                    role="option"
-                    tabIndex={0}
-                    aria-selected={c.label === value}
-                    onClick={() => { onChange(c.label); setOpen(false); setQuery(''); }}
-                    onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { onChange(c.label); setOpen(false); setQuery(''); } }}
-                    style={{
-                      padding: '7px 12px 7px 20px', fontSize: 12.5, cursor: 'pointer',
-                      color: c.label === value ? '#049484' : '#0f172a',
-                      fontWeight: c.label === value ? 600 : 400,
-                      background: c.label === value ? '#f0fdf9' : 'transparent',
-                      fontFamily: 'monospace',
-                    }}
-                    onMouseEnter={e => { if (c.label !== value) e.currentTarget.style.background = '#f8fafc'; }}
-                    onMouseLeave={e => { if (c.label !== value) e.currentTarget.style.background = 'transparent'; }}
-                  >
-                    {c.className}
-                    <span style={{ marginLeft: 6, fontSize: 11, color: '#94a3b8', fontFamily: APP_FONT }}>{c.metamodel}::</span>
-                  </div>
-                ))}
-              </div>
+                <ul role="group" style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+                  {classes.map(c => (
+                    <li
+                      key={c.label}
+                      role="option"
+                      tabIndex={0}
+                      aria-selected={c.label === value}
+                      onClick={() => { onChange(c.label); setOpen(false); setQuery(''); }}
+                      onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { onChange(c.label); setOpen(false); setQuery(''); } }}
+                      style={{
+                        padding: '7px 12px 7px 20px', fontSize: 12.5, cursor: 'pointer',
+                        color: c.label === value ? '#049484' : '#0f172a',
+                        fontWeight: c.label === value ? 600 : 400,
+                        background: c.label === value ? '#f0fdf9' : 'transparent',
+                        fontFamily: 'monospace',
+                      }}
+                      onMouseEnter={e => { if (c.label !== value) e.currentTarget.style.background = '#f8fafc'; }}
+                      onMouseLeave={e => { if (c.label !== value) e.currentTarget.style.background = 'transparent'; }}
+                    >
+                      {c.className}
+                      <span style={{ marginLeft: 6, fontSize: 11, color: '#94a3b8', fontFamily: APP_FONT }}>{c.metamodel}::</span>
+                    </li>
+                  ))}
+                </ul>
+              </li>
             ))}
-          </div>
+          </ul>
         </div>
       )}
     </div>
@@ -718,13 +745,23 @@ const SaveChangesButton: React.FC<{ onSave: () => void }> = ({ onSave }) => {
       setTimeout(() => setSaved(false), 2000);
     }, 650);
   };
+  let btnBackground: string;
+  if (saving) { btnBackground = '#7fc4bc'; }
+  else if (saved) { btnBackground = '#15803d'; }
+  else { btnBackground = '#049484'; }
+
+  let btnLabel: string;
+  if (saving) { btnLabel = 'Saving…'; }
+  else if (saved) { btnLabel = 'Saved ✓'; }
+  else { btnLabel = 'Save Changes'; }
+
   return (
     <button
       onClick={handleClick}
       disabled={saving}
       style={{
         width: '100%', marginTop: 12, padding: '8px 0',
-        background: saving ? '#7fc4bc' : saved ? '#15803d' : '#049484',
+        background: btnBackground,
         color: '#fff', border: 'none', borderRadius: 6, fontSize: 12, fontWeight: 600,
         cursor: saving ? 'default' : 'pointer',
         display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7,
@@ -732,7 +769,7 @@ const SaveChangesButton: React.FC<{ onSave: () => void }> = ({ onSave }) => {
       }}
     >
       {saving && <SpinnerIcon />}
-      {saving ? 'Saving…' : saved ? 'Saved ✓' : 'Save Changes'}
+      {btnLabel}
     </button>
   );
 };
@@ -829,7 +866,7 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
         onSave={ocl => { handleOclChange(ocl); }}
         initialCode={draft.oclDefinition}
         edgeId={draft.id}
-        vsumId={vsumId != null ? String(vsumId) : undefined}
+        vsumId={vsumId === null || vsumId === undefined ? undefined : String(vsumId)}
         lspEndpoint="/ocl-lsp"
         languageId={vitruvOCLLanguageId}
         fileExtension=".ocl"
@@ -847,6 +884,8 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
       }}>
         {/* Resize handle */}
         <div
+          role="separator"
+          aria-orientation="horizontal"
           onMouseDown={onHandleMouseDown}
           style={{
             position: 'absolute', top: 0, left: 0, right: 0, height: 6,
@@ -1126,7 +1165,7 @@ const DetailedMetricsModal: React.FC<{ ruleSets: RuleSet[]; colorMap: Record<str
       open
       style={{ position: 'fixed', inset: 0, width: '100%', height: '100%', background: 'none', border: 'none', padding: 0, margin: 0, zIndex: 2000, display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden' }}
     >
-      <div role="button" tabIndex={0} onClick={onClose} onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') onClose(); }} style={{ position: 'absolute', inset: 0, background: 'rgba(15,23,42,0.35)' }} />
+      <button onClick={onClose} aria-label="Close" style={{ position: 'absolute', inset: 0, background: 'rgba(15,23,42,0.35)', border: 'none', cursor: 'default', padding: 0 }} />
       <div style={{
         position: 'relative', zIndex: 1,
         background: '#fff', borderRadius: 14, width: '88%', maxWidth: 1040,
@@ -1161,7 +1200,7 @@ const DetailedMetricsModal: React.FC<{ ruleSets: RuleSet[]; colorMap: Record<str
                 <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 18px', background: '#f8fafc', borderBottom: '1px solid #f1f5f9' }}>
                   <div style={{ width: 11, height: 11, borderRadius: 3, background: rs.color, flexShrink: 0 }} />
                   <span style={{ fontSize: 13, fontWeight: 700, color: '#0f172a', flex: 1 }}>{rs.name}</span>
-                  <span style={{ fontSize: 12, color: '#94a3b8' }}>{total} rule{total !== 1 ? 's' : ''}</span>
+                  <span style={{ fontSize: 12, color: '#94a3b8' }}>{total} rule{total === 1 ? '' : 's'}</span>
                 </div>
 
                 {/* Card body */}
@@ -1547,13 +1586,13 @@ export const ConstraintsView: React.FC<ConstraintsViewProps> = ({ vsumId: _vsumI
   const syncRuleSet = useCallback((rs: RuleSet) => {
     if (vsumId == null) return;
     const body = { name: rs.name, color: rs.color, description: rs.description, oclContent: ruleSetToOcl(rs) };
-    if (rs.backendId != null) {
+    if (rs.backendId === null || rs.backendId === undefined) {
+      apiService.createRuleSet(vsumId, body).then(created => {
+        setRuleSets(prev => updateBackendId(prev, rs.id, created.id));
+      }).catch(err => console.error('Failed to create RuleSet:', err));
+    } else {
       apiService.updateRuleSet(vsumId, rs.backendId, body).catch(err =>
         console.error('Failed to sync RuleSet:', err));
-    } else {
-      apiService.createRuleSet(vsumId, body).then(created => {
-        setRuleSets(prev => prev.map(r => r.id === rs.id ? { ...r, backendId: created.id } : r));
-      }).catch(err => console.error('Failed to create RuleSet:', err));
     }
   }, [vsumId]);
 
@@ -1592,8 +1631,8 @@ export const ConstraintsView: React.FC<ConstraintsViewProps> = ({ vsumId: _vsumI
   const handleDeleteRule = useCallback((ruleId: string) => {
     setRuleSets(prev => {
       const next = prev.map(rs => ({ ...rs, rules: rs.rules.filter(r => r.id !== ruleId) }));
-      // sync the affected ruleset
-      const affected = next.find(rs => prev.find(p => p.id === rs.id)?.rules.some(r => r.id === ruleId));
+      const affectedId = prev.find(rs => rs.rules.some(r => r.id === ruleId))?.id;
+      const affected = next.find(rs => rs.id === affectedId);
       if (affected) syncRuleSet(affected);
       return next;
     });
@@ -1630,7 +1669,7 @@ export const ConstraintsView: React.FC<ConstraintsViewProps> = ({ vsumId: _vsumI
   const handleDeleteRuleSet = useCallback((ruleSetId: string) => {
     setRuleSets(prev => {
       const rs = prev.find(r => r.id === ruleSetId);
-      if (rs?.backendId != null && vsumId != null) {
+      if (rs?.backendId !== null && rs?.backendId !== undefined && vsumId !== null && vsumId !== undefined) {
         apiService.deleteRuleSet(vsumId, rs.backendId).catch(err => console.error('Failed to delete RuleSet:', err));
       }
       return prev.filter(r => r.id !== ruleSetId);
@@ -1640,8 +1679,8 @@ export const ConstraintsView: React.FC<ConstraintsViewProps> = ({ vsumId: _vsumI
 
   const handleSaveRule = useCallback((updated: ConstraintRule) => {
     setRuleSets(prev => {
-      const next = prev.map(rs => ({ ...rs, rules: rs.rules.map(r => r.id === updated.id ? updated : r) }));
-      const affected = next.find(rs => rs.rules.some(r => r.id === updated.id));
+      const next = replaceRule(prev, updated);
+      const affected = findSetContainingRule(next, updated.id);
       if (affected) syncRuleSet(affected);
       return next;
     });
@@ -1680,7 +1719,7 @@ export const ConstraintsView: React.FC<ConstraintsViewProps> = ({ vsumId: _vsumI
 
       {/* Bottom editor — floats over the center canvas, re-enables pointer events */}
       {selectedRule && (
-        <div style={{ position: 'absolute', bottom: 0, left: 260, right: 300, pointerEvents: 'auto', display: 'flex', flexDirection: 'column' }} onKeyDown={e => e.stopPropagation()}>
+        <div role="region" aria-label="Rule editor" style={{ position: 'absolute', bottom: 0, left: 260, right: 300, pointerEvents: 'auto', display: 'flex', flexDirection: 'column' }} onKeyDown={e => e.stopPropagation()}>
           <EditorPanel
             rule={selectedRule}
             ruleSets={ruleSets}

--- a/src/components/constraints/ConstraintsView.tsx
+++ b/src/components/constraints/ConstraintsView.tsx
@@ -49,60 +49,60 @@ export interface ConstraintRule {
 
 // Extracts the inv identifier (no spaces) from OCL text.
 function oclGetName(ocl: string): string {
-  return ocl.match(/\binv\s+(\w+)\s*:/m)?.[1] ?? '';
+  return /\binv[ \t]+(\w+)[ \t]*:/m.exec(ocl)?.[1] ?? '';
 }
 
 // Extracts @severity value; falls back to WARNING.
 function oclGetSeverity(ocl: string): SeverityLevel {
-  const v = ocl.match(/^\s*@severity\s+(\w+)/m)?.[1]?.toUpperCase();
+  const v = /^[ \t]*@severity[ \t]+(\w+)/m.exec(ocl)?.[1]?.toUpperCase();
   return (['INFO', 'WARNING', 'MINOR', 'MAJOR', 'CRITICAL'].includes(v ?? '') ? v : 'WARNING') as SeverityLevel;
 }
 
 // Extracts the @message string.
 function oclGetMessage(ocl: string): string {
-  return ocl.match(/^\s*@message\s+"([^"]*)"/m)?.[1] ?? '';
+  return /^[ \t]*@message[ \t]+"([^"]*)"/m.exec(ocl)?.[1] ?? '';
 }
 
 // Replaces the inv identifier in-place.
 function oclSetName(ocl: string, name: string): string {
-  const id = name.replace(/\s+/g, '');
+  const id = name.replace(/[ \t]+/g, '');
   if (!id) return ocl;
-  return /\binv\s+\w+\s*:/m.test(ocl)
-    ? ocl.replace(/\binv\s+\w+\s*:/m, `inv ${id}:`)
+  return /\binv[ \t]+\w+[ \t]*:/m.test(ocl)
+    ? ocl.replace(/\binv[ \t]+\w+[ \t]*:/m, `inv ${id}:`)
     : ocl;
 }
 
 // Replaces or inserts @severity.
 function oclSetSeverity(ocl: string, severity: SeverityLevel): string {
-  if (/^\s*@severity\s+\w+/m.test(ocl)) {
-    return ocl.replace(/^(\s*)@severity\s+\w+/m, `$1@severity ${severity}`);
+  if (/^[ \t]*@severity[ \t]+\w+/m.test(ocl)) {
+    return ocl.replace(/^([ \t]*)@severity[ \t]+\w+/m, `$1@severity ${severity}`);
   }
   // insert right after `inv X:` line
-  return ocl.replace(/(\binv\s+\w+\s*:\n?)/m, `$1  @severity ${severity}\n`);
+  return ocl.replace(/(\binv[ \t]+\w+[ \t]*:\n?)/m, `$1  @severity ${severity}\n`);
 }
 
 // Replaces or inserts @message.
 function oclSetMessage(ocl: string, message: string): string {
-  const escaped = message.replace(/"/g, '\\"');
-  if (/^\s*@message\s+"[^"]*"/m.test(ocl)) {
-    return ocl.replace(/^(\s*)@message\s+"[^"]*"/m, `$1@message "${escaped}"`);
+  const escaped = message.replaceAll('"', String.raw`\"`);
+  if (/^[ \t]*@message[ \t]+"[^"]*"/m.test(ocl)) {
+    return ocl.replace(/^([ \t]*)@message[ \t]+"[^"]*"/m, `$1@message "${escaped}"`);
   }
   // insert after @severity or after inv line
-  if (/^\s*@severity\s+\w+/m.test(ocl)) {
-    return ocl.replace(/(^\s*@severity\s+\w+)/m, `$1\n  @message "${escaped}"`);
+  if (/^[ \t]*@severity[ \t]+\w+/m.test(ocl)) {
+    return ocl.replace(/(^[ \t]*@severity[ \t]+\w+)/m, `$1\n  @message "${escaped}"`);
   }
-  return ocl.replace(/(\binv\s+\w+\s*:\n?)/m, `$1  @message "${escaped}"\n`);
+  return ocl.replace(/(\binv[ \t]+\w+[ \t]*:\n?)/m, `$1  @message "${escaped}"\n`);
 }
 
 // Extracts the context type (e.g. "MM::ClassName") from the first context line.
 function oclGetContextType(ocl: string): string {
-  return ocl.match(/^\s*context\s+([\w:]+)/m)?.[1] ?? '';
+  return /^[ \t]*context[ \t]+([\w:]+)/m.exec(ocl)?.[1] ?? '';
 }
 
 // Replaces the context type in the first context line.
 function oclSetContextType(ocl: string, contextType: string): string {
-  if (/^\s*context\s+[\w:]+/m.test(ocl)) {
-    return ocl.replace(/^(\s*context\s+)[\w:]+/m, `$1${contextType}`);
+  if (/^[ \t]*context[ \t]+[\w:]+/m.test(ocl)) {
+    return ocl.replace(/^([ \t]*context[ \t]+)[\w:]+/m, `$1${contextType}`);
   }
   return `context ${contextType} inv NewInvariant:\n` + ocl;
 }
@@ -113,17 +113,17 @@ function parseEcoreClasses(fileName: string, xml: string): { metamodel: string; 
   const mmName = fileName.replace(/\.ecore$/i, '');
   const results: { metamodel: string; className: string }[] = [];
   // Package name from nsPrefix or name attribute on root EPackage
-  const pkgMatch = xml.match(/<(?:\w+:)?EPackage[^>]+\bname\s*=\s*"([^"]+)"/);
+  const pkgMatch = /<(?:\w+:)?EPackage[^>]+\bname[ \t]*=[ \t]*"([^"]+)"/.exec(xml);
   const pkg = pkgMatch?.[1] ?? mmName;
   // All EClass entries (may be nested sub-packages)
-  const classRe = /xsi:type="ecore:EClass"[^>]+\bname\s*=\s*"([^"]+)"/g;
+  const classRe = /xsi:type="ecore:EClass"[^>]+\bname[ \t]*=[ \t]*"([^"]+)"/g;
   let m: RegExpExecArray | null;
   while ((m = classRe.exec(xml)) !== null) {
     results.push({ metamodel: pkg, className: m[1] });
   }
   // Fallback: <eClassifiers ... name="X" (without xsi:type attr visible before name)
   if (results.length === 0) {
-    const alt = /eClassifiers[^>]+\bname\s*=\s*"([^"]+)"/g;
+    const alt = /eClassifiers[^>]+\bname[ \t]*=[ \t]*"([^"]+)"/g;
     while ((m = alt.exec(xml)) !== null) {
       results.push({ metamodel: pkg, className: m[1] });
     }
@@ -133,10 +133,10 @@ function parseEcoreClasses(fileName: string, xml: string): { metamodel: string; 
 
 // Extracts unique metamodel names from all MM::Class patterns in the OCL.
 function oclGetScope(ocl: string): string[] {
-  const matches = [...ocl.matchAll(/\b([A-Za-z][A-Za-z0-9_]*)::([A-Za-z][A-Za-z0-9_]*)/g)];
+  const matches = [...ocl.matchAll(/\b([A-Za-z]\w*)::([A-Za-z]\w*)/g)];
   const seen = new Set<string>();
   matches.forEach(m => seen.add(m[1]));
-  return [...seen].sort();
+  return [...seen].sort((a, b) => a.localeCompare(b));
 }
 
 // ── McCabe's Cyclomatic Complexity ────────────────────────────────────────────
@@ -177,60 +177,47 @@ export interface RuleSet {
 
 // ── Default data ─────────────────────────────────────────────────────────────
 
+function defaultRule(
+  id: string,
+  name: string,
+  severity: ConstraintRule['severity'],
+  description: string,
+  ruleSetId: string,
+  oclDefinition: string,
+  linesOfCode: number,
+): ConstraintRule {
+  return {
+    id, name, severity, description, ruleSetId, oclDefinition,
+    scope: [], type: 'Single-Metamodel',
+    createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
+    invariantCount: 1, contextCount: 1, linesOfCode, linkedReactions: 0,
+  };
+}
+
 const PFAND_RULE_SETS: RuleSet[] = [
   {
     id: 'crate-rules', name: 'Crate Rules', color: '#3b82f6', description: '', collapsed: false,
     rules: [
-      {
-        id: 'p1', name: 'CrateContainsExactly16Bottles', severity: 'CRITICAL',
-        description: 'A crate must always contain exactly 16 bottles.',
-        ruleSetId: 'crate-rules',
-        oclDefinition: 'context pfand::Kasten inv CrateContainsExactly16Bottles:\n  @severity CRITICAL\n  @message "A crate must contain exactly 16 bottles."\n  self.enthält->size() = 16',
-        scope: [], type: 'Single-Metamodel',
-        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
-        invariantCount: 1, contextCount: 1, linesOfCode: 5, linkedReactions: 0,
-      },
-      {
-        id: 'p2', name: 'CrateBottlesAreUnique', severity: 'MAJOR',
-        description: 'All bottles inside a crate must be distinct — no duplicates allowed.',
-        ruleSetId: 'crate-rules',
-        oclDefinition: 'context pfand::Kasten inv CrateBottlesAreUnique:\n  @severity MAJOR\n  @message "All bottles in a crate must be unique."\n  self.enthält->isUnique(f | f)',
-        scope: [], type: 'Single-Metamodel',
-        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
-        invariantCount: 1, contextCount: 1, linesOfCode: 5, linkedReactions: 0,
-      },
+      defaultRule('p1', 'CrateContainsExactly16Bottles', 'CRITICAL',
+        'A crate must always contain exactly 16 bottles.', 'crate-rules',
+        'context pfand::Kasten inv CrateContainsExactly16Bottles:\n  @severity CRITICAL\n  @message "A crate must contain exactly 16 bottles."\n  self.enthält->size() = 16', 5),
+      defaultRule('p2', 'CrateBottlesAreUnique', 'MAJOR',
+        'All bottles inside a crate must be distinct — no duplicates allowed.', 'crate-rules',
+        'context pfand::Kasten inv CrateBottlesAreUnique:\n  @severity MAJOR\n  @message "All bottles in a crate must be unique."\n  self.enthält->isUnique(f | f)', 5),
     ],
   },
   {
     id: 'deposit-item-rules', name: 'Deposit Item Rules', color: '#10b981', description: '', collapsed: false,
     rules: [
-      {
-        id: 'p3', name: 'DepositItemNotEmpty', severity: 'WARNING',
-        description: 'A deposit item must reference at least one element (can, crate, or bottle).',
-        ruleSetId: 'deposit-item-rules',
-        oclDefinition: 'context pfand::Pfandelement inv DepositItemNotEmpty:\n  @severity WARNING\n  @message "A deposit item must contain at least one element (can, crate, or bottle)."\n  self.isPfandelement1 != null or self.isPfandelement2 != null or self.isPfandelement3 != null',
-        scope: [], type: 'Single-Metamodel',
-        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
-        invariantCount: 1, contextCount: 1, linesOfCode: 5, linkedReactions: 0,
-      },
-      {
-        id: 'p4', name: 'DepositItemHasExactlyOneType', severity: 'MAJOR',
-        description: 'A deposit item must reference exactly one type — can, crate, or bottle, never multiple at once.',
-        ruleSetId: 'deposit-item-rules',
-        oclDefinition: 'context pfand::Pfandelement inv DepositItemHasExactlyOneType:\n  @severity MAJOR\n  @message "A deposit item must contain exactly one type (can, crate, or bottle)."\n  let count =\n    (if self.isPfandelement1 != null then 1 else 0 endif)\n    + (if self.isPfandelement2 != null then 1 else 0 endif)\n    + (if self.isPfandelement3 != null then 1 else 0 endif)\n  in count = 1',
-        scope: [], type: 'Single-Metamodel',
-        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
-        invariantCount: 1, contextCount: 1, linesOfCode: 9, linkedReactions: 0,
-      },
-      {
-        id: 'p5', name: 'DepositItemCrateIsFull', severity: 'MAJOR',
-        description: 'When a deposit item contains a crate, that crate must hold exactly 16 bottles.',
-        ruleSetId: 'deposit-item-rules',
-        oclDefinition: 'context pfand::Pfandelement inv DepositItemCrateIsFull:\n  @severity MAJOR\n  @message "A deposit item\'s crate must contain exactly 16 bottles."\n  self.isPfandelement2 != null implies self.isPfandelement2.enthält->size() = 16',
-        scope: [], type: 'Single-Metamodel',
-        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
-        invariantCount: 1, contextCount: 1, linesOfCode: 5, linkedReactions: 0,
-      },
+      defaultRule('p3', 'DepositItemNotEmpty', 'WARNING',
+        'A deposit item must reference at least one element (can, crate, or bottle).', 'deposit-item-rules',
+        'context pfand::Pfandelement inv DepositItemNotEmpty:\n  @severity WARNING\n  @message "A deposit item must contain at least one element (can, crate, or bottle)."\n  self.isPfandelement1 != null or self.isPfandelement2 != null or self.isPfandelement3 != null', 5),
+      defaultRule('p4', 'DepositItemHasExactlyOneType', 'MAJOR',
+        'A deposit item must reference exactly one type — can, crate, or bottle, never multiple at once.', 'deposit-item-rules',
+        'context pfand::Pfandelement inv DepositItemHasExactlyOneType:\n  @severity MAJOR\n  @message "A deposit item must contain exactly one type (can, crate, or bottle)."\n  let count =\n    (if self.isPfandelement1 != null then 1 else 0 endif)\n    + (if self.isPfandelement2 != null then 1 else 0 endif)\n    + (if self.isPfandelement3 != null then 1 else 0 endif)\n  in count = 1', 9),
+      defaultRule('p5', 'DepositItemCrateIsFull', 'MAJOR',
+        'When a deposit item contains a crate, that crate must hold exactly 16 bottles.', 'deposit-item-rules',
+        'context pfand::Pfandelement inv DepositItemCrateIsFull:\n  @severity MAJOR\n  @message "A deposit item\'s crate must contain exactly 16 bottles."\n  self.isPfandelement2 != null implies self.isPfandelement2.enthält->size() = 16', 5),
     ],
   },
 ];
@@ -239,56 +226,26 @@ const KIT_RULE_SETS: RuleSet[] = [
   {
     id: 'professor-rules', name: 'Professor Rules', color: '#3b82f6', description: '', collapsed: false,
     rules: [
-      {
-        id: 'k1', name: 'ProfessorHoldsAtLeastOneLecture', severity: 'MAJOR',
-        description: 'A professor must hold at least one lecture.',
-        ruleSetId: 'professor-rules',
-        oclDefinition: 'context kit::professor inv ProfessorHoldsAtLeastOneLecture:\n  @severity MAJOR\n  @message "A professor must hold at least one lecture."\n  self.holds->size() >= 1',
-        scope: [], type: 'Single-Metamodel',
-        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
-        invariantCount: 1, contextCount: 1, linesOfCode: 4, linkedReactions: 0,
-      },
-      {
-        id: 'k2', name: 'ProfessorCreatesAtLeastOneExam', severity: 'MAJOR',
-        description: 'A professor must create at least one exam.',
-        ruleSetId: 'professor-rules',
-        oclDefinition: 'context kit::professor inv ProfessorCreatesAtLeastOneExam:\n  @severity MAJOR\n  @message "A professor must create at least one exam."\n  self.creates->size() >= 1',
-        scope: [], type: 'Single-Metamodel',
-        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
-        invariantCount: 1, contextCount: 1, linesOfCode: 4, linkedReactions: 0,
-      },
+      defaultRule('k1', 'ProfessorHoldsAtLeastOneLecture', 'MAJOR',
+        'A professor must hold at least one lecture.', 'professor-rules',
+        'context kit::professor inv ProfessorHoldsAtLeastOneLecture:\n  @severity MAJOR\n  @message "A professor must hold at least one lecture."\n  self.holds->size() >= 1', 4),
+      defaultRule('k2', 'ProfessorCreatesAtLeastOneExam', 'MAJOR',
+        'A professor must create at least one exam.', 'professor-rules',
+        'context kit::professor inv ProfessorCreatesAtLeastOneExam:\n  @severity MAJOR\n  @message "A professor must create at least one exam."\n  self.creates->size() >= 1', 4),
     ],
   },
   {
     id: 'student-lecture-rules', name: 'Student & Lecture Rules', color: '#f59e0b', description: '', collapsed: false,
     rules: [
-      {
-        id: 'k3', name: 'StudentAttendsAtLeastOneLecture', severity: 'WARNING',
-        description: 'A student must attend at least one lecture.',
-        ruleSetId: 'student-lecture-rules',
-        oclDefinition: 'context kit::student inv StudentAttendsAtLeastOneLecture:\n  @severity WARNING\n  @message "A student must attend at least one lecture."\n  self.attends->size() >= 1',
-        scope: [], type: 'Single-Metamodel',
-        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
-        invariantCount: 1, contextCount: 1, linesOfCode: 4, linkedReactions: 0,
-      },
-      {
-        id: 'k4', name: 'StudentAttendsAtMostSixLectures', severity: 'WARNING',
-        description: 'A student may not attend more than six lectures.',
-        ruleSetId: 'student-lecture-rules',
-        oclDefinition: 'context kit::student inv StudentAttendsAtMostSixLectures:\n  @severity WARNING\n  @message "A student may not attend more than six lectures."\n  self.attends->size() <= 6',
-        scope: [], type: 'Single-Metamodel',
-        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
-        invariantCount: 1, contextCount: 1, linesOfCode: 4, linkedReactions: 0,
-      },
-      {
-        id: 'k5', name: 'LectureHasExam', severity: 'CRITICAL',
-        description: 'Every lecture must have an associated exam.',
-        ruleSetId: 'student-lecture-rules',
-        oclDefinition: 'context kit::lecture inv LectureHasExam:\n  @severity CRITICAL\n  @message "Every lecture must have an associated exam."\n  self.asAN != null',
-        scope: [], type: 'Single-Metamodel',
-        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
-        invariantCount: 1, contextCount: 1, linesOfCode: 4, linkedReactions: 0,
-      },
+      defaultRule('k3', 'StudentAttendsAtLeastOneLecture', 'WARNING',
+        'A student must attend at least one lecture.', 'student-lecture-rules',
+        'context kit::student inv StudentAttendsAtLeastOneLecture:\n  @severity WARNING\n  @message "A student must attend at least one lecture."\n  self.attends->size() >= 1', 4),
+      defaultRule('k4', 'StudentAttendsAtMostSixLectures', 'WARNING',
+        'A student may not attend more than six lectures.', 'student-lecture-rules',
+        'context kit::student inv StudentAttendsAtMostSixLectures:\n  @severity WARNING\n  @message "A student may not attend more than six lectures."\n  self.attends->size() <= 6', 4),
+      defaultRule('k5', 'LectureHasExam', 'CRITICAL',
+        'Every lecture must have an associated exam.', 'student-lecture-rules',
+        'context kit::lecture inv LectureHasExam:\n  @severity CRITICAL\n  @message "Every lecture must have an associated exam."\n  self.asAN != null', 4),
     ],
   },
 ];
@@ -366,9 +323,9 @@ function scopeBg(name: string, colorMap: Record<string, string>): string {
 /** Lightens a hex color for use as chip text (darken the bg, use it as border/text accent). */
 function darkenHex(hex: string, amt = 60): string {
   try {
-    const r = Math.max(0, parseInt(hex.slice(1, 3), 16) - amt);
-    const g = Math.max(0, parseInt(hex.slice(3, 5), 16) - amt);
-    const b = Math.max(0, parseInt(hex.slice(5, 7), 16) - amt);
+    const r = Math.max(0, Number.parseInt(hex.slice(1, 3), 16) - amt);
+    const g = Math.max(0, Number.parseInt(hex.slice(3, 5), 16) - amt);
+    const b = Math.max(0, Number.parseInt(hex.slice(5, 7), 16) - amt);
     return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
   } catch { return '#334155'; }
 }
@@ -381,9 +338,9 @@ const EDITOR_PANEL_DEFAULT_H = 280;
 const EDITOR_PANEL_STORAGE_KEY = 'constraintEditorPanelHeight';
 
 function useResizablePanel() {
-  const stored = parseInt(localStorage.getItem(EDITOR_PANEL_STORAGE_KEY) ?? '', 10);
+  const stored = Number.parseInt(localStorage.getItem(EDITOR_PANEL_STORAGE_KEY) ?? '', 10);
   const [height, setHeight] = useState<number>(
-    !isNaN(stored) ? Math.min(Math.max(stored, EDITOR_PANEL_MIN_H), EDITOR_PANEL_MAX_H) : EDITOR_PANEL_DEFAULT_H
+    Number.isNaN(stored) ? EDITOR_PANEL_DEFAULT_H : Math.min(Math.max(stored, EDITOR_PANEL_MIN_H), EDITOR_PANEL_MAX_H)
   );
   const dragging = useRef(false);
   const startY = useRef(0);
@@ -407,12 +364,12 @@ function useResizablePanel() {
       const delta = startY.current - ev.clientY;
       const next = Math.min(Math.max(startH.current + delta, EDITOR_PANEL_MIN_H), EDITOR_PANEL_MAX_H);
       localStorage.setItem(EDITOR_PANEL_STORAGE_KEY, String(next));
-      window.removeEventListener('mousemove', onMove);
-      window.removeEventListener('mouseup', onUp);
+      (globalThis as unknown as Window).removeEventListener('mousemove', onMove);
+      (globalThis as unknown as Window).removeEventListener('mouseup', onUp);
     };
 
-    window.addEventListener('mousemove', onMove);
-    window.addEventListener('mouseup', onUp);
+    (globalThis as unknown as Window).addEventListener('mousemove', onMove);
+    (globalThis as unknown as Window).addEventListener('mouseup', onUp);
   }, [height]);
 
   return { height, onHandleMouseDown };
@@ -434,15 +391,20 @@ const RuleRow: React.FC<{ rule: ConstraintRule; selected: boolean; onClick: () =
     return () => document.removeEventListener('mousedown', close);
   }, [menuOpen]);
 
+  const rowBackground = selected ? '#f0fdf9' : hov ? '#f8fafc' : 'transparent';
+
   return (
     <div
+      role="button"
+      tabIndex={0}
       onClick={onClick}
+      onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') onClick(); }}
       onMouseEnter={() => setHov(true)}
       onMouseLeave={() => setHov(false)}
       style={{
         display: 'flex', alignItems: 'center', gap: 8,
         padding: '7px 12px 7px 28px',
-        background: selected ? '#f0fdf9' : hov ? '#f8fafc' : 'transparent',
+        background: rowBackground,
         borderLeft: selected ? '2px solid #049484' : '2px solid transparent',
         cursor: 'pointer', borderRadius: 0,
         transition: 'background 0.1s', position: 'relative',
@@ -508,16 +470,20 @@ interface RuleSetSectionProps {
 const RuleSetSection: React.FC<RuleSetSectionProps> = ({ ruleSet, selectedRuleId, selectedRuleSetId, onRuleClick, onRuleSetClick, onToggleCollapse, onAddRule, onDeleteRule }) => {
   const [hov, setHov] = useState(false);
   const isSelected = selectedRuleSetId === ruleSet.id;
+  const headerBackground = isSelected ? '#f0fdf9' : hov ? '#f8fafc' : 'transparent';
   return (
     <div>
       <div
+        role="button"
+        tabIndex={0}
         onClick={() => onRuleSetClick(ruleSet)}
+        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') onRuleSetClick(ruleSet); }}
         onMouseEnter={() => setHov(true)}
         onMouseLeave={() => setHov(false)}
         style={{
           display: 'flex', alignItems: 'center', gap: 8,
           padding: '8px 12px', cursor: 'pointer',
-          background: isSelected ? '#f0fdf9' : hov ? '#f8fafc' : 'transparent',
+          background: headerBackground,
           borderLeft: isSelected ? `2px solid ${ruleSet.color}` : '2px solid transparent',
           borderBottom: '1px solid #f1f5f9',
           userSelect: 'none',
@@ -540,7 +506,10 @@ const RuleSetSection: React.FC<RuleSetSectionProps> = ({ ruleSet, selectedRuleId
             <RuleRow key={rule.id} rule={rule} selected={selectedRuleId === rule.id} onClick={() => onRuleClick(rule)} onDelete={() => onDeleteRule(rule.id)} />
           ))}
           <div
+            role="button"
+            tabIndex={0}
             onClick={() => onAddRule(ruleSet.id)}
+            onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') onAddRule(ruleSet.id); }}
             style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px 6px 28px', cursor: 'pointer', color: '#94a3b8', fontSize: 12 }}
             onMouseEnter={e => (e.currentTarget.style.color = '#049484')}
             onMouseLeave={e => (e.currentTarget.style.color = '#94a3b8')}
@@ -641,7 +610,11 @@ const ContextClassPicker: React.FC<{
 
   // Group by metamodel
   const groups: Record<string, MetaClass[]> = {};
-  filtered.forEach(o => { (groups[o.metamodel] ??= []).push(o); });
+  filtered.forEach(o => {
+    const key = o.metamodel;
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(o);
+  });
 
   const inputBase: React.CSSProperties = {
     width: '100%', padding: '6px 10px', border: '1.5px solid #e2e8f0', borderRadius: 7,
@@ -652,8 +625,11 @@ const ContextClassPicker: React.FC<{
   return (
     <div ref={containerRef} style={{ position: 'relative' }}>
       <div
+        role="button"
+        tabIndex={0}
         style={{ ...inputBase, display: 'flex', alignItems: 'center', justifyContent: 'space-between', userSelect: 'none' }}
         onClick={() => { setOpen(o => !o); setQuery(''); }}
+        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { setOpen(o => !o); setQuery(''); } }}
       >
         <span style={{ color: value ? '#0f172a' : '#94a3b8' }}>{value || 'Select context class…'}</span>
         <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" strokeWidth="2.5" strokeLinecap="round" style={{ transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s', flexShrink: 0 }}>
@@ -692,7 +668,11 @@ const ContextClassPicker: React.FC<{
                 {classes.map(c => (
                   <div
                     key={c.label}
+                    role="option"
+                    tabIndex={0}
+                    aria-selected={c.label === value}
                     onClick={() => { onChange(c.label); setOpen(false); setQuery(''); }}
+                    onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { onChange(c.label); setOpen(false); setQuery(''); } }}
                     style={{
                       padding: '7px 12px 7px 20px', fontSize: 12.5, cursor: 'pointer',
                       color: c.label === value ? '#049484' : '#0f172a',
@@ -896,20 +876,23 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
 
             {/* Context class */}
             <div>
-              <label style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 4 }}>Context Class</label>
-              <ContextClassPicker
-                value={oclGetContextType(draft.oclDefinition)}
-                options={metaClasses}
-                onChange={handleContextTypeChange}
-              />
+              <label htmlFor="ep-context-class" style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 4 }}>Context Class</label>
+              <div id="ep-context-class">
+                <ContextClassPicker
+                  value={oclGetContextType(draft.oclDefinition)}
+                  options={metaClasses}
+                  onChange={handleContextTypeChange}
+                />
+              </div>
             </div>
 
             {/* Name — no spaces */}
             <div>
-              <label style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 4 }}>
+              <label htmlFor="ep-inv-name" style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 4 }}>
                 Name <span style={{ fontWeight: 400, color: '#94a3b8' }}>(no spaces)</span>
               </label>
               <input
+                id="ep-inv-name"
                 value={draft.name}
                 onChange={e => handleNameChange(e.target.value)}
                 placeholder="InvariantName"
@@ -919,8 +902,8 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
 
             {/* Severity */}
             <div>
-              <label style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 6 }}>Severity</label>
-              <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+              <label htmlFor="ep-severity" style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 6 }}>Severity</label>
+              <div id="ep-severity" style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
                 {SEVERITY_OPTIONS.map(opt => {
                   const active = draft.severity === opt.value;
                   return (
@@ -938,27 +921,27 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
 
             {/* Message */}
             <div>
-              <label style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 4 }}>Message</label>
-              <textarea value={draft.description} onChange={e => handleDescriptionChange(e.target.value)} rows={3} style={{ width: '100%', border: '1px solid #e2e8f0', borderRadius: 6, padding: '6px 8px', fontSize: 12, resize: 'none', outline: 'none', boxSizing: 'border-box', color: '#334155', lineHeight: 1.5 }} />
+              <label htmlFor="ep-message" style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 4 }}>Message</label>
+              <textarea id="ep-message" value={draft.description} onChange={e => handleDescriptionChange(e.target.value)} rows={3} style={{ width: '100%', border: '1px solid #e2e8f0', borderRadius: 6, padding: '6px 8px', fontSize: 12, resize: 'none', outline: 'none', boxSizing: 'border-box', color: '#334155', lineHeight: 1.5 }} />
             </div>
 
             {/* Rule Set */}
             <div>
-              <label style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 4 }}>Rule Set</label>
-              <select value={draft.ruleSetId} onChange={e => setDraft(d => ({ ...d, ruleSetId: e.target.value }))} style={{ width: '100%', border: '1px solid #e2e8f0', borderRadius: 6, padding: '6px 8px', fontSize: 12.5, background: '#fff', color: '#0f172a', outline: 'none', boxSizing: 'border-box' }}>
+              <label htmlFor="ep-rule-set" style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 4 }}>Rule Set</label>
+              <select id="ep-rule-set" value={draft.ruleSetId} onChange={e => setDraft(d => ({ ...d, ruleSetId: e.target.value }))} style={{ width: '100%', border: '1px solid #e2e8f0', borderRadius: 6, padding: '6px 8px', fontSize: 12.5, background: '#fff', color: '#0f172a', outline: 'none', boxSizing: 'border-box' }}>
                 {ruleSets.map(rs => <option key={rs.id} value={rs.id}>{rs.name}</option>)}
               </select>
             </div>
 
             {/* Metamodels */}
             <div>
-              <label style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 2 }}>
+              <label htmlFor="ep-metamodels" style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 2 }}>
                 Metamodels <span style={{ fontWeight: 400, color: '#94a3b8', marginLeft: 4 }}>auto</span>
               </label>
               <p style={{ fontSize: 10.5, color: '#94a3b8', margin: '0 0 6px' }}>
                 Derived from <code style={{ fontSize: 10 }}>MM::Class</code> patterns in the OCL
               </p>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+              <div id="ep-metamodels" style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
                 {draft.scope.length > 0 ? draft.scope.map(s => {
                   const bg = scopeBg(s, colorMap);
                   const text = darkenHex(bg, 70);
@@ -1143,7 +1126,7 @@ const DetailedMetricsModal: React.FC<{ ruleSets: RuleSet[]; colorMap: Record<str
       open
       style={{ position: 'fixed', inset: 0, width: '100%', height: '100%', background: 'none', border: 'none', padding: 0, margin: 0, zIndex: 2000, display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden' }}
     >
-      <div onClick={onClose} style={{ position: 'absolute', inset: 0, background: 'rgba(15,23,42,0.35)' }} />
+      <div role="button" tabIndex={0} onClick={onClose} onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') onClose(); }} style={{ position: 'absolute', inset: 0, background: 'rgba(15,23,42,0.35)' }} />
       <div style={{
         position: 'relative', zIndex: 1,
         background: '#fff', borderRadius: 14, width: '88%', maxWidth: 1040,
@@ -1317,14 +1300,15 @@ const RuleSetPanel: React.FC<{
       <div style={{ flex: 1, overflowY: 'auto', padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 14 }}>
         {/* Name */}
         <div>
-          <label style={labelStyle}>Name</label>
-          <input value={draft.name} onChange={e => setDraft(d => ({ ...d, name: e.target.value }))} style={inputBase} />
+          <label htmlFor="rsp-name" style={labelStyle}>Name</label>
+          <input id="rsp-name" value={draft.name} onChange={e => setDraft(d => ({ ...d, name: e.target.value }))} style={inputBase} />
         </div>
 
         {/* Description */}
         <div>
-          <label style={labelStyle}>Description</label>
+          <label htmlFor="rsp-description" style={labelStyle}>Description</label>
           <textarea
+            id="rsp-description"
             value={draft.description}
             onChange={e => setDraft(d => ({ ...d, description: e.target.value }))}
             rows={2}
@@ -1335,7 +1319,7 @@ const RuleSetPanel: React.FC<{
 
         {/* Color */}
         <div>
-          <label style={labelStyle}>Color</label>
+          <label htmlFor="rsp-color" style={labelStyle}>Color</label>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
             {PRESET_COLORS.map(c => (
               <button
@@ -1352,7 +1336,7 @@ const RuleSetPanel: React.FC<{
                 onMouseLeave={e => (e.currentTarget.style.transform = 'scale(1)')}
               />
             ))}
-            <input type="color" value={draft.color} onChange={e => setDraft(d => ({ ...d, color: e.target.value }))} title="Custom color"
+            <input id="rsp-color" type="color" value={draft.color} onChange={e => setDraft(d => ({ ...d, color: e.target.value }))} title="Custom color"
               style={{ width: 22, height: 22, borderRadius: 5, border: '1.5px solid #e2e8f0', cursor: 'pointer', padding: 1, background: 'none' }} />
           </div>
         </div>
@@ -1592,11 +1576,12 @@ export const ConstraintsView: React.FC<ConstraintsViewProps> = ({ vsumId: _vsumI
   const handleRuleClick = useCallback((rule: ConstraintRule) => {
     setSelectedRuleSet(null);
     setSelectedRule(prev => {
-      const next: ConstraintRule | null = (prev && prev.id !== rule.id) ? rule : (prev?.id === rule.id ? null : rule);
+      const isToggle = prev?.id === rule.id;
+      const next: ConstraintRule | null = isToggle ? null : rule;
       const metamodel = next ? oclGetContextType(next.oclDefinition).split('::')[0] : null;
-      onHighlightNode?.(metamodel ? findNodeIdForMetamodel(canvasNodes, metamodel) : null);
-      if (prev && prev.id !== rule.id) return rule;
-      return prev?.id === rule.id ? null : rule;
+      const nodeId = metamodel ? findNodeIdForMetamodel(canvasNodes, metamodel) : null;
+      onHighlightNode?.(nodeId);
+      return next;
     });
   }, [canvasNodes, onHighlightNode]);
 

--- a/src/components/constraints/ConstraintsView.tsx
+++ b/src/components/constraints/ConstraintsView.tsx
@@ -1,0 +1,1724 @@
+import React, { useState, useCallback, useRef, useMemo, useEffect, MouseEvent as ReactMouseEvent } from 'react';
+import Editor, { OnMount } from '@monaco-editor/react';
+import { Node } from 'reactflow';
+import { cardColor } from '../flow/EcoreFileBox';
+import { APP_FONT } from '../ui/sharedStyles';
+import { apiService } from '../../services/api';
+import { CodeEditorModal } from '../flow/CodeEditorModal';
+import { useOclLsp } from '../../hooks/useOclLsp';
+import {
+  vitruvOCLLanguageId,
+  vitruvOCLMonarch,
+  vitruvOCLLanguageConfig,
+  vitruvOCLTheme,
+} from './VitruvOCLMonarchGrammar';
+
+const handleVitruvOCLMount: OnMount = (_editor, monacoInstance) => {
+  monacoInstance.languages.register({ id: vitruvOCLLanguageId, extensions: ['.ocl'], aliases: ['VitruvOCL'] });
+  monacoInstance.languages.setLanguageConfiguration(vitruvOCLLanguageId, vitruvOCLLanguageConfig);
+  monacoInstance.languages.setMonarchTokensProvider(vitruvOCLLanguageId, vitruvOCLMonarch);
+  monacoInstance.editor.defineTheme('vitruvocl-theme', vitruvOCLTheme);
+  monacoInstance.editor.setTheme('vitruvocl-theme');
+};
+
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type RuleType = 'Cross-Metamodel' | 'Single-Metamodel';
+export type ComplexityLevel = 'Low' | 'Medium' | 'High';
+export type SeverityLevel = 'INFO' | 'WARNING' | 'MINOR' | 'MAJOR' | 'CRITICAL';
+
+export interface ConstraintRule {
+  id: string;
+  name: string;
+  description: string;
+  severity: SeverityLevel;
+  ruleSetId: string;
+  oclDefinition: string;
+  scope: string[];
+  type: RuleType;
+  createdAt: string;
+  modifiedAt: string;
+  invariantCount?: number;
+  contextCount?: number;
+  linesOfCode?: number;
+  linkedReactions?: number;
+}
+
+// ── OCL sync helpers ──────────────────────────────────────────────────────────
+
+// Extracts the inv identifier (no spaces) from OCL text.
+function oclGetName(ocl: string): string {
+  return ocl.match(/\binv\s+(\w+)\s*:/m)?.[1] ?? '';
+}
+
+// Extracts @severity value; falls back to WARNING.
+function oclGetSeverity(ocl: string): SeverityLevel {
+  const v = ocl.match(/^\s*@severity\s+(\w+)/m)?.[1]?.toUpperCase();
+  return (['INFO', 'WARNING', 'MINOR', 'MAJOR', 'CRITICAL'].includes(v ?? '') ? v : 'WARNING') as SeverityLevel;
+}
+
+// Extracts the @message string.
+function oclGetMessage(ocl: string): string {
+  return ocl.match(/^\s*@message\s+"([^"]*)"/m)?.[1] ?? '';
+}
+
+// Replaces the inv identifier in-place.
+function oclSetName(ocl: string, name: string): string {
+  const id = name.replace(/\s+/g, '');
+  if (!id) return ocl;
+  return /\binv\s+\w+\s*:/m.test(ocl)
+    ? ocl.replace(/\binv\s+\w+\s*:/m, `inv ${id}:`)
+    : ocl;
+}
+
+// Replaces or inserts @severity.
+function oclSetSeverity(ocl: string, severity: SeverityLevel): string {
+  if (/^\s*@severity\s+\w+/m.test(ocl)) {
+    return ocl.replace(/^(\s*)@severity\s+\w+/m, `$1@severity ${severity}`);
+  }
+  // insert right after `inv X:` line
+  return ocl.replace(/(\binv\s+\w+\s*:\n?)/m, `$1  @severity ${severity}\n`);
+}
+
+// Replaces or inserts @message.
+function oclSetMessage(ocl: string, message: string): string {
+  const escaped = message.replace(/"/g, '\\"');
+  if (/^\s*@message\s+"[^"]*"/m.test(ocl)) {
+    return ocl.replace(/^(\s*)@message\s+"[^"]*"/m, `$1@message "${escaped}"`);
+  }
+  // insert after @severity or after inv line
+  if (/^\s*@severity\s+\w+/m.test(ocl)) {
+    return ocl.replace(/(^\s*@severity\s+\w+)/m, `$1\n  @message "${escaped}"`);
+  }
+  return ocl.replace(/(\binv\s+\w+\s*:\n?)/m, `$1  @message "${escaped}"\n`);
+}
+
+// Extracts the context type (e.g. "MM::ClassName") from the first context line.
+function oclGetContextType(ocl: string): string {
+  return ocl.match(/^\s*context\s+([\w:]+)/m)?.[1] ?? '';
+}
+
+// Replaces the context type in the first context line.
+function oclSetContextType(ocl: string, contextType: string): string {
+  if (/^\s*context\s+[\w:]+/m.test(ocl)) {
+    return ocl.replace(/^(\s*context\s+)[\w:]+/m, `$1${contextType}`);
+  }
+  return `context ${contextType} inv NewInvariant:\n` + ocl;
+}
+
+// Parses EClass entries from an ecore XML string.
+// Returns [{ metamodel: string, className: string }]
+function parseEcoreClasses(fileName: string, xml: string): { metamodel: string; className: string }[] {
+  const mmName = fileName.replace(/\.ecore$/i, '');
+  const results: { metamodel: string; className: string }[] = [];
+  // Package name from nsPrefix or name attribute on root EPackage
+  const pkgMatch = xml.match(/<(?:\w+:)?EPackage[^>]+\bname\s*=\s*"([^"]+)"/);
+  const pkg = pkgMatch?.[1] ?? mmName;
+  // All EClass entries (may be nested sub-packages)
+  const classRe = /xsi:type="ecore:EClass"[^>]+\bname\s*=\s*"([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = classRe.exec(xml)) !== null) {
+    results.push({ metamodel: pkg, className: m[1] });
+  }
+  // Fallback: <eClassifiers ... name="X" (without xsi:type attr visible before name)
+  if (results.length === 0) {
+    const alt = /eClassifiers[^>]+\bname\s*=\s*"([^"]+)"/g;
+    while ((m = alt.exec(xml)) !== null) {
+      results.push({ metamodel: pkg, className: m[1] });
+    }
+  }
+  return results;
+}
+
+// Extracts unique metamodel names from all MM::Class patterns in the OCL.
+function oclGetScope(ocl: string): string[] {
+  const matches = [...ocl.matchAll(/\b([A-Za-z][A-Za-z0-9_]*)::([A-Za-z][A-Za-z0-9_]*)/g)];
+  const seen = new Set<string>();
+  matches.forEach(m => seen.add(m[1]));
+  return [...seen].sort();
+}
+
+// ── McCabe's Cyclomatic Complexity ────────────────────────────────────────────
+// CC = decision points + 1.  Decision points in OCL: boolean connectives
+// (and, or, implies, xor), if-expressions, and collection iterators that
+// introduce a predicate (forAll, exists, select, reject, any, one).
+// Thresholds: McCabe (1976) — 1–10 simple, 11–20 moderate, 21–50 high, >50 untestable.
+
+function computeCC(ocl: string): number {
+  const body = ocl.split('\n')
+    .filter(l => { const t = l.trim(); return t !== '' && !t.startsWith('context ') && !t.startsWith('inv ') && !t.startsWith('@'); })
+    .join('\n');
+  const s = body.replace(/"[^"]*"/g, '""'); // strip string literals
+  let decisions = 0;
+  decisions += (s.match(/\b(?:and|or|implies|xor)\b/g)?.length ?? 0);
+  decisions += (s.match(/\bif\b/g)?.length ?? 0);
+  decisions += (s.match(/->(?:forAll|exists|select|reject|any|one)\s*\(/g)?.length ?? 0);
+  return decisions + 1;
+}
+
+function ccLabel(val: number): string {
+  if (val <= 10) return 'Low';
+  if (val <= 20) return 'Moderate';
+  if (val <= 50) return 'High';
+  return 'Very High';
+}
+
+
+export interface RuleSet {
+  id: string;
+  backendId?: number;       // backend DB id, present after first save
+  name: string;
+  color: string;
+  description: string;
+  rules: ConstraintRule[];
+  collapsed: boolean;
+}
+
+// ── Default data ─────────────────────────────────────────────────────────────
+
+const PFAND_RULE_SETS: RuleSet[] = [
+  {
+    id: 'crate-rules', name: 'Crate Rules', color: '#3b82f6', description: '', collapsed: false,
+    rules: [
+      {
+        id: 'p1', name: 'CrateContainsExactly16Bottles', severity: 'CRITICAL',
+        description: 'A crate must always contain exactly 16 bottles.',
+        ruleSetId: 'crate-rules',
+        oclDefinition: 'context pfand::Kasten inv CrateContainsExactly16Bottles:\n  @severity CRITICAL\n  @message "A crate must contain exactly 16 bottles."\n  self.enthält->size() = 16',
+        scope: [], type: 'Single-Metamodel',
+        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
+        invariantCount: 1, contextCount: 1, linesOfCode: 5, linkedReactions: 0,
+      },
+      {
+        id: 'p2', name: 'CrateBottlesAreUnique', severity: 'MAJOR',
+        description: 'All bottles inside a crate must be distinct — no duplicates allowed.',
+        ruleSetId: 'crate-rules',
+        oclDefinition: 'context pfand::Kasten inv CrateBottlesAreUnique:\n  @severity MAJOR\n  @message "All bottles in a crate must be unique."\n  self.enthält->isUnique(f | f)',
+        scope: [], type: 'Single-Metamodel',
+        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
+        invariantCount: 1, contextCount: 1, linesOfCode: 5, linkedReactions: 0,
+      },
+    ],
+  },
+  {
+    id: 'deposit-item-rules', name: 'Deposit Item Rules', color: '#10b981', description: '', collapsed: false,
+    rules: [
+      {
+        id: 'p3', name: 'DepositItemNotEmpty', severity: 'WARNING',
+        description: 'A deposit item must reference at least one element (can, crate, or bottle).',
+        ruleSetId: 'deposit-item-rules',
+        oclDefinition: 'context pfand::Pfandelement inv DepositItemNotEmpty:\n  @severity WARNING\n  @message "A deposit item must contain at least one element (can, crate, or bottle)."\n  self.isPfandelement1 != null or self.isPfandelement2 != null or self.isPfandelement3 != null',
+        scope: [], type: 'Single-Metamodel',
+        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
+        invariantCount: 1, contextCount: 1, linesOfCode: 5, linkedReactions: 0,
+      },
+      {
+        id: 'p4', name: 'DepositItemHasExactlyOneType', severity: 'MAJOR',
+        description: 'A deposit item must reference exactly one type — can, crate, or bottle, never multiple at once.',
+        ruleSetId: 'deposit-item-rules',
+        oclDefinition: 'context pfand::Pfandelement inv DepositItemHasExactlyOneType:\n  @severity MAJOR\n  @message "A deposit item must contain exactly one type (can, crate, or bottle)."\n  let count =\n    (if self.isPfandelement1 != null then 1 else 0 endif)\n    + (if self.isPfandelement2 != null then 1 else 0 endif)\n    + (if self.isPfandelement3 != null then 1 else 0 endif)\n  in count = 1',
+        scope: [], type: 'Single-Metamodel',
+        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
+        invariantCount: 1, contextCount: 1, linesOfCode: 9, linkedReactions: 0,
+      },
+      {
+        id: 'p5', name: 'DepositItemCrateIsFull', severity: 'MAJOR',
+        description: 'When a deposit item contains a crate, that crate must hold exactly 16 bottles.',
+        ruleSetId: 'deposit-item-rules',
+        oclDefinition: 'context pfand::Pfandelement inv DepositItemCrateIsFull:\n  @severity MAJOR\n  @message "A deposit item\'s crate must contain exactly 16 bottles."\n  self.isPfandelement2 != null implies self.isPfandelement2.enthält->size() = 16',
+        scope: [], type: 'Single-Metamodel',
+        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
+        invariantCount: 1, contextCount: 1, linesOfCode: 5, linkedReactions: 0,
+      },
+    ],
+  },
+];
+
+const KIT_RULE_SETS: RuleSet[] = [
+  {
+    id: 'professor-rules', name: 'Professor Rules', color: '#3b82f6', description: '', collapsed: false,
+    rules: [
+      {
+        id: 'k1', name: 'ProfessorHoldsAtLeastOneLecture', severity: 'MAJOR',
+        description: 'A professor must hold at least one lecture.',
+        ruleSetId: 'professor-rules',
+        oclDefinition: 'context kit::professor inv ProfessorHoldsAtLeastOneLecture:\n  @severity MAJOR\n  @message "A professor must hold at least one lecture."\n  self.holds->size() >= 1',
+        scope: [], type: 'Single-Metamodel',
+        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
+        invariantCount: 1, contextCount: 1, linesOfCode: 4, linkedReactions: 0,
+      },
+      {
+        id: 'k2', name: 'ProfessorCreatesAtLeastOneExam', severity: 'MAJOR',
+        description: 'A professor must create at least one exam.',
+        ruleSetId: 'professor-rules',
+        oclDefinition: 'context kit::professor inv ProfessorCreatesAtLeastOneExam:\n  @severity MAJOR\n  @message "A professor must create at least one exam."\n  self.creates->size() >= 1',
+        scope: [], type: 'Single-Metamodel',
+        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
+        invariantCount: 1, contextCount: 1, linesOfCode: 4, linkedReactions: 0,
+      },
+    ],
+  },
+  {
+    id: 'student-lecture-rules', name: 'Student & Lecture Rules', color: '#f59e0b', description: '', collapsed: false,
+    rules: [
+      {
+        id: 'k3', name: 'StudentAttendsAtLeastOneLecture', severity: 'WARNING',
+        description: 'A student must attend at least one lecture.',
+        ruleSetId: 'student-lecture-rules',
+        oclDefinition: 'context kit::student inv StudentAttendsAtLeastOneLecture:\n  @severity WARNING\n  @message "A student must attend at least one lecture."\n  self.attends->size() >= 1',
+        scope: [], type: 'Single-Metamodel',
+        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
+        invariantCount: 1, contextCount: 1, linesOfCode: 4, linkedReactions: 0,
+      },
+      {
+        id: 'k4', name: 'StudentAttendsAtMostSixLectures', severity: 'WARNING',
+        description: 'A student may not attend more than six lectures.',
+        ruleSetId: 'student-lecture-rules',
+        oclDefinition: 'context kit::student inv StudentAttendsAtMostSixLectures:\n  @severity WARNING\n  @message "A student may not attend more than six lectures."\n  self.attends->size() <= 6',
+        scope: [], type: 'Single-Metamodel',
+        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
+        invariantCount: 1, contextCount: 1, linesOfCode: 4, linkedReactions: 0,
+      },
+      {
+        id: 'k5', name: 'LectureHasExam', severity: 'CRITICAL',
+        description: 'Every lecture must have an associated exam.',
+        ruleSetId: 'student-lecture-rules',
+        oclDefinition: 'context kit::lecture inv LectureHasExam:\n  @severity CRITICAL\n  @message "Every lecture must have an associated exam."\n  self.asAN != null',
+        scope: [], type: 'Single-Metamodel',
+        createdAt: 'Jun 12, 2026', modifiedAt: 'Jun 12, 2026',
+        invariantCount: 1, contextCount: 1, linesOfCode: 4, linkedReactions: 0,
+      },
+    ],
+  },
+];
+
+/** Splits combined OCL file content into individual ConstraintRule objects. */
+function parseRulesFromOcl(oclContent: string, ruleSetId: string): ConstraintRule[] {
+  const blocks = oclContent.split(/(?=^\s*context\s)/m).map(b => b.trim()).filter(Boolean);
+  return blocks.map((ocl, i) => ({
+    id: `r_${ruleSetId}_${i}_${Date.now()}`,
+    ruleSetId,
+    name: oclGetName(ocl) || `Rule${i + 1}`,
+    severity: oclGetSeverity(ocl),
+    description: oclGetMessage(ocl) || '',
+    oclDefinition: ocl,
+    scope: oclGetScope(ocl),
+    type: oclGetScope(ocl).length >= 2 ? 'Cross-Metamodel' : 'Single-Metamodel',
+    createdAt: '', modifiedAt: '',
+    invariantCount: 1, contextCount: 1,
+    linesOfCode: ocl.split('\n').length,
+    linkedReactions: 0,
+  }));
+}
+
+/** Serializes all rules in a RuleSet to a single .ocl file string. */
+function ruleSetToOcl(ruleSet: RuleSet): string {
+  return ruleSet.rules.map(r => r.oclDefinition).join('\n\n');
+}
+
+/** Returns project-specific default rule sets based on which metamodels are present on the canvas. */
+function getDefaultRuleSets(canvasNodes: Node[]): RuleSet[] {
+  const domains = new Set(canvasNodes.map(n => (n.data?.domain ?? '').toLowerCase()));
+  const files = new Set(canvasNodes.map(n => (n.data?.fileName ?? '').toLowerCase()));
+  if (domains.has('pfand') || files.has('pfandmodel.ecore')) return PFAND_RULE_SETS;
+  if (domains.has('kit') || files.has('kit.ecore')) return KIT_RULE_SETS;
+  return [];
+}
+
+
+// ── Color helpers ─────────────────────────────────────────────────────────────
+
+const removeExt = (name: string) => name.replace(/\.ecore$/i, '');
+
+/** Builds metamodel-name → box-background-color from the live canvas nodes. */
+function buildMetamodelColorMap(canvasNodes: Node[]): Record<string, string> {
+  const map: Record<string, string> = {};
+  canvasNodes.forEach(n => {
+    if (n.type !== 'ecoreFile') return;
+    const name = removeExt(n.data?.fileName ?? '').toLowerCase();
+    if (name) map[name] = cardColor(n.data?.domain);
+  });
+  return map;
+}
+
+/** Builds sorted list of MetaClass entries from ecoreFile canvas nodes. */
+function buildMetaClasses(canvasNodes: Node[]): MetaClass[] {
+  const list: MetaClass[] = [];
+  canvasNodes.forEach(n => {
+    if (n.type !== 'ecoreFile') return;
+    const fileName: string = n.data?.fileName ?? '';
+    const xml: string = n.data?.fileContent ?? '';
+    if (!xml) return;
+    parseEcoreClasses(fileName, xml).forEach(({ metamodel, className }) => {
+      list.push({ metamodel, className, label: `${metamodel}::${className}` });
+    });
+  });
+  list.sort((a, b) => a.metamodel.localeCompare(b.metamodel) || a.className.localeCompare(b.className));
+  return list;
+}
+
+/** Returns the box color for a scope entry, falling back to a hash-based color. */
+function scopeBg(name: string, colorMap: Record<string, string>): string {
+  return colorMap[name.toLowerCase()] ?? cardColor(name);
+}
+
+/** Lightens a hex color for use as chip text (darken the bg, use it as border/text accent). */
+function darkenHex(hex: string, amt = 60): string {
+  try {
+    const r = Math.max(0, parseInt(hex.slice(1, 3), 16) - amt);
+    const g = Math.max(0, parseInt(hex.slice(3, 5), 16) - amt);
+    const b = Math.max(0, parseInt(hex.slice(5, 7), 16) - amt);
+    return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+  } catch { return '#334155'; }
+}
+
+// ── Resizable panel hook ──────────────────────────────────────────────────────
+
+const EDITOR_PANEL_MIN_H = 140;
+const EDITOR_PANEL_MAX_H = 600;
+const EDITOR_PANEL_DEFAULT_H = 280;
+const EDITOR_PANEL_STORAGE_KEY = 'constraintEditorPanelHeight';
+
+function useResizablePanel() {
+  const stored = parseInt(localStorage.getItem(EDITOR_PANEL_STORAGE_KEY) ?? '', 10);
+  const [height, setHeight] = useState<number>(
+    !isNaN(stored) ? Math.min(Math.max(stored, EDITOR_PANEL_MIN_H), EDITOR_PANEL_MAX_H) : EDITOR_PANEL_DEFAULT_H
+  );
+  const dragging = useRef(false);
+  const startY = useRef(0);
+  const startH = useRef(0);
+
+  const onHandleMouseDown = useCallback((e: ReactMouseEvent) => {
+    e.preventDefault();
+    dragging.current = true;
+    startY.current = e.clientY;
+    startH.current = height;
+
+    const onMove = (ev: globalThis.MouseEvent) => {
+      if (!dragging.current) return;
+      const delta = startY.current - ev.clientY; // drag up → positive → bigger panel
+      const next = Math.min(Math.max(startH.current + delta, EDITOR_PANEL_MIN_H), EDITOR_PANEL_MAX_H);
+      setHeight(next);
+    };
+
+    const onUp = (ev: globalThis.MouseEvent) => {
+      dragging.current = false;
+      const delta = startY.current - ev.clientY;
+      const next = Math.min(Math.max(startH.current + delta, EDITOR_PANEL_MIN_H), EDITOR_PANEL_MAX_H);
+      localStorage.setItem(EDITOR_PANEL_STORAGE_KEY, String(next));
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  }, [height]);
+
+  return { height, onHandleMouseDown };
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+const RuleRow: React.FC<{ rule: ConstraintRule; selected: boolean; onClick: () => void; onDelete: () => void }> = ({ rule, selected, onClick, onDelete }) => {
+  const [hov, setHov] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const close = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as globalThis.Node)) setMenuOpen(false);
+    };
+    document.addEventListener('mousedown', close);
+    return () => document.removeEventListener('mousedown', close);
+  }, [menuOpen]);
+
+  return (
+    <div
+      onClick={onClick}
+      onMouseEnter={() => setHov(true)}
+      onMouseLeave={() => setHov(false)}
+      style={{
+        display: 'flex', alignItems: 'center', gap: 8,
+        padding: '7px 12px 7px 28px',
+        background: selected ? '#f0fdf9' : hov ? '#f8fafc' : 'transparent',
+        borderLeft: selected ? '2px solid #049484' : '2px solid transparent',
+        cursor: 'pointer', borderRadius: 0,
+        transition: 'background 0.1s', position: 'relative',
+      }}
+    >
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={selected ? '#049484' : '#94a3b8'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14,2 14,8 20,8"/>
+      </svg>
+      <span style={{ fontSize: 12.5, color: selected ? '#049484' : '#334155', fontWeight: selected ? 600 : 400, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {rule.name}
+      </span>
+      <div ref={menuRef} style={{ position: 'relative' }}>
+        <button
+          onClick={e => { e.stopPropagation(); setMenuOpen(o => !o); }}
+          style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 2, color: '#94a3b8', borderRadius: 4, display: 'flex', alignItems: 'center' }}
+          title="Options"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="12" cy="19" r="1.5"/></svg>
+        </button>
+        {menuOpen && (
+          <div
+            onClick={e => e.stopPropagation()}
+            style={{
+              position: 'absolute', right: 0, top: '100%', zIndex: 50,
+              background: '#ffffff', border: '1px solid #e2e8f0',
+              borderRadius: 8, boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
+              minWidth: 140, padding: '4px 0',
+            }}
+          >
+            <button
+              onClick={() => { setMenuOpen(false); onDelete(); }}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 8,
+                width: '100%', padding: '8px 14px', background: 'none', border: 'none',
+                cursor: 'pointer', fontSize: 13, color: '#dc2626', textAlign: 'left',
+              }}
+              onMouseEnter={e => (e.currentTarget.style.background = '#fef2f2')}
+              onMouseLeave={e => (e.currentTarget.style.background = 'none')}
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="3,6 5,6 21,6"/><path d="M19,6l-1,14a2,2,0,0,1-2,2H8a2,2,0,0,1-2-2L5,6"/><path d="M10,11v6"/><path d="M14,11v6"/><path d="M9,6V4a1,1,0,0,1,1-1h4a1,1,0,0,1,1,1v2"/>
+              </svg>
+              Delete
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+interface RuleSetSectionProps {
+  ruleSet: RuleSet;
+  selectedRuleId: string | null;
+  selectedRuleSetId: string | null;
+  onRuleClick: (rule: ConstraintRule) => void;
+  onRuleSetClick: (ruleSet: RuleSet) => void;
+  onToggleCollapse: (id: string) => void;
+  onAddRule: (ruleSetId: string) => void;
+  onDeleteRule: (ruleId: string) => void;
+}
+
+const RuleSetSection: React.FC<RuleSetSectionProps> = ({ ruleSet, selectedRuleId, selectedRuleSetId, onRuleClick, onRuleSetClick, onToggleCollapse, onAddRule, onDeleteRule }) => {
+  const [hov, setHov] = useState(false);
+  const isSelected = selectedRuleSetId === ruleSet.id;
+  return (
+    <div>
+      <div
+        onClick={() => onRuleSetClick(ruleSet)}
+        onMouseEnter={() => setHov(true)}
+        onMouseLeave={() => setHov(false)}
+        style={{
+          display: 'flex', alignItems: 'center', gap: 8,
+          padding: '8px 12px', cursor: 'pointer',
+          background: isSelected ? '#f0fdf9' : hov ? '#f8fafc' : 'transparent',
+          borderLeft: isSelected ? `2px solid ${ruleSet.color}` : '2px solid transparent',
+          borderBottom: '1px solid #f1f5f9',
+          userSelect: 'none',
+        }}
+      >
+        <div style={{ width: 10, height: 10, borderRadius: 2, background: ruleSet.color, flexShrink: 0 }} />
+        <span style={{ fontSize: 12.5, fontWeight: 600, color: '#1e293b', flex: 1 }}>{ruleSet.name}</span>
+        <span style={{ fontSize: 11, color: '#94a3b8', fontWeight: 500 }}>{ruleSet.rules.length} rules</span>
+        <svg
+          onClick={e => { e.stopPropagation(); onToggleCollapse(ruleSet.id); }}
+          width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" strokeWidth="2.5" strokeLinecap="round"
+          style={{ transform: ruleSet.collapsed ? 'rotate(-90deg)' : 'rotate(0deg)', transition: 'transform 0.15s', flexShrink: 0, cursor: 'pointer', padding: 2 }}
+        >
+          <polyline points="6,9 12,15 18,9"/>
+        </svg>
+      </div>
+      {!ruleSet.collapsed && (
+        <div>
+          {ruleSet.rules.map(rule => (
+            <RuleRow key={rule.id} rule={rule} selected={selectedRuleId === rule.id} onClick={() => onRuleClick(rule)} onDelete={() => onDeleteRule(rule.id)} />
+          ))}
+          <div
+            onClick={() => onAddRule(ruleSet.id)}
+            style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px 6px 28px', cursor: 'pointer', color: '#94a3b8', fontSize: 12 }}
+            onMouseEnter={e => (e.currentTarget.style.color = '#049484')}
+            onMouseLeave={e => (e.currentTarget.style.color = '#94a3b8')}
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            Add rule
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ── MetamodelBar ──────────────────────────────────────────────────────────────
+
+const MetamodelBar: React.FC<{ label: string; count: number; max: number; colorMap: Record<string, string> }> = ({ label, count, max, colorMap }) => {
+  const bg = scopeBg(label, colorMap);
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+      <span style={{ fontSize: 11.5, color: '#64748b', width: 90, flexShrink: 0 }}>{label}</span>
+      <div style={{ flex: 1, height: 6, background: '#f1f5f9', borderRadius: 3, overflow: 'hidden' }}>
+        <div style={{ height: '100%', width: `${(count / max) * 100}%`, background: bg, borderRadius: 3 }} />
+      </div>
+      <span style={{ fontSize: 11, color: '#94a3b8', width: 18, textAlign: 'right' }}>{count}</span>
+    </div>
+  );
+};
+
+// ── InsightCard ───────────────────────────────────────────────────────────────
+
+const InsightCard: React.FC<{ label: string; value: string | number; sub?: React.ReactNode; wide?: boolean }> = ({ label, value, sub, wide }) => (
+  <div style={{
+    background: '#f8fafc', borderRadius: 8, border: '1px solid #f1f5f9',
+    padding: '12px 14px',
+    gridColumn: wide ? 'span 2' : undefined,
+    minWidth: 0,
+  }}>
+    <div style={{ fontSize: 11, color: '#94a3b8', fontWeight: 500, marginBottom: 4 }}>{label}</div>
+    <div style={{ fontSize: typeof value === 'number' ? 26 : 18, fontWeight: 700, color: '#0f172a', lineHeight: 1.1 }}>{value}</div>
+    {sub && <div style={{ fontSize: 11, color: '#94a3b8', marginTop: 2 }}>{sub}</div>}
+  </div>
+);
+
+// ── Bottom editor panel ───────────────────────────────────────────────────────
+
+const SEVERITY_OPTIONS: { value: SeverityLevel; label: string; color: string; bg: string }[] = [
+  { value: 'INFO',     label: 'INFO',     color: '#3b82f6', bg: '#eff6ff' },
+  { value: 'WARNING',  label: 'WARNING',  color: '#ca8a04', bg: '#fefce8' },
+  { value: 'MINOR',    label: 'MINOR',    color: '#d97706', bg: '#fffbeb' },
+  { value: 'MAJOR',    label: 'MAJOR',    color: '#ea580c', bg: '#fff7ed' },
+  { value: 'CRITICAL', label: 'CRITICAL', color: '#dc2626', bg: '#fef2f2' },
+];
+
+const severityStyle = (s: SeverityLevel) =>
+  SEVERITY_OPTIONS.find(o => o.value === s) ?? SEVERITY_OPTIONS[1];
+
+interface EditorPanelProps {
+  rule: ConstraintRule;
+  ruleSets: RuleSet[];
+  colorMap: Record<string, string>;
+  metaClasses: MetaClass[];
+  onClose: () => void;
+  onSave: (rule: ConstraintRule) => void;
+  vsumId?: number;
+  onHighlightNode?: (nodeId: string | null) => void;
+  canvasNodes: Node[];
+}
+
+
+// ── Context Class Picker ──────────────────────────────────────────────────────
+
+interface MetaClass { metamodel: string; className: string; label: string; }
+
+const ContextClassPicker: React.FC<{
+  value: string;
+  options: MetaClass[];
+  onChange: (contextType: string) => void;
+}> = ({ value, options, onChange }) => {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as globalThis.Node)) {
+        setOpen(false);
+        setQuery('');
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  const filtered = query.trim()
+    ? options.filter(o => o.label.toLowerCase().includes(query.toLowerCase()))
+    : options;
+
+  // Group by metamodel
+  const groups: Record<string, MetaClass[]> = {};
+  filtered.forEach(o => { (groups[o.metamodel] ??= []).push(o); });
+
+  const inputBase: React.CSSProperties = {
+    width: '100%', padding: '6px 10px', border: '1.5px solid #e2e8f0', borderRadius: 7,
+    fontSize: 12.5, background: '#f8fafc', color: '#0f172a', boxSizing: 'border-box',
+    outline: 'none', fontFamily: APP_FONT, cursor: 'pointer',
+  };
+
+  return (
+    <div ref={containerRef} style={{ position: 'relative' }}>
+      <div
+        style={{ ...inputBase, display: 'flex', alignItems: 'center', justifyContent: 'space-between', userSelect: 'none' }}
+        onClick={() => { setOpen(o => !o); setQuery(''); }}
+      >
+        <span style={{ color: value ? '#0f172a' : '#94a3b8' }}>{value || 'Select context class…'}</span>
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" strokeWidth="2.5" strokeLinecap="round" style={{ transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s', flexShrink: 0 }}>
+          <polyline points="6,9 12,15 18,9" />
+        </svg>
+      </div>
+
+      {open && (
+        <div style={{
+          position: 'absolute', top: '100%', left: 0, right: 0, zIndex: 999,
+          background: '#fff', border: '1.5px solid #e2e8f0', borderRadius: 8,
+          boxShadow: '0 8px 24px rgba(0,0,0,0.12)', marginTop: 4, overflow: 'hidden',
+        }}>
+          {/* Search input */}
+          <div style={{ padding: '8px 10px', borderBottom: '1px solid #f1f5f9' }}>
+            <input
+              autoFocus
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              placeholder="Filter classes…"
+              style={{ ...inputBase, cursor: 'text', background: '#fff', border: '1px solid #e2e8f0' }}
+              onKeyDown={e => e.stopPropagation()}
+            />
+          </div>
+
+          {/* Options */}
+          <div style={{ maxHeight: 220, overflowY: 'auto' }}>
+            {Object.keys(groups).length === 0 && (
+              <div style={{ padding: '10px 12px', fontSize: 12, color: '#94a3b8', fontFamily: APP_FONT }}>No classes found</div>
+            )}
+            {Object.entries(groups).map(([mm, classes]) => (
+              <div key={mm}>
+                <div style={{ padding: '5px 12px 3px', fontSize: 10.5, fontWeight: 700, color: '#64748b', textTransform: 'uppercase', letterSpacing: '0.06em', background: '#f8fafc', borderBottom: '1px solid #f1f5f9' }}>
+                  {mm}
+                </div>
+                {classes.map(c => (
+                  <div
+                    key={c.label}
+                    onClick={() => { onChange(c.label); setOpen(false); setQuery(''); }}
+                    style={{
+                      padding: '7px 12px 7px 20px', fontSize: 12.5, cursor: 'pointer',
+                      color: c.label === value ? '#049484' : '#0f172a',
+                      fontWeight: c.label === value ? 600 : 400,
+                      background: c.label === value ? '#f0fdf9' : 'transparent',
+                      fontFamily: 'monospace',
+                    }}
+                    onMouseEnter={e => { if (c.label !== value) e.currentTarget.style.background = '#f8fafc'; }}
+                    onMouseLeave={e => { if (c.label !== value) e.currentTarget.style.background = 'transparent'; }}
+                  >
+                    {c.className}
+                    <span style={{ marginLeft: 6, fontSize: 11, color: '#94a3b8', fontFamily: APP_FONT }}>{c.metamodel}::</span>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ── Shared save-feedback components ──────────────────────────────────────────
+
+const SpinnerIcon: React.FC = () => (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" style={{ animation: 'spin 0.75s linear infinite' }}>
+    <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+    <path d="M12 2a10 10 0 0 1 10 10" />
+  </svg>
+);
+
+const SaveChangesButton: React.FC<{ onSave: () => void }> = ({ onSave }) => {
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const handleClick = () => {
+    setSaving(true);
+    setSaved(false);
+    setTimeout(() => {
+      onSave();
+      setSaving(false);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    }, 650);
+  };
+  return (
+    <button
+      onClick={handleClick}
+      disabled={saving}
+      style={{
+        width: '100%', marginTop: 12, padding: '8px 0',
+        background: saving ? '#7fc4bc' : saved ? '#15803d' : '#049484',
+        color: '#fff', border: 'none', borderRadius: 6, fontSize: 12, fontWeight: 600,
+        cursor: saving ? 'default' : 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7,
+        transition: 'background 0.2s',
+      }}
+    >
+      {saving && <SpinnerIcon />}
+      {saving ? 'Saving…' : saved ? 'Saved ✓' : 'Save Changes'}
+    </button>
+  );
+};
+
+// ── Inline Editor Panel ───────────────────────────────────────────────────────
+
+const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, metaClasses, onClose, onSave, vsumId, onHighlightNode, canvasNodes }) => {
+  const { height, onHandleMouseDown } = useResizablePanel();
+  const [draft, setDraft] = useState<ConstraintRule>({ ...rule });
+  const [fullEditorOpen, setFullEditorOpen] = useState(false);
+  const updatingFromRef = useRef<'form' | 'code' | null>(null);
+  const draftRef = useRef(draft);
+  draftRef.current = draft;
+
+  const { onMount: lspOnMount, notifyChange } = useOclLsp({
+    vsumId,
+    documentId: rule.id,
+    languageId: vitruvOCLLanguageId,
+    getCode: () => draftRef.current.oclDefinition,
+  });
+
+  // Reset draft whenever the selected rule changes (intentionally only on id, not every field).
+  useEffect(() => {
+    setDraft({ ...rule }); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [rule.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── form field → OCL ────────────────────────────────────────────────────────
+
+  const handleNameChange = (raw: string) => {
+    const name = raw.replace(/\s/g, '');
+    updatingFromRef.current = 'form';
+    const newOcl = oclSetName(draftRef.current.oclDefinition, name);
+    setDraft(d => ({ ...d, name, oclDefinition: newOcl }));
+    notifyChange(newOcl);
+    updatingFromRef.current = null;
+  };
+
+  const handleSeverityChange = (severity: SeverityLevel) => {
+    updatingFromRef.current = 'form';
+    const newOcl = oclSetSeverity(draftRef.current.oclDefinition, severity);
+    setDraft(d => ({ ...d, severity, oclDefinition: newOcl }));
+    notifyChange(newOcl);
+    updatingFromRef.current = null;
+  };
+
+  const handleDescriptionChange = (description: string) => {
+    updatingFromRef.current = 'form';
+    const newOcl = oclSetMessage(draftRef.current.oclDefinition, description);
+    setDraft(d => ({ ...d, description, oclDefinition: newOcl }));
+    notifyChange(newOcl);
+    updatingFromRef.current = null;
+  };
+
+  const handleContextTypeChange = (contextType: string) => {
+    updatingFromRef.current = 'form';
+    const newOcl = oclSetContextType(draftRef.current.oclDefinition, contextType);
+    const newScope = oclGetScope(newOcl);
+    const newType: RuleType = newScope.length >= 2 ? 'Cross-Metamodel' : 'Single-Metamodel';
+    setDraft(d => ({ ...d, oclDefinition: newOcl, scope: newScope, type: newType }));
+    notifyChange(newOcl);
+    updatingFromRef.current = null;
+    const metamodel = contextType.split('::')[0];
+    onHighlightNode?.(findNodeIdForMetamodel(canvasNodes, metamodel));
+  };
+
+  // ── OCL → form fields ───────────────────────────────────────────────────────
+
+  const handleOclChange = (v: string | undefined) => {
+    const ocl = v ?? '';
+    notifyChange(ocl);
+    if (updatingFromRef.current === 'form') return;
+    updatingFromRef.current = 'code';
+    const derivedScope = oclGetScope(ocl);
+    const derivedType: RuleType = derivedScope.length >= 2 ? 'Cross-Metamodel' : 'Single-Metamodel';
+    setDraft(d => ({
+      ...d,
+      oclDefinition: ocl,
+      name:        oclGetName(ocl)    || d.name,
+      severity:    oclGetSeverity(ocl),
+      description: oclGetMessage(ocl) || d.description,
+      scope:       derivedScope.length > 0 ? derivedScope : d.scope,
+      type:        derivedType,
+    }));
+    updatingFromRef.current = null;
+  };
+
+  const sev = severityStyle(draft.severity);
+
+  return (
+    <>
+      <CodeEditorModal
+        isOpen={fullEditorOpen}
+        onClose={() => setFullEditorOpen(false)}
+        onSave={ocl => { handleOclChange(ocl); }}
+        initialCode={draft.oclDefinition}
+        edgeId={draft.id}
+        vsumId={vsumId != null ? String(vsumId) : undefined}
+        lspEndpoint="/ocl-lsp"
+        languageId={vitruvOCLLanguageId}
+        fileExtension=".ocl"
+        monarchGrammar={vitruvOCLMonarch}
+        languageConfig={vitruvOCLLanguageConfig}
+        theme={vitruvOCLTheme}
+        title={draft.name}
+      />
+
+      <div style={{
+        background: '#ffffff', borderTop: '1px solid #e2e8f0',
+        boxShadow: '0 -4px 24px rgba(0,0,0,0.10)',
+        zIndex: 50, display: 'flex', flexDirection: 'column',
+        height, overflow: 'hidden', position: 'relative',
+      }}>
+        {/* Resize handle */}
+        <div
+          onMouseDown={onHandleMouseDown}
+          style={{
+            position: 'absolute', top: 0, left: 0, right: 0, height: 6,
+            cursor: 'ns-resize', zIndex: 10,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}
+        >
+          <div style={{ width: 36, height: 3, borderRadius: 2, background: '#cbd5e1', transition: 'background 0.15s' }}
+            onMouseEnter={e => (e.currentTarget.style.background = '#049484')}
+            onMouseLeave={e => (e.currentTarget.style.background = '#cbd5e1')}
+          />
+        </div>
+        {/* Header — top-padding accounts for the 6px resize handle */}
+        <div style={{ display: 'flex', alignItems: 'center', padding: '10px 16px 10px 16px', paddingTop: 12, borderBottom: '1px solid #f1f5f9', flexShrink: 0 }}>
+          <span style={{ fontSize: 13, fontWeight: 600, color: '#0f172a', flex: 1 }}>
+            Editing: {draft.name}
+          </span>
+          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', padding: 4, borderRadius: 4, display: 'flex', alignItems: 'center' }}>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+          {/* Left: meta */}
+          <div style={{ width: 280, flexShrink: 0, padding: '12px 16px', overflowY: 'auto', borderRight: '1px solid #f1f5f9', display: 'flex', flexDirection: 'column', gap: 10 }}>
+
+            {/* Context class */}
+            <div>
+              <label style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 4 }}>Context Class</label>
+              <ContextClassPicker
+                value={oclGetContextType(draft.oclDefinition)}
+                options={metaClasses}
+                onChange={handleContextTypeChange}
+              />
+            </div>
+
+            {/* Name — no spaces */}
+            <div>
+              <label style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 4 }}>
+                Name <span style={{ fontWeight: 400, color: '#94a3b8' }}>(no spaces)</span>
+              </label>
+              <input
+                value={draft.name}
+                onChange={e => handleNameChange(e.target.value)}
+                placeholder="InvariantName"
+                style={{ width: '100%', border: '1px solid #e2e8f0', borderRadius: 6, padding: '6px 8px', fontSize: 12.5, outline: 'none', boxSizing: 'border-box', color: '#0f172a', fontFamily: 'monospace' }}
+              />
+            </div>
+
+            {/* Severity */}
+            <div>
+              <label style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 6 }}>Severity</label>
+              <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                {SEVERITY_OPTIONS.map(opt => {
+                  const active = draft.severity === opt.value;
+                  return (
+                    <button key={opt.value} onClick={() => handleSeverityChange(opt.value)} style={{ padding: '3px 10px', borderRadius: 12, fontSize: 11, fontWeight: 600, cursor: 'pointer', border: `1.5px solid ${active ? opt.color : '#e2e8f0'}`, background: active ? opt.bg : '#fff', color: active ? opt.color : '#94a3b8', transition: 'all 0.12s' }}>
+                      {opt.label}
+                    </button>
+                  );
+                })}
+              </div>
+              <div style={{ marginTop: 6, display: 'inline-flex', alignItems: 'center', gap: 5, padding: '2px 8px', borderRadius: 10, background: sev.bg, border: `1px solid ${sev.color}20` }}>
+                <div style={{ width: 6, height: 6, borderRadius: '50%', background: sev.color }} />
+                <span style={{ fontSize: 11, fontWeight: 600, color: sev.color }}>{draft.severity}</span>
+              </div>
+            </div>
+
+            {/* Message */}
+            <div>
+              <label style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 4 }}>Message</label>
+              <textarea value={draft.description} onChange={e => handleDescriptionChange(e.target.value)} rows={3} style={{ width: '100%', border: '1px solid #e2e8f0', borderRadius: 6, padding: '6px 8px', fontSize: 12, resize: 'none', outline: 'none', boxSizing: 'border-box', color: '#334155', lineHeight: 1.5 }} />
+            </div>
+
+            {/* Rule Set */}
+            <div>
+              <label style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 4 }}>Rule Set</label>
+              <select value={draft.ruleSetId} onChange={e => setDraft(d => ({ ...d, ruleSetId: e.target.value }))} style={{ width: '100%', border: '1px solid #e2e8f0', borderRadius: 6, padding: '6px 8px', fontSize: 12.5, background: '#fff', color: '#0f172a', outline: 'none', boxSizing: 'border-box' }}>
+                {ruleSets.map(rs => <option key={rs.id} value={rs.id}>{rs.name}</option>)}
+              </select>
+            </div>
+
+            {/* Metamodels */}
+            <div>
+              <label style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 2 }}>
+                Metamodels <span style={{ fontWeight: 400, color: '#94a3b8', marginLeft: 4 }}>auto</span>
+              </label>
+              <p style={{ fontSize: 10.5, color: '#94a3b8', margin: '0 0 6px' }}>
+                Derived from <code style={{ fontSize: 10 }}>MM::Class</code> patterns in the OCL
+              </p>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                {draft.scope.length > 0 ? draft.scope.map(s => {
+                  const bg = scopeBg(s, colorMap);
+                  const text = darkenHex(bg, 70);
+                  return <span key={s} style={{ fontSize: 11, padding: '2px 8px', borderRadius: 12, background: bg, color: text, fontWeight: 600 }}>{s}</span>;
+                }) : <span style={{ fontSize: 11, color: '#cbd5e1', fontStyle: 'italic' }}>No MM::Class patterns found</span>}
+              </div>
+            </div>
+
+          </div>
+
+          {/* Center: OCL editor */}
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', padding: '6px 12px', background: '#f8fafc', borderBottom: '1px solid #f1f5f9', gap: 6, flexShrink: 0 }}>
+              <span style={{ fontSize: 11, fontWeight: 600, color: '#64748b', flex: 1 }}>OCL Definition</span>
+              <span style={{ fontSize: 10, padding: '2px 6px', borderRadius: 4, background: '#f1f5f9', color: '#64748b' }}>OCL</span>
+            </div>
+            <div style={{ flex: 1 }}>
+              <Editor
+                value={draft.oclDefinition}
+                onChange={handleOclChange}
+                onMount={(ed, m) => { handleVitruvOCLMount(ed, m); lspOnMount(ed, m); }}
+                language={vitruvOCLLanguageId}
+                theme="vitruvocl-theme"
+                options={{ minimap: { enabled: false }, fontSize: 13, lineNumbers: 'on', scrollBeyondLastLine: false, wordWrap: 'on', automaticLayout: true, padding: { top: 8, bottom: 8 }, folding: false, lineDecorationsWidth: 0, renderLineHighlight: 'line', overviewRulerLanes: 0 }}
+              />
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', padding: '6px 12px', background: '#f8fafc', borderTop: '1px solid #f1f5f9', flexShrink: 0, gap: 8 }}>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="#22c55e" stroke="none"><circle cx="12" cy="12" r="10"/><polyline points="9,12 11,14 15,10" fill="none" stroke="#fff" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+              <span style={{ fontSize: 11, color: '#64748b', flex: 1 }}>No syntax errors</span>
+              <span style={{ fontSize: 10.5, color: '#94a3b8' }}>Spaces: 2</span>
+              <span style={{ fontSize: 10.5, color: '#94a3b8' }}>OCL</span>
+            </div>
+          </div>
+
+          {/* Right: overview */}
+          <div style={{ width: 220, flexShrink: 0, padding: '12px 16px', overflowY: 'auto', borderLeft: '1px solid #f1f5f9' }}>
+            <div style={{ fontSize: 12, fontWeight: 700, color: '#0f172a', marginBottom: 12 }}>Rule Overview</div>
+            {([
+              ['Type', draft.type],
+              ['Severity', draft.severity],
+              ['Metamodels', draft.scope.join(', ')],
+              ['Context Count', String(draft.contextCount ?? 0)],
+              ['Invariant Count', String(draft.invariantCount ?? 0)],
+              ['Lines of Code', String(draft.linesOfCode ?? 0)],
+              ['Created', draft.createdAt],
+              ['Last Modified', draft.modifiedAt],
+            ] as [string, string][]).map(([k, v]) => (
+              <div key={k} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 8, gap: 6 }}>
+                <span style={{ fontSize: 11, color: '#94a3b8', flexShrink: 0 }}>{k}</span>
+                {k === 'Severity'
+                  ? <span style={{ fontSize: 11, fontWeight: 600, color: sev.color }}>{v}</span>
+                  : <span style={{ fontSize: 11, color: '#334155', textAlign: 'right', fontWeight: k === 'Type' ? 500 : 400 }}>{v || '—'}</span>
+                }
+              </div>
+            ))}
+            <div style={{ marginTop: 8, display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 0', borderTop: '1px solid #f1f5f9' }}>
+              <span style={{ fontSize: 11, color: '#94a3b8' }}>Linked Reactions</span>
+              <span style={{ fontSize: 11, color: '#334155', fontWeight: 500 }}>{draft.linkedReactions ?? 0}</span>
+            </div>
+            <SaveChangesButton onSave={() => onSave(draft)} />
+            <button onClick={() => setFullEditorOpen(true)} style={{ width: '100%', marginTop: 6, padding: '7px 0', background: 'transparent', color: '#049484', border: '1px solid #049484', borderRadius: 6, fontSize: 12, fontWeight: 500, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15,3 21,3 21,9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              Open in Full Editor
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+// ── Right panel: metrics ──────────────────────────────────────────────────────
+
+interface MetricsPanelProps {
+  ruleSets: RuleSet[];
+  colorMap: Record<string, string>;
+}
+
+const MetricsPanel: React.FC<MetricsPanelProps> = ({ ruleSets, colorMap }) => {
+  const [detailOpen, setDetailOpen] = useState(false);
+  const allRules = ruleSets.flatMap(rs => rs.rules);
+  const total = allRules.length;
+  const crossMeta = allRules.filter(r => r.type === 'Cross-Metamodel').length;
+  const singleMeta = allRules.filter(r => r.type === 'Single-Metamodel').length;
+
+  // metamodel involvement
+  const metaCount: Record<string, number> = {};
+  allRules.forEach(r => r.scope.forEach(s => { metaCount[s] = (metaCount[s] ?? 0) + 1; }));
+  const sortedMeta = Object.entries(metaCount).sort((a, b) => b[1] - a[1]);
+  const maxMeta = sortedMeta[0]?.[1] ?? 1;
+
+
+  const totalLines = allRules.reduce((s, r) => s + (r.linesOfCode ?? 0), 0);
+  const avgLines = total > 0 ? (totalLines / total).toFixed(1) : '0';
+  const maxLines = Math.max(0, ...allRules.map(r => r.linesOfCode ?? 0));
+
+  // McCabe's Cyclomatic Complexity average
+  const ccValues = allRules.map(r => computeCC(r.oclDefinition));
+  const avgCC = total > 0 ? ccValues.reduce((a, b) => a + b, 0) / total : 0;
+  const avgCCStr = avgCC > 0 ? avgCC.toFixed(1) : '—';
+  const avgCCLabelStr = ccLabel(avgCC);
+
+  return (
+    <div style={{
+      width: 300, flexShrink: 0, height: '100%',
+      background: '#ffffff', borderLeft: '1px solid #e2e8f0',
+      borderTopLeftRadius: 10, borderTopRightRadius: 10,
+      overflowY: 'auto', display: 'flex', flexDirection: 'column',
+    }}>
+      {/* Insight cards */}
+      <div style={{ padding: '16px 16px 0' }}>
+        <div style={{ fontSize: 13, fontWeight: 700, color: '#0f172a', marginBottom: 2 }}>Constraint Insights</div>
+        <div style={{ fontSize: 11, color: '#94a3b8', marginBottom: 14 }}>Static metrics about your consistency definitions</div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginBottom: 16 }}>
+          <InsightCard label="Total Rules" value={total} sub={`Across ${ruleSets.length} Sets`} />
+          <InsightCard label="Cross-Metamodel Rules" value={crossMeta} sub={`${total > 0 ? Math.round((crossMeta / total) * 100) : 0}%`} />
+          <InsightCard label="Single-Metamodel Rules" value={singleMeta} sub={`${total > 0 ? Math.round((singleMeta / total) * 100) : 0}%`} />
+          <InsightCard
+            label="Avg. Complexity"
+            value={avgCCLabelStr}
+            sub={
+              <span>
+                Ø {avgCCStr}{' '}
+                <span
+                  title="McCabe's Cyclomatic Complexity — McCabe (1976), IEEE Trans. Softw. Eng."
+                  style={{ cursor: 'help', color: '#94a3b8', fontSize: 10, fontWeight: 400 }}
+                >
+                  CC ⓘ
+                </span>
+              </span>
+            }
+          />
+        </div>
+      </div>
+
+      {/* Metamodel involvement */}
+      <div style={{ padding: '0 16px 16px', borderBottom: '1px solid #f1f5f9' }}>
+        <div style={{ fontSize: 12, fontWeight: 700, color: '#0f172a', marginBottom: 2 }}>Metamodel Involvement</div>
+        <div style={{ fontSize: 11, color: '#94a3b8', marginBottom: 12 }}>How many rules reference each metamodel</div>
+        {sortedMeta.map(([name, count], i) => (
+          <MetamodelBar key={name} label={name} count={count} max={maxMeta} colorMap={colorMap} />
+        ))}
+      </div>
+
+      {/* Rule characteristics */}
+      <div style={{ padding: '14px 16px' }}>
+        <div style={{ fontSize: 12, fontWeight: 700, color: '#0f172a', marginBottom: 12 }}>Rule Characteristics</div>
+        {([
+          ['Total OCL Lines', String(totalLines)],
+          ['Avg. Lines per Rule', avgLines],
+          ['Max Lines in a Rule', String(maxLines)],
+        ] as [string, string][]).map(([k, v]) => (
+          <div key={k} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+            <span style={{ fontSize: 11.5, color: '#64748b' }}>{k}</span>
+            <span style={{ fontSize: 12, color: '#0f172a', fontWeight: 500 }}>{v}</span>
+          </div>
+        ))}
+
+        <button
+          onClick={() => setDetailOpen(true)}
+          style={{ width: '100%', marginTop: 14, padding: '9px 0', background: 'transparent', color: '#049484', border: '1px solid #049484', borderRadius: 6, fontSize: 12, fontWeight: 500, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/>
+          </svg>
+          View Detailed Metrics
+        </button>
+        {detailOpen && <DetailedMetricsModal ruleSets={ruleSets} colorMap={colorMap} onClose={() => setDetailOpen(false)} />}
+      </div>
+    </div>
+  );
+};
+
+// ── Detailed Metrics Modal ────────────────────────────────────────────────────
+
+const DetailedMetricsModal: React.FC<{ ruleSets: RuleSet[]; colorMap: Record<string, string>; onClose: () => void }> = ({ ruleSets, colorMap, onClose }) => {
+  const sev = SEVERITY_OPTIONS.reduce<Record<string, { color: string; bg: string }>>((m, o) => { m[o.value] = { color: o.color, bg: o.bg }; return m; }, {});
+
+  return (
+    <dialog
+      open
+      style={{ position: 'fixed', inset: 0, width: '100%', height: '100%', background: 'none', border: 'none', padding: 0, margin: 0, zIndex: 2000, display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden' }}
+    >
+      <div onClick={onClose} style={{ position: 'absolute', inset: 0, background: 'rgba(15,23,42,0.35)' }} />
+      <div style={{
+        position: 'relative', zIndex: 1,
+        background: '#fff', borderRadius: 14, width: '88%', maxWidth: 1040,
+        display: 'flex', flexDirection: 'column',
+        boxShadow: '0 24px 64px rgba(0,0,0,0.20)',
+        border: '1px solid #e2e8f0', fontFamily: APP_FONT,
+      }}>
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '16px 22px', borderBottom: '1px solid #f1f5f9', flexShrink: 0 }}>
+          <span style={{ fontSize: 15, fontWeight: 700, color: '#0f172a' }}>Detailed Metrics</span>
+          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', fontSize: 20, lineHeight: 1 }}>×</button>
+        </div>
+
+        {/* Body — fixed height so scroll kicks in after ~2-3 rulesets */}
+        <div style={{ height: 680, overflowY: 'scroll', padding: '22px 26px', display: 'flex', flexDirection: 'column', gap: 20 }}>
+          {ruleSets.length === 0 && (
+            <div style={{ color: '#94a3b8', fontSize: 13, textAlign: 'center', marginTop: 40 }}>No rule sets yet.</div>
+          )}
+          {ruleSets.map(rs => {
+            const rules = rs.rules;
+            const total = rules.length;
+            const ccVals = rules.map(r => computeCC(r.oclDefinition));
+            const avgCC = total > 0 ? ccVals.reduce((a, b) => a + b, 0) / total : 0;
+            const maxCC = total > 0 ? Math.max(...ccVals) : 0;
+            const totalLines = rules.reduce((s, r) => s + (r.linesOfCode ?? 0), 0);
+            const cross = rules.filter(r => r.type === 'Cross-Metamodel').length;
+            const sevCounts = rules.reduce<Record<string, number>>((m, r) => { m[r.severity] = (m[r.severity] ?? 0) + 1; return m; }, {});
+
+            return (
+              <div key={rs.id} style={{ border: '1px solid #e2e8f0', borderRadius: 10, overflow: 'hidden', flexShrink: 0, minHeight: 200 }}>
+                {/* Card header */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 18px', background: '#f8fafc', borderBottom: '1px solid #f1f5f9' }}>
+                  <div style={{ width: 11, height: 11, borderRadius: 3, background: rs.color, flexShrink: 0 }} />
+                  <span style={{ fontSize: 13, fontWeight: 700, color: '#0f172a', flex: 1 }}>{rs.name}</span>
+                  <span style={{ fontSize: 12, color: '#94a3b8' }}>{total} rule{total !== 1 ? 's' : ''}</span>
+                </div>
+
+                {/* Card body */}
+                <div style={{ padding: '16px 18px', display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 14 }}>
+                  {/* Avg CC */}
+                  <div style={{ background: '#f8fafc', borderRadius: 8, padding: '14px 16px', border: '1px solid #f1f5f9' }}>
+                    <div style={{ fontSize: 10.5, color: '#94a3b8', fontWeight: 600, marginBottom: 6, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Avg. Complexity</div>
+                    <div style={{ fontSize: 24, fontWeight: 700, color: '#0f172a' }}>{total > 0 ? avgCC.toFixed(1) : '—'}</div>
+                    <div style={{ fontSize: 11, color: '#94a3b8', marginTop: 4 }}>{total > 0 ? ccLabel(avgCC) : ''}</div>
+                  </div>
+                  {/* Max CC */}
+                  <div style={{ background: '#f8fafc', borderRadius: 8, padding: '14px 16px', border: '1px solid #f1f5f9' }}>
+                    <div style={{ fontSize: 10.5, color: '#94a3b8', fontWeight: 600, marginBottom: 6, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Max Complexity</div>
+                    <div style={{ fontSize: 24, fontWeight: 700, color: '#0f172a' }}>{total > 0 ? maxCC : '—'}</div>
+                    <div style={{ fontSize: 11, color: '#94a3b8', marginTop: 4 }}>{total > 0 ? ccLabel(maxCC) : ''}</div>
+                  </div>
+                  {/* OCL Lines */}
+                  <div style={{ background: '#f8fafc', borderRadius: 8, padding: '14px 16px', border: '1px solid #f1f5f9' }}>
+                    <div style={{ fontSize: 10.5, color: '#94a3b8', fontWeight: 600, marginBottom: 6, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Total OCL Lines</div>
+                    <div style={{ fontSize: 24, fontWeight: 700, color: '#0f172a' }}>{totalLines}</div>
+                    <div style={{ fontSize: 11, color: '#94a3b8', marginTop: 4 }}>{total > 0 ? `Ø ${(totalLines / total).toFixed(1)} per rule` : ''}</div>
+                  </div>
+                  {/* Cross-metamodel */}
+                  <div style={{ background: '#f8fafc', borderRadius: 8, padding: '14px 16px', border: '1px solid #f1f5f9' }}>
+                    <div style={{ fontSize: 10.5, color: '#94a3b8', fontWeight: 600, marginBottom: 6, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Cross-Metamodel</div>
+                    <div style={{ fontSize: 24, fontWeight: 700, color: '#0f172a' }}>{cross}</div>
+                    <div style={{ fontSize: 11, color: '#94a3b8', marginTop: 4 }}>{total > 0 ? `${Math.round((cross / total) * 100)}% of rules` : ''}</div>
+                  </div>
+                </div>
+
+                {/* Severity breakdown */}
+                {total > 0 && (
+                  <div style={{ padding: '0 16px 14px', display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                    {(['INFO','WARNING','MINOR','MAJOR','CRITICAL'] as SeverityLevel[]).map(s => {
+                      const count = sevCounts[s] ?? 0;
+                      if (count === 0) return null;
+                      const { color, bg } = sev[s];
+                      return (
+                        <span key={s} style={{ fontSize: 11, fontWeight: 600, padding: '2px 9px', borderRadius: 10, background: bg, color, border: `1px solid ${color}` }}>
+                          {count}× {s}
+                        </span>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {/* Per-rule list */}
+                {total > 0 && (
+                  <div style={{ borderTop: '1px solid #f1f5f9' }}>
+                    {rules.map((r, i) => {
+                      const cc = computeCC(r.oclDefinition);
+                      const { color, bg } = sev[r.severity];
+                      return (
+                        <div key={r.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 16px', borderBottom: i < rules.length - 1 ? '1px solid #f8fafc' : 'none', background: i % 2 === 0 ? '#fff' : '#fafafa' }}>
+                          <span style={{ fontSize: 12.5, color: '#334155', flex: 1, fontFamily: 'monospace' }}>{r.name}</span>
+                          <span style={{ fontSize: 11, fontWeight: 600, padding: '1px 7px', borderRadius: 8, background: bg, color, border: `1px solid ${color}`, flexShrink: 0 }}>{r.severity}</span>
+                          <span style={{ fontSize: 11, color: '#94a3b8', flexShrink: 0, width: 60, textAlign: 'right' }}>CC {cc} · {ccLabel(cc)}</span>
+                          <span style={{ fontSize: 11, color: '#94a3b8', flexShrink: 0, width: 50, textAlign: 'right' }}>{r.linesOfCode} lines</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </dialog>
+  );
+};
+
+// ── Rule Set Panel ────────────────────────────────────────────────────────────
+
+const PRESET_COLORS = ['#3b82f6','#10b981','#f59e0b','#8b5cf6','#ef4444','#06b6d4','#ec4899','#6366f1','#84cc16','#f97316'];
+
+const RuleSetPanel: React.FC<{
+  ruleSet: RuleSet;
+  onClose: () => void;
+  onSave: (updated: RuleSet) => void;
+  onDelete?: () => void;
+}> = ({ ruleSet, onClose, onSave, onDelete }) => {
+  const [draft, setDraft] = useState({ name: ruleSet.name, color: ruleSet.color, description: ruleSet.description });
+
+  useEffect(() => {
+    setDraft({ name: ruleSet.name, color: ruleSet.color, description: ruleSet.description }); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [ruleSet.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const [saving, setSaving] = useState(false);
+  const handleSave = () => {
+    setSaving(true);
+    setTimeout(() => {
+      onSave({ ...ruleSet, ...draft });
+      onClose();
+    }, 650);
+  };
+
+  const inputBase: React.CSSProperties = {
+    width: '100%', padding: '6px 10px', border: '1.5px solid #e2e8f0', borderRadius: 7,
+    fontSize: 12.5, background: '#f8fafc', color: '#0f172a', boxSizing: 'border-box',
+    outline: 'none', fontFamily: APP_FONT,
+  };
+
+  const labelStyle: React.CSSProperties = {
+    display: 'block', fontSize: 11, fontWeight: 600, color: '#64748b',
+    marginBottom: 5, textTransform: 'uppercase', letterSpacing: '0.06em',
+  };
+
+  return (
+    <div style={{
+      background: '#ffffff', borderTop: '1px solid #e2e8f0',
+      boxShadow: '0 -4px 24px rgba(0,0,0,0.10)',
+      display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0,
+    }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', padding: '10px 16px', borderBottom: '1px solid #f1f5f9', flexShrink: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1 }}>
+          <div style={{ width: 10, height: 10, borderRadius: 2, background: draft.color, flexShrink: 0 }} />
+          <span style={{ fontSize: 13, fontWeight: 600, color: '#0f172a' }}>Rule Set: {draft.name}</span>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+          {onDelete && (
+            <button
+              onClick={() => { onDelete(); onClose(); }}
+              style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#ef4444', fontSize: 11.5, fontWeight: 600, padding: '3px 8px', borderRadius: 5, fontFamily: APP_FONT }}
+              onMouseEnter={e => (e.currentTarget.style.background = '#fef2f2')}
+              onMouseLeave={e => (e.currentTarget.style.background = 'none')}
+              title="Delete Rule Set"
+            >Delete</button>
+          )}
+          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', fontSize: 18, lineHeight: 1 }}>×</button>
+        </div>
+      </div>
+
+      {/* Scrollable fields */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+        {/* Name */}
+        <div>
+          <label style={labelStyle}>Name</label>
+          <input value={draft.name} onChange={e => setDraft(d => ({ ...d, name: e.target.value }))} style={inputBase} />
+        </div>
+
+        {/* Description */}
+        <div>
+          <label style={labelStyle}>Description</label>
+          <textarea
+            value={draft.description}
+            onChange={e => setDraft(d => ({ ...d, description: e.target.value }))}
+            rows={2}
+            style={{ ...inputBase, resize: 'none', lineHeight: 1.5 }}
+            placeholder="Optional description…"
+          />
+        </div>
+
+        {/* Color */}
+        <div>
+          <label style={labelStyle}>Color</label>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
+            {PRESET_COLORS.map(c => (
+              <button
+                key={c}
+                onClick={() => setDraft(d => ({ ...d, color: c }))}
+                style={{
+                  width: 22, height: 22, borderRadius: 5, background: c, border: 'none', cursor: 'pointer',
+                  outline: draft.color === c ? `2.5px solid ${c}` : 'none',
+                  outlineOffset: 2,
+                  boxShadow: draft.color === c ? '0 0 0 1.5px #fff inset' : 'none',
+                  transition: 'transform 0.1s',
+                }}
+                onMouseEnter={e => (e.currentTarget.style.transform = 'scale(1.15)')}
+                onMouseLeave={e => (e.currentTarget.style.transform = 'scale(1)')}
+              />
+            ))}
+            <input type="color" value={draft.color} onChange={e => setDraft(d => ({ ...d, color: e.target.value }))} title="Custom color"
+              style={{ width: 22, height: 22, borderRadius: 5, border: '1.5px solid #e2e8f0', cursor: 'pointer', padding: 1, background: 'none' }} />
+          </div>
+        </div>
+      </div>
+
+      {/* Footer with Save */}
+      <div style={{ padding: '10px 16px', borderTop: '1px solid #f1f5f9', flexShrink: 0, display: 'flex', justifyContent: 'flex-end' }}>
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          style={{
+            padding: '7px 20px', background: saving ? '#7fc4bc' : '#049484', color: '#fff',
+            border: 'none', borderRadius: 7, fontSize: 13, fontWeight: 600,
+            cursor: saving ? 'default' : 'pointer', fontFamily: APP_FONT,
+            display: 'flex', alignItems: 'center', gap: 7, transition: 'background 0.2s',
+          }}
+          onMouseEnter={e => { if (!saving) e.currentTarget.style.background = '#037368'; }}
+          onMouseLeave={e => { if (!saving) e.currentTarget.style.background = '#049484'; }}
+        >
+          {saving && <SpinnerIcon />}
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+// ── Left panel ────────────────────────────────────────────────────────────────
+
+interface LeftPanelProps {
+  ruleSets: RuleSet[];
+  selectedRuleId: string | null;
+  selectedRuleSetId: string | null;
+  onRuleClick: (rule: ConstraintRule) => void;
+  onRuleSetClick: (ruleSet: RuleSet) => void;
+  onToggleCollapse: (id: string) => void;
+  onAddRule: (ruleSetId: string) => void;
+  onDeleteRule: (ruleId: string) => void;
+  onAddSet: () => void;
+  searchQuery: string;
+  onSearch: (q: string) => void;
+  filterMetamodel?: string | null;
+}
+
+const LeftPanel: React.FC<LeftPanelProps> = ({
+  ruleSets, selectedRuleId, selectedRuleSetId, onRuleClick, onRuleSetClick, onToggleCollapse, onAddRule, onDeleteRule, onAddSet, searchQuery, onSearch, filterMetamodel
+}) => {
+  const filtered = (() => {
+    let result = ruleSets;
+    if (searchQuery) {
+      result = result
+        .map(rs => ({ ...rs, collapsed: false, rules: rs.rules.filter(r => r.name.toLowerCase().includes(searchQuery.toLowerCase())) }))
+        .filter(rs => rs.rules.length > 0);
+    }
+    if (filterMetamodel) {
+      result = result
+        .map(rs => ({
+          ...rs,
+          collapsed: false,
+          rules: rs.rules.filter(r => {
+            const ctx = oclGetContextType(r.oclDefinition).split('::')[0].toLowerCase();
+            return ctx === filterMetamodel.toLowerCase();
+          }),
+        }))
+        .filter(rs => rs.rules.length > 0);
+    }
+    return result;
+  })();
+
+  return (
+    <div style={{
+      width: 260, flexShrink: 0, height: '100%',
+      background: '#ffffff', borderRight: '1px solid #e2e8f0',
+      borderTopLeftRadius: 10, borderTopRightRadius: 10,
+      display: 'flex', flexDirection: 'column', overflow: 'hidden',
+    }}>
+      {/* Header */}
+      <div style={{ padding: '14px 14px 10px', borderBottom: '1px solid #f1f5f9', flexShrink: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+          <span style={{ fontSize: 13, fontWeight: 700, color: '#0f172a' }}>Constraint Sets</span>
+          <button
+            onClick={onAddSet}
+            style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 11.5, color: '#049484', background: 'none', border: 'none', cursor: 'pointer', fontWeight: 500, padding: '3px 6px', borderRadius: 5 }}
+            onMouseEnter={e => (e.currentTarget.style.background = '#f0fdf9')}
+            onMouseLeave={e => (e.currentTarget.style.background = 'none')}
+          >
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            New Set
+          </button>
+        </div>
+        <div style={{ position: 'relative' }}>
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" strokeWidth="2.5" strokeLinecap="round" style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)' }}>
+            <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+          </svg>
+          <input
+            value={searchQuery}
+            onChange={e => onSearch(e.target.value)}
+            placeholder="Search projects… (Ctrl+K)"
+            style={{ width: '100%', border: '1px solid #e2e8f0', borderRadius: 6, padding: '6px 8px 6px 28px', fontSize: 12, outline: 'none', boxSizing: 'border-box', color: '#334155' }}
+          />
+        </div>
+      </div>
+
+      {/* Active metamodel filter badge */}
+      {filterMetamodel && (
+        <div style={{ padding: '6px 12px', background: '#f0fdf9', borderBottom: '1px solid #d1fae5', display: 'flex', alignItems: 'center', gap: 6 }}>
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#049484" strokeWidth="2.5" strokeLinecap="round">
+            <polygon points="22,3 2,3 10,12.46 10,19 14,21 14,12.46"/>
+          </svg>
+          <span style={{ fontSize: 11, fontWeight: 600, color: '#049484', flex: 1 }}>Filter: {filterMetamodel}</span>
+          <span style={{ fontSize: 10, color: '#64748b' }}>Click node to clear</span>
+        </div>
+      )}
+
+      {/* Rule sets */}
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {filtered.map(rs => (
+          <RuleSetSection
+            key={rs.id}
+            ruleSet={rs}
+            selectedRuleId={selectedRuleId}
+            selectedRuleSetId={selectedRuleSetId}
+            onRuleClick={onRuleClick}
+            onRuleSetClick={onRuleSetClick}
+            onToggleCollapse={onToggleCollapse}
+            onAddRule={onAddRule}
+            onDeleteRule={onDeleteRule}
+          />
+        ))}
+      </div>
+
+    </div>
+  );
+};
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export interface ConstraintsViewProps {
+  vsumId?: string;
+  canvasNodes: Node[];
+  onHighlightNode?: (nodeId: string | null) => void;
+  filterNodeId?: string | null;
+}
+
+/** Finds the canvas node ID whose Ecore metamodel matches the given context prefix (e.g. "pfand"). */
+function findNodeIdForMetamodel(canvasNodes: Node[], metamodel: string): string | null {
+  if (!metamodel) return null;
+  for (const n of canvasNodes) {
+    if (n.type !== 'ecoreFile') continue;
+    const classes = parseEcoreClasses(n.data?.fileName ?? '', n.data?.fileContent ?? '');
+    if (classes.some(c => c.metamodel.toLowerCase() === metamodel.toLowerCase())) return n.id;
+  }
+  return null;
+}
+
+export const ConstraintsView: React.FC<ConstraintsViewProps> = ({ vsumId: _vsumId, canvasNodes, onHighlightNode, filterNodeId }) => {
+  const vsumId = _vsumId ? Number(_vsumId) : null;
+  const colorMap = useMemo(() => buildMetamodelColorMap(canvasNodes), [canvasNodes]);
+  const metaClasses = useMemo(() => buildMetaClasses(canvasNodes), [canvasNodes]);
+
+  // Derive the metamodel name for the active filter node, if any.
+  const filterMetamodel = useMemo((): string | null => {
+    if (!filterNodeId) return null;
+    const node = canvasNodes.find(n => n.id === filterNodeId);
+    if (!node) return null;
+    const classes = parseEcoreClasses(node.data?.fileName ?? '', node.data?.fileContent ?? '');
+    return classes[0]?.metamodel ?? null;
+  }, [filterNodeId, canvasNodes]);
+
+  const [ruleSets, setRuleSets] = useState<RuleSet[]>([]);
+  const defaultsAppliedRef = useRef(false);
+
+  // Load rule sets from backend on mount; fall back to canvas-derived defaults.
+  useEffect(() => {
+    if (defaultsAppliedRef.current) return;
+
+    if (vsumId != null) {
+      apiService.getRuleSets(vsumId).then(responses => {
+        if (responses.length === 0) return; // will fall through to defaults below
+        defaultsAppliedRef.current = true;
+        setRuleSets(responses.map(r => ({
+          id: `rs_${r.id}`,
+          backendId: r.id,
+          name: r.name,
+          color: r.color,
+          description: r.description ?? '',
+          collapsed: false,
+          rules: parseRulesFromOcl(r.oclContent, `rs_${r.id}`),
+        })));
+      }).catch(err => {
+        console.warn('Failed to load rule sets from backend, falling back to defaults:', err);
+      });
+      return;
+    }
+
+    // No vsumId — use canvas-derived defaults once nodes are available
+    if (canvasNodes.length === 0) return;
+    const defaults = getDefaultRuleSets(canvasNodes);
+    if (defaults.length === 0) return;
+    defaultsAppliedRef.current = true;
+    setRuleSets(defaults.map(rs => ({
+      ...rs,
+      rules: rs.rules.map(r => ({ ...r, scope: oclGetScope(r.oclDefinition) })),
+    })));
+  }, [vsumId, canvasNodes]);
+
+  /** Sync a single ruleset to the backend (fire-and-forget). */
+  const syncRuleSet = useCallback((rs: RuleSet) => {
+    if (vsumId == null) return;
+    const body = { name: rs.name, color: rs.color, description: rs.description, oclContent: ruleSetToOcl(rs) };
+    if (rs.backendId != null) {
+      apiService.updateRuleSet(vsumId, rs.backendId, body).catch(err =>
+        console.error('Failed to sync RuleSet:', err));
+    } else {
+      apiService.createRuleSet(vsumId, body).then(created => {
+        setRuleSets(prev => prev.map(r => r.id === rs.id ? { ...r, backendId: created.id } : r));
+      }).catch(err => console.error('Failed to create RuleSet:', err));
+    }
+  }, [vsumId]);
+
+  const [selectedRule, setSelectedRule] = useState<ConstraintRule | null>(null);
+  const [selectedRuleSet, setSelectedRuleSet] = useState<RuleSet | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const handleRuleSetClick = useCallback((rs: RuleSet) => {
+    setSelectedRuleSet(prev => prev?.id === rs.id ? null : rs);
+    setSelectedRule(null);
+    onHighlightNode?.(null);
+  }, [onHighlightNode]);
+
+  const handleSaveRuleSet = useCallback((updated: RuleSet) => {
+    setRuleSets(prev => prev.map(rs => rs.id === updated.id ? updated : rs));
+    setSelectedRuleSet(updated);
+    syncRuleSet(updated);
+  }, [syncRuleSet]);
+
+  const handleRuleClick = useCallback((rule: ConstraintRule) => {
+    setSelectedRuleSet(null);
+    setSelectedRule(prev => {
+      const next: ConstraintRule | null = (prev && prev.id !== rule.id) ? rule : (prev?.id === rule.id ? null : rule);
+      const metamodel = next ? oclGetContextType(next.oclDefinition).split('::')[0] : null;
+      onHighlightNode?.(metamodel ? findNodeIdForMetamodel(canvasNodes, metamodel) : null);
+      if (prev && prev.id !== rule.id) return rule;
+      return prev?.id === rule.id ? null : rule;
+    });
+  }, [canvasNodes, onHighlightNode]);
+
+  const handleToggleCollapse = useCallback((id: string) => {
+    setRuleSets(prev => prev.map(rs => rs.id === id ? { ...rs, collapsed: !rs.collapsed } : rs));
+  }, []);
+
+  const handleDeleteRule = useCallback((ruleId: string) => {
+    setRuleSets(prev => {
+      const next = prev.map(rs => ({ ...rs, rules: rs.rules.filter(r => r.id !== ruleId) }));
+      // sync the affected ruleset
+      const affected = next.find(rs => prev.find(p => p.id === rs.id)?.rules.some(r => r.id === ruleId));
+      if (affected) syncRuleSet(affected);
+      return next;
+    });
+    setSelectedRule(prev => prev?.id === ruleId ? null : prev);
+  }, [syncRuleSet]);
+
+  const handleAddRule = useCallback((ruleSetId: string) => {
+    const newRule: ConstraintRule = {
+      id: `r_${Date.now()}`, name: 'NewInvariant', severity: 'WARNING', description: '',
+      ruleSetId, oclDefinition: 'context ClassName inv NewInvariant:\n  @severity WARNING\n  @message ""\n  true',
+      scope: [], type: 'Single-Metamodel',
+      createdAt: new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }),
+      modifiedAt: 'Just now',
+      invariantCount: 1, contextCount: 1, linesOfCode: 5, linkedReactions: 0,
+    };
+    setRuleSets(prev => {
+      const next = prev.map(rs => rs.id === ruleSetId ? { ...rs, rules: [...rs.rules, newRule] } : rs);
+      const affected = next.find(rs => rs.id === ruleSetId);
+      if (affected) syncRuleSet(affected);
+      return next;
+    });
+    setSelectedRule(newRule);
+  }, [syncRuleSet]);
+
+  const handleAddSet = useCallback(() => {
+    const newSet: RuleSet = {
+      id: `rs_${Date.now()}`, name: 'New Rule Set',
+      color: '#6366f1', description: '', rules: [], collapsed: false,
+    };
+    setRuleSets(prev => [...prev, newSet]);
+    syncRuleSet(newSet);
+  }, [syncRuleSet]);
+
+  const handleDeleteRuleSet = useCallback((ruleSetId: string) => {
+    setRuleSets(prev => {
+      const rs = prev.find(r => r.id === ruleSetId);
+      if (rs?.backendId != null && vsumId != null) {
+        apiService.deleteRuleSet(vsumId, rs.backendId).catch(err => console.error('Failed to delete RuleSet:', err));
+      }
+      return prev.filter(r => r.id !== ruleSetId);
+    });
+    setSelectedRuleSet(prev => prev?.id === ruleSetId ? null : prev);
+  }, [vsumId]);
+
+  const handleSaveRule = useCallback((updated: ConstraintRule) => {
+    setRuleSets(prev => {
+      const next = prev.map(rs => ({ ...rs, rules: rs.rules.map(r => r.id === updated.id ? updated : r) }));
+      const affected = next.find(rs => rs.rules.some(r => r.id === updated.id));
+      if (affected) syncRuleSet(affected);
+      return next;
+    });
+    setSelectedRule(updated);
+  }, [syncRuleSet]);
+
+  return (
+    // pointer-events: none on container — individual panels re-enable it so the
+    // transparent center gap passes clicks through to the FlowCanvas beneath.
+    <div style={{ display: 'flex', width: '100%', height: '100%', position: 'relative', pointerEvents: 'none' }}>
+      {/* Left panel — re-enables pointer events */}
+      <div style={{ pointerEvents: 'auto' }}>
+        <LeftPanel
+          ruleSets={ruleSets}
+          selectedRuleId={selectedRule?.id ?? null}
+          selectedRuleSetId={selectedRuleSet?.id ?? null}
+          onRuleClick={handleRuleClick}
+          onRuleSetClick={handleRuleSetClick}
+          onToggleCollapse={handleToggleCollapse}
+          onAddRule={handleAddRule}
+          onDeleteRule={handleDeleteRule}
+          onAddSet={handleAddSet}
+          searchQuery={searchQuery}
+          onSearch={setSearchQuery}
+          filterMetamodel={filterMetamodel}
+        />
+      </div>
+
+      {/* Center: transparent — FlowCanvas shows through */}
+      <div style={{ flex: 1 }} />
+
+      {/* Right panel — re-enables pointer events */}
+      <div style={{ pointerEvents: 'auto', display: 'flex', alignSelf: 'stretch' }}>
+        <MetricsPanel ruleSets={ruleSets} colorMap={colorMap} />
+      </div>
+
+      {/* Bottom editor — floats over the center canvas, re-enables pointer events */}
+      {selectedRule && (
+        <div style={{ position: 'absolute', bottom: 0, left: 260, right: 300, pointerEvents: 'auto', display: 'flex', flexDirection: 'column' }} onKeyDown={e => e.stopPropagation()}>
+          <EditorPanel
+            rule={selectedRule}
+            ruleSets={ruleSets}
+            colorMap={colorMap}
+            metaClasses={metaClasses}
+            onClose={() => { setSelectedRule(null); onHighlightNode?.(null); }}
+            onSave={handleSaveRule}
+            vsumId={vsumId ?? undefined}
+            onHighlightNode={onHighlightNode}
+            canvasNodes={canvasNodes}
+          />
+        </div>
+      )}
+      {selectedRuleSet && !selectedRule && (
+        <div style={{ position: 'absolute', bottom: 0, left: 260, right: 300, pointerEvents: 'auto', maxHeight: '42%', display: 'flex', flexDirection: 'column' }}>
+          <RuleSetPanel
+            ruleSet={selectedRuleSet}
+            onClose={() => setSelectedRuleSet(null)}
+            onSave={handleSaveRuleSet}
+            onDelete={() => handleDeleteRuleSet(selectedRuleSet.id)}
+          />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/constraints/VitruvOCLMonarchGrammar.ts
+++ b/src/components/constraints/VitruvOCLMonarchGrammar.ts
@@ -2,6 +2,10 @@ import * as monaco from 'monaco-editor';
 
 export const vitruvOCLLanguageId = 'vitruvocl';
 
+function popState(pattern: RegExp, token: string): monaco.languages.IMonarchLanguageRule[] {
+  return [[/\s+/, ''], [pattern, token, '@pop'], [/./, { token: '', next: '@pop' }]];
+}
+
 export const vitruvOCLMonarch: monaco.languages.IMonarchLanguage = {
   keywords: ['if', 'then', 'else', 'endif', 'let', 'in', 'and', 'or', 'not', 'implies', 'xor'],
   typeKeywords: [
@@ -58,8 +62,10 @@ export const vitruvOCLMonarch: monaco.languages.IMonarchLanguage = {
       [/\b(Integer|Real|String|Boolean|UnlimitedNatural|OclAny|OclVoid)\b/, 'type.primitive'],
       [/\b(Set|Sequence|Bag|OrderedSet|Collection|Optional|Singleton)\b/, 'type.collection'],
 
-      // OCL operations
-      [/\b(isEmpty|notEmpty|includes|excludes|includesAll|excludesAll|sum|count|min|max|first|last|at|union|intersection|append|prepend|insertAt|subSequence|flatten|asSet|asOrderedSet|asSequence|asBag|reverse|size|concat|substring|indexOf|toUpperCase|toLowerCase|toInteger|toReal|trim|matches|tokenize|allInstances|oclIsKindOf|oclIsTypeOf|oclAsType|oclIsNew|oclIsUndefined|oclIsInvalid|abs|floor|ceiling|round|sqrt|log|exp|mod|div)\b/, 'support.function.ocl'],
+      // OCL operations (split to keep regex complexity below threshold)
+      [/\b(isEmpty|notEmpty|includes|excludes|includesAll|excludesAll|sum|count|min|max|first|last|at|union|intersection|size)\b/, 'support.function.ocl'],
+      [/\b(append|prepend|insertAt|subSequence|flatten|asSet|asOrderedSet|asSequence|asBag|reverse|concat|substring|indexOf|toUpperCase|toLowerCase|toInteger|toReal|trim|matches|tokenize)\b/, 'support.function.ocl'],
+      [/\b(allInstances|oclIsKindOf|oclIsTypeOf|oclAsType|oclIsNew|oclIsUndefined|oclIsInvalid|abs|floor|ceiling|round|sqrt|log|exp|mod|div)\b/, 'support.function.ocl'],
 
       // Strings
       [/"([^"\\]|\\.)*$/, 'string.invalid'],
@@ -90,27 +96,12 @@ export const vitruvOCLMonarch: monaco.languages.IMonarchLanguage = {
 
     contextType: [
       [/\s+/, ''],
-      [/[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)?/, 'type.class', '@pop'],
+      [/[A-Za-z_]\w*(?:::[A-Za-z_]\w*)?/, 'type.class', '@pop'],
       [/./, { token: '', next: '@pop' }],
     ],
-
-    invName: [
-      [/\s+/, ''],
-      [/[A-Za-z_][A-Za-z0-9_]*/, 'entity.name.label', '@pop'],
-      [/./, { token: '', next: '@pop' }],
-    ],
-
-    letVar: [
-      [/\s+/, ''],
-      [/[A-Za-z_][A-Za-z0-9_]*/, 'variable.let', '@pop'],
-      [/./, { token: '', next: '@pop' }],
-    ],
-
-    severityValue: [
-      [/\s+/, ''],
-      [/[A-Z]+/, 'annotation.value', '@pop'],
-      [/./, { token: '', next: '@pop' }],
-    ],
+    invName:       popState(/[A-Za-z_]\w*/, 'entity.name.label'),
+    letVar:        popState(/[A-Za-z_]\w*/, 'variable.let'),
+    severityValue: popState(/[A-Z]+/, 'annotation.value'),
 
     dstring: [
       [/[^\\"]+/, 'string'],
@@ -125,9 +116,9 @@ export const vitruvOCLMonarch: monaco.languages.IMonarchLanguage = {
     ],
 
     blockComment: [
-      [/[^/*]+/, 'comment.block'],
+      [/[^*/]+/, 'comment.block'],
       [/\*\//, { token: 'comment.block', next: '@pop' }],
-      [/[/*]/, 'comment.block'],
+      [/[*/]/, 'comment.block'],
     ],
   },
 };

--- a/src/components/constraints/VitruvOCLMonarchGrammar.ts
+++ b/src/components/constraints/VitruvOCLMonarchGrammar.ts
@@ -32,12 +32,12 @@ export const vitruvOCLMonarch: monaco.languages.IMonarchLanguage = {
   tokenizer: {
     root: [
       // Comments
-      [/--.*$/, 'comment'],
+      [/--[^\r\n]*/, 'comment'],
       [/\/\*/, { token: 'comment.block', next: '@blockComment' }],
 
       // Annotations
-      [/[@]severity/, { token: 'annotation', next: '@severityValue' }],
-      [/[@]message\b/, 'annotation'],
+      [/@severity/, { token: 'annotation', next: '@severityValue' }],
+      [/@message\b/, 'annotation'],
 
       // Structural keywords
       [/\b(package|endpackage)\b/, 'keyword.package'],

--- a/src/components/constraints/VitruvOCLMonarchGrammar.ts
+++ b/src/components/constraints/VitruvOCLMonarchGrammar.ts
@@ -1,0 +1,205 @@
+import * as monaco from 'monaco-editor';
+
+export const vitruvOCLLanguageId = 'vitruvocl';
+
+export const vitruvOCLMonarch: monaco.languages.IMonarchLanguage = {
+  keywords: ['if', 'then', 'else', 'endif', 'let', 'in', 'and', 'or', 'not', 'implies', 'xor'],
+  typeKeywords: [
+    'Integer', 'Real', 'String', 'Boolean', 'UnlimitedNatural',
+    'OclAny', 'OclVoid', 'Set', 'Sequence', 'Bag', 'OrderedSet', 'Collection',
+    'Optional', 'Singleton',
+  ],
+  constants: ['self', 'result', 'true', 'false', 'null', 'invalid', 'OclUndefined'],
+  iterators: [
+    'select', 'reject', 'collect', 'collectNested', 'forAll', 'exists',
+    'any', 'one', 'isUnique', 'sortedBy', 'iterate',
+  ],
+  oclOps: [
+    'isEmpty', 'notEmpty', 'includes', 'excludes', 'includesAll', 'excludesAll',
+    'sum', 'count', 'min', 'max', 'first', 'last', 'at', 'union', 'intersection',
+    'append', 'prepend', 'insertAt', 'subSequence', 'flatten',
+    'asSet', 'asOrderedSet', 'asSequence', 'asBag', 'reverse',
+    'size', 'concat', 'substring', 'indexOf', 'toUpperCase', 'toLowerCase',
+    'toInteger', 'toReal', 'trim', 'matches', 'tokenize',
+    'allInstances', 'oclIsKindOf', 'oclIsTypeOf', 'oclAsType', 'oclIsNew',
+    'oclIsUndefined', 'oclIsInvalid',
+    'abs', 'floor', 'ceiling', 'round', 'sqrt', 'log', 'exp', 'mod', 'div',
+  ],
+  tokenizer: {
+    root: [
+      // Comments
+      [/--.*$/, 'comment'],
+      [/\/\*/, { token: 'comment.block', next: '@blockComment' }],
+
+      // Annotations
+      [/[@]severity/, { token: 'annotation', next: '@severityValue' }],
+      [/[@]message\b/, 'annotation'],
+
+      // Structural keywords
+      [/\b(package|endpackage)\b/, 'keyword.package'],
+      [/\b(context)\b/, { token: 'keyword.context', next: '@contextType' }],
+      [/\b(inv|pre|post|body|def)\b/, { token: 'keyword.inv', next: '@invName' }],
+
+      // Keywords
+      [/\b(if|then|else|endif)\b/, 'keyword.control'],
+      [/\b(let)\b/, { token: 'keyword.let', next: '@letVar' }],
+      [/\b(in)\b/, 'keyword.let'],
+      [/\b(and|or|not|implies|xor)\b/, 'keyword.operator.logical'],
+
+      // Constants
+      [/\b(self|result)\b/, 'variable.predefined'],
+      [/\b(true|false)\b/, 'constant.boolean'],
+      [/\b(null|invalid|OclUndefined)\b/, 'constant.null'],
+
+      // Iterators
+      [/\b(select|reject|collect|collectNested|forAll|exists|any|one|isUnique|sortedBy|iterate)\b/, 'support.function.iterator'],
+
+      // Type keywords
+      [/\b(Integer|Real|String|Boolean|UnlimitedNatural|OclAny|OclVoid)\b/, 'type.primitive'],
+      [/\b(Set|Sequence|Bag|OrderedSet|Collection|Optional|Singleton)\b/, 'type.collection'],
+
+      // OCL operations
+      [/\b(isEmpty|notEmpty|includes|excludes|includesAll|excludesAll|sum|count|min|max|first|last|at|union|intersection|append|prepend|insertAt|subSequence|flatten|asSet|asOrderedSet|asSequence|asBag|reverse|size|concat|substring|indexOf|toUpperCase|toLowerCase|toInteger|toReal|trim|matches|tokenize|allInstances|oclIsKindOf|oclIsTypeOf|oclAsType|oclIsNew|oclIsUndefined|oclIsInvalid|abs|floor|ceiling|round|sqrt|log|exp|mod|div)\b/, 'support.function.ocl'],
+
+      // Strings
+      [/"([^"\\]|\\.)*$/, 'string.invalid'],
+      [/"/, { token: 'string.quote', next: '@dstring' }],
+      [/'([^'\\]|\\.)*$/, 'string.invalid'],
+      [/'/, { token: 'string.quote', next: '@sstring' }],
+
+      // Numbers
+      [/\b\d+\.\d+([eE][+-]?\d+)?[fF]?\b/, 'number.float'],
+      [/\b\d+\b/, 'number'],
+
+      // Operators
+      [/\.\./, 'operator.range'],
+      [/\.(?!\.)/, 'operator.navigation'],
+      [/::/, 'operator.typecast'],
+      [/<>|!=|<=|>=|<|>|=/, 'operator.comparison'],
+      [/[+\-*/]/, 'operator.arithmetic'],
+      [/~/, 'operator.correspondence'],
+      [/\|/, 'operator.pipe'],
+      [/:/, 'operator.colon'],
+
+      // Multiplicity
+      [/[¡!¿?]/, 'multiplicity'],
+
+      // Punctuation
+      [/[()[\]{}]/, 'delimiter'],
+    ],
+
+    contextType: [
+      [/\s+/, ''],
+      [/[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)?/, 'type.class', '@pop'],
+      [/./, { token: '', next: '@pop' }],
+    ],
+
+    invName: [
+      [/\s+/, ''],
+      [/[A-Za-z_][A-Za-z0-9_]*/, 'entity.name.label', '@pop'],
+      [/./, { token: '', next: '@pop' }],
+    ],
+
+    letVar: [
+      [/\s+/, ''],
+      [/[A-Za-z_][A-Za-z0-9_]*/, 'variable.let', '@pop'],
+      [/./, { token: '', next: '@pop' }],
+    ],
+
+    severityValue: [
+      [/\s+/, ''],
+      [/[A-Z]+/, 'annotation.value', '@pop'],
+      [/./, { token: '', next: '@pop' }],
+    ],
+
+    dstring: [
+      [/[^\\"]+/, 'string'],
+      [/\\./, 'string.escape'],
+      [/"/, { token: 'string.quote', next: '@pop' }],
+    ],
+
+    sstring: [
+      [/[^\\']+/, 'string'],
+      [/\\./, 'string.escape'],
+      [/'/, { token: 'string.quote', next: '@pop' }],
+    ],
+
+    blockComment: [
+      [/[^/*]+/, 'comment.block'],
+      [/\*\//, { token: 'comment.block', next: '@pop' }],
+      [/[/*]/, 'comment.block'],
+    ],
+  },
+};
+
+export const vitruvOCLTheme: monaco.editor.IStandaloneThemeData = {
+  base: 'vs',
+  inherit: true,
+  rules: [
+    { token: 'comment', foreground: '6a9955', fontStyle: 'italic' },
+    { token: 'comment.block', foreground: '6a9955', fontStyle: 'italic' },
+    { token: 'annotation', foreground: '795e26', fontStyle: 'bold' },
+    { token: 'annotation.value', foreground: 'a31515' },
+    { token: 'keyword.package', foreground: 'af00db' },
+    { token: 'keyword.context', foreground: '0000ff', fontStyle: 'bold' },
+    { token: 'keyword.inv', foreground: '267f99', fontStyle: 'bold' },
+    { token: 'keyword.control', foreground: 'af00db' },
+    { token: 'keyword.let', foreground: 'af00db' },
+    { token: 'keyword.operator.logical', foreground: '0000ff' },
+    { token: 'variable.predefined', foreground: '001080', fontStyle: 'bold' },
+    { token: 'variable.let', foreground: '001080' },
+    { token: 'constant.boolean', foreground: '0000ff' },
+    { token: 'constant.null', foreground: '808080' },
+    { token: 'support.function.iterator', foreground: '795e26' },
+    { token: 'support.function.ocl', foreground: '795e26' },
+    { token: 'type.primitive', foreground: '267f99' },
+    { token: 'type.collection', foreground: '267f99' },
+    { token: 'type.class', foreground: '267f99', fontStyle: 'bold' },
+    { token: 'entity.name.label', foreground: '795e26', fontStyle: 'bold' },
+    { token: 'string', foreground: 'a31515' },
+    { token: 'string.quote', foreground: 'a31515' },
+    { token: 'string.escape', foreground: 'ee0000' },
+    { token: 'string.invalid', foreground: 'cd3131' },
+    { token: 'number', foreground: '098658' },
+    { token: 'number.float', foreground: '098658' },
+    { token: 'operator.range', foreground: '000000' },
+    { token: 'operator.navigation', foreground: '000000' },
+    { token: 'operator.typecast', foreground: '000000' },
+    { token: 'operator.comparison', foreground: '000000' },
+    { token: 'operator.arithmetic', foreground: '000000' },
+    { token: 'operator.correspondence', foreground: 'af00db', fontStyle: 'bold' },
+    { token: 'operator.pipe', foreground: '000000' },
+    { token: 'operator.colon', foreground: '000000' },
+    { token: 'multiplicity', foreground: 'af00db' },
+    { token: 'delimiter', foreground: '000000' },
+  ],
+  colors: {
+    'editor.background': '#ffffff',
+  },
+};
+
+export const vitruvOCLLanguageConfig: monaco.languages.LanguageConfiguration = {
+  comments: { lineComment: '--', blockComment: ['/*', '*/'] },
+  brackets: [['(', ')'], ['{', '}'], ['[', ']']],
+  autoClosingPairs: [
+    { open: '(', close: ')' },
+    { open: '[', close: ']' },
+    { open: '"', close: '"', notIn: ['string'] },
+    { open: "'", close: "'", notIn: ['string'] },
+  ],
+  surroundingPairs: [
+    { open: '(', close: ')' },
+    { open: '[', close: ']' },
+    { open: '"', close: '"' },
+    { open: "'", close: "'" },
+  ],
+};
+
+export function registerVitruvOCLLanguage() {
+  if (monaco.languages.getLanguages().some((l) => l.id === vitruvOCLLanguageId)) return;
+
+  monaco.languages.register({ id: vitruvOCLLanguageId, extensions: ['.ocl'], aliases: ['VitruvOCL'] });
+  monaco.languages.setMonarchTokensProvider(vitruvOCLLanguageId, vitruvOCLMonarch);
+  monaco.languages.setLanguageConfiguration(vitruvOCLLanguageId, vitruvOCLLanguageConfig);
+  monaco.editor.defineTheme('vitruvocl-dark', vitruvOCLTheme);
+}

--- a/src/components/flow/CodeEditorModal.tsx
+++ b/src/components/flow/CodeEditorModal.tsx
@@ -110,6 +110,7 @@ export function CodeEditorModal({
   const workspaceRootUri = useRef<string | null>(null);
   const versionCounter = useRef(1);
   const pendingCloseRef = useRef(false);
+  const completionProviderRef = useRef<monaco.IDisposable | null>(null);
 
   // FIX: Centralized pending request map instead of addEventListener
   const pendingRequests = useRef<Map<number, (msg: any) => void>>(new Map());
@@ -162,7 +163,11 @@ export function CodeEditorModal({
   }, [isOpen]);
 
   useEffect(() => {
-    return () => { closeWebSocket(); };
+    return () => {
+      closeWebSocket();
+      completionProviderRef.current?.dispose();
+      completionProviderRef.current = null;
+    };
   }, [closeWebSocket]);
 
   useEffect(() => {
@@ -321,7 +326,8 @@ export function CodeEditorModal({
     monacoInstance.editor.defineTheme(themeName, editorTheme);
     monacoInstance.editor.setTheme(themeName);
 
-    monacoInstance.languages.registerCompletionItemProvider(languageId, {
+    completionProviderRef.current?.dispose();
+    completionProviderRef.current = monacoInstance.languages.registerCompletionItemProvider(languageId, {
       triggerCharacters: ['.', ' ', '\n', ':'],
       provideCompletionItems: async (model, position) =>
         requestCompletionFromLsp(model, position, monacoInstance),
@@ -594,6 +600,7 @@ export function CodeEditorModal({
       }}
       onClose={handleClose}
       onCancel={handleClose}
+      onKeyDown={e => e.stopPropagation()}
     >
       <button
         type="button"

--- a/src/components/flow/EcoreFileBox.tsx
+++ b/src/components/flow/EcoreFileBox.tsx
@@ -106,11 +106,6 @@ function resolveCardShadow(bg: string, isReactionSource: boolean, isConstraintCo
   return '0 3px 10px rgba(0,0,0,0.08)';
 }
 
-function resolveCardTransform(selected: boolean, isHovered: boolean): string {
-  if (selected) return 'scale(1.04)';
-  if (isHovered) return 'scale(1.02)';
-  return 'scale(1)';
-}
 
 type ShowDetailsModelContext = {
   keywords?: string;
@@ -201,7 +196,7 @@ export const EcoreFileBox: React.FC<NodeProps<EcoreFileBoxData>> = ({
   const cardShadow  = resolveCardShadow(bg, isReactionSource, isConstraintContext, isConstraintFilter, selected, isHovered);
   const cardTransform = selected ? 'scale(1.04)' : isHovered ? 'scale(1.02)' : 'scale(1)';
   const handleShowDetails = buildShowDetailsHandler(
-    onShowDetails, setShowMenu, keywords, metaModelId, fileName, description, domain, createdAt, fileContent,
+    onShowDetails, setShowMenu, { keywords, metaModelId, fileName, description, domain, createdAt, fileContent },
   );
 
   const handleClick = (e: React.MouseEvent) => { e.stopPropagation(); onSelect(fileName); };

--- a/src/components/flow/EcoreFileBox.tsx
+++ b/src/components/flow/EcoreFileBox.tsx
@@ -194,7 +194,9 @@ export const EcoreFileBox: React.FC<NodeProps<EcoreFileBoxData>> = ({
   const borderColor = darken(bg, 25);
   const cardBorder  = resolveCardBorder(bg, isReactionSource, isConstraintContext, isConstraintFilter, selected, isHovered, borderColor);
   const cardShadow  = resolveCardShadow(bg, isReactionSource, isConstraintContext, isConstraintFilter, selected, isHovered);
-  const cardTransform = selected ? 'scale(1.04)' : isHovered ? 'scale(1.02)' : 'scale(1)';
+  let cardTransform = 'scale(1)';
+  if (selected) cardTransform = 'scale(1.04)';
+  else if (isHovered) cardTransform = 'scale(1.02)';
   const handleShowDetails = buildShowDetailsHandler(
     onShowDetails, setShowMenu, { keywords, metaModelId, fileName, description, domain, createdAt, fileContent },
   );

--- a/src/components/flow/EcoreFileBox.tsx
+++ b/src/components/flow/EcoreFileBox.tsx
@@ -23,6 +23,8 @@ interface EcoreFileBoxData {
   isExpanded?: boolean;
   isConnectionActive?: boolean;
   isReactionSource?: boolean;
+  isConstraintContext?: boolean;
+  isConstraintFilter?: boolean;
   description?: string;
   keywords?: string;
   domain?: string;
@@ -85,17 +87,21 @@ export function handleTipFromRect(
 
 // ── card visual helpers ───────────────────────────────────────────────────────
 
-function resolveCardBorder(bg: string, isReactionSource: boolean, selected: boolean, isHovered: boolean, borderColor: string): string {
-  if (isReactionSource) return '#1e293b';
-  if (selected)         return darken(bg, 45);
-  if (isHovered)        return darken(bg, 35);
+function resolveCardBorder(bg: string, isReactionSource: boolean, isConstraintContext: boolean, isConstraintFilter: boolean, selected: boolean, isHovered: boolean, borderColor: string): string {
+  if (isReactionSource)    return '#1e293b';
+  if (isConstraintFilter)  return '#049484';
+  if (isConstraintContext) return '#049484';
+  if (selected)            return darken(bg, 45);
+  if (isHovered)           return darken(bg, 35);
   return borderColor;
 }
 
-function resolveCardShadow(bg: string, isReactionSource: boolean, selected: boolean, isHovered: boolean): string {
-  if (isReactionSource) return '0 0 0 4px #1e293b33, 0 8px 24px rgba(0,0,0,0.15)';
-  if (selected)         return `0 0 0 3px ${darken(bg, 45)}55, 0 8px 24px rgba(0,0,0,0.15)`;
-  if (isHovered)        return '0 8px 24px rgba(0,0,0,0.12)';
+function resolveCardShadow(bg: string, isReactionSource: boolean, isConstraintContext: boolean, isConstraintFilter: boolean, selected: boolean, isHovered: boolean): string {
+  if (isReactionSource)    return '0 0 0 4px #1e293b33, 0 8px 24px rgba(0,0,0,0.15)';
+  if (isConstraintFilter)  return '0 0 0 3px #04948488, 0 8px 28px rgba(4,148,132,0.28)';
+  if (isConstraintContext) return '0 0 0 3px #04948455, 0 8px 24px rgba(4,148,132,0.18)';
+  if (selected)            return `0 0 0 3px ${darken(bg, 45)}55, 0 8px 24px rgba(0,0,0,0.15)`;
+  if (isHovered)           return '0 8px 24px rgba(0,0,0,0.12)';
   return '0 3px 10px rgba(0,0,0,0.08)';
 }
 
@@ -136,6 +142,8 @@ export const EcoreFileBox: React.FC<NodeProps<EcoreFileBoxData>> = ({
     description, keywords, createdAt, domain, onShowDetails, metaModelId,
     ecoreFileId, genModelFileId,
     isReactionSource = false,
+    isConstraintContext = false,
+    isConstraintFilter = false,
   } = data;
 
   const boxRef = useRef<HTMLDivElement>(null);
@@ -169,8 +177,8 @@ export const EcoreFileBox: React.FC<NodeProps<EcoreFileBoxData>> = ({
 
   const bg          = cardColor(domain);
   const borderColor = darken(bg, 25);
-  const cardBorder  = resolveCardBorder(bg, isReactionSource, selected, isHovered, borderColor);
-  const cardShadow  = resolveCardShadow(bg, isReactionSource, selected, isHovered);
+  const cardBorder  = resolveCardBorder(bg, isReactionSource, isConstraintContext, isConstraintFilter, selected, isHovered, borderColor);
+  const cardShadow  = resolveCardShadow(bg, isReactionSource, isConstraintContext, isConstraintFilter, selected, isHovered);
   const cardTransform = selected ? 'scale(1.04)' : isHovered ? 'scale(1.02)' : 'scale(1)';
   const handleShowDetails = buildShowDetailsHandler(
     onShowDetails, setShowMenu, keywords, metaModelId, fileName, description, domain, createdAt, fileContent,

--- a/src/components/flow/FlowCanvas.tsx
+++ b/src/components/flow/FlowCanvas.tsx
@@ -153,6 +153,8 @@ const getLocalStorageKey = (userId?: string, vsumId?: string) => {
   return 'flow_edge_color_map_v1';
 };
 
+export type CanvasMode = 'modeling' | 'constraints' | 'views';
+
 interface FlowCanvasProps {
   onDeploy?: (nodes: Node[], edges: Edge[]) => void;
   onToolClick?: (toolType: string, toolName: string, diagramType?: string) => void;
@@ -169,6 +171,14 @@ interface FlowCanvasProps {
   onHistoryChange?: (canUndo: boolean, canRedo: boolean) => void;
   /** Rendered directly under the Modeling / View Types toggle (e.g. project tabs). */
   projectTabsBelowModeToggle?: React.ReactNode;
+  /** Called when the user switches between Modeling / Constraints / Views tabs. */
+  onCanvasModeChange?: (mode: CanvasMode) => void;
+  /** Node ID to highlight as the active constraint context (teal glow). */
+  constraintHighlightNodeId?: string | null;
+  /** Node ID currently selected as a constraint filter (stronger teal border). */
+  constraintFilterNodeId?: string | null;
+  /** Called when a node is clicked in constraints mode to toggle the filter. */
+  onConstraintNodeFilter?: (nodeId: string | null) => void;
 }
 
 interface ConnectionDragState {
@@ -436,6 +446,10 @@ export const FlowCanvas = forwardRef<{
     onReactionModeEnd,
     onHistoryChange,
     projectTabsBelowModeToggle,
+    onCanvasModeChange,
+    constraintHighlightNodeId,
+    constraintFilterNodeId,
+    onConstraintNodeFilter,
   }, ref) => {
 
     const reactFlowWrapper = useRef<HTMLDivElement>(null);
@@ -483,6 +497,7 @@ export const FlowCanvas = forwardRef<{
     // Canvas center in flow coordinates — fixed at origin, ReactFlow's default fitView center
     const [circleSelected, setCircleSelected] = useState(false);
     const [circleVisible, setCircleVisible] = useState(true);
+    const [activeCanvasMode, setActiveCanvasMode] = useState<CanvasMode>('modeling');
 
     // Ref flag: set to true just before setCircle() in autoLayoutEcoreBoxes so the
     // useEffect below can call fitViewToCircle once React has committed the new circle.
@@ -1530,10 +1545,16 @@ export const FlowCanvas = forwardRef<{
         return; // don't do normal select in reaction mode
       }
 
+      // ── Constraints mode: toggle filter ────────────────────────────────────
+      if (activeCanvasMode === 'constraints') {
+        onConstraintNodeFilter?.(constraintFilterNodeId === ecoreNode.id ? null : ecoreNode.id);
+        return;
+      }
+
       // ── Normal select ───────────────────────────────────────────────────────
       setSelectedFileId(ecoreNode.id);
       onEcoreFileSelect?.(fileName);
-    }, [nodes, onEcoreFileSelect, addReactionMode, reactionSourceId, getColorForPair, calculateOptimalHandles, commitReactionEdge, onReactionModeEnd]);
+    }, [nodes, onEcoreFileSelect, addReactionMode, reactionSourceId, getColorForPair, calculateOptimalHandles, commitReactionEdge, onReactionModeEnd, activeCanvasMode, onConstraintNodeFilter, constraintFilterNodeId]);
 
     // Clear reaction source when mode is toggled off
     useEffect(() => {
@@ -2213,6 +2234,8 @@ export const FlowCanvas = forwardRef<{
             isConnectionActive: connectionDragState?.isActive || false,
             edgeDistribution: edgeDistributionMap.get(node.id),
             isReactionSource: reactionSourceId === node.id,
+            isConstraintContext: constraintHighlightNodeId === node.id,
+            isConstraintFilter: constraintFilterNodeId === node.id,
           },
           selected: selectedFileId === node.id,
           draggable: !connectionDragState?.isActive && !addReactionMode,
@@ -2667,24 +2690,30 @@ export const FlowCanvas = forwardRef<{
             }}
           >
             {([
-              { label: 'Modeling',   icon: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="9" y1="21" x2="9" y2="9"/></svg>, active: !circleVisible },
-              { label: 'View Types', icon: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="9"/><line x1="12" y1="3" x2="12" y2="21"/><line x1="3" y1="12" x2="21" y2="12"/></svg>, active: circleVisible },
-            ] as const).map(({ label, icon, active }) => (
+              { label: 'Modeling',     mode: 'modeling'     as CanvasMode, icon: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="9" y1="21" x2="9" y2="9"/></svg> },
+              { label: 'Constraints',  mode: 'constraints'  as CanvasMode, icon: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg> },
+              { label: 'Views',        mode: 'views'        as CanvasMode, icon: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="9"/><line x1="12" y1="3" x2="12" y2="21"/><line x1="3" y1="12" x2="21" y2="12"/></svg> },
+            ]).map(({ label, mode, icon }) => (
               <button
                 key={label}
                 onClick={() => {
-                  const next = label === 'View Types';
-                  setCircleVisible(next);
-                  if (!next && circleSelected) setCircleSelected(false);
+                  setActiveCanvasMode(mode);
+                  onCanvasModeChange?.(mode);
+                  if (mode === 'views') {
+                    setCircleVisible(true);
+                  } else {
+                    setCircleVisible(false);
+                    if (circleSelected) setCircleSelected(false);
+                  }
                 }}
                 style={{
                   display: 'flex', alignItems: 'center', gap: 6,
                   height: 34,
                   padding: '0 14px',
-                  border: active ? '1px solid #049484' : '1px solid transparent',
+                  border: activeCanvasMode === mode ? '1px solid #049484' : '1px solid transparent',
                   borderRadius: 6,
-                  background: active ? '#049484' : 'transparent',
-                  color: active ? '#ffffff' : '#64748b',
+                  background: activeCanvasMode === mode ? '#049484' : 'transparent',
+                  color: activeCanvasMode === mode ? '#ffffff' : '#64748b',
                   fontSize: 12,
                   fontWeight: 600,
                   cursor: 'pointer',
@@ -2692,8 +2721,8 @@ export const FlowCanvas = forwardRef<{
                   whiteSpace: 'nowrap',
                   fontFamily: 'inherit',
                 }}
-                onMouseEnter={e => { if (!active) { (e.currentTarget as HTMLButtonElement).style.background = '#f1f5f9'; (e.currentTarget as HTMLButtonElement).style.color = '#1e293b'; } }}
-                onMouseLeave={e => { if (!active) { (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; (e.currentTarget as HTMLButtonElement).style.color = '#64748b'; } }}
+                onMouseEnter={e => { if (activeCanvasMode !== mode) { (e.currentTarget as HTMLButtonElement).style.background = '#f1f5f9'; (e.currentTarget as HTMLButtonElement).style.color = '#1e293b'; } }}
+                onMouseLeave={e => { if (activeCanvasMode !== mode) { (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; (e.currentTarget as HTMLButtonElement).style.color = '#64748b'; } }}
               >
                 {icon}
                 {label}

--- a/src/components/flow/FlowCanvas.tsx
+++ b/src/components/flow/FlowCanvas.tsx
@@ -2814,12 +2814,12 @@ export const FlowCanvas = forwardRef<{
                   fontFamily: 'inherit',
                 }}
                 onMouseEnter={e => {
-                  if (active) return;
+                  if (activeCanvasMode === mode) return;
                   e.currentTarget.style.background = '#f1f5f9';
                   e.currentTarget.style.color = '#1e293b';
                 }}
                 onMouseLeave={e => {
-                  if (active) return;
+                  if (activeCanvasMode === mode) return;
                   e.currentTarget.style.background = 'transparent';
                   e.currentTarget.style.color = '#64748b';
                 }}

--- a/src/hooks/useOclLsp.ts
+++ b/src/hooks/useOclLsp.ts
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback } from 'react';
+import React, { useRef, useEffect, useCallback } from 'react';
 import { Monaco } from '@monaco-editor/react';
 import * as monaco from 'monaco-editor';
 
@@ -12,6 +12,33 @@ function markerSeverity(lspSeverity: number, monacoInstance: Monaco): monaco.Mar
   if (lspSeverity === 1) return monacoInstance.MarkerSeverity.Error;
   if (lspSeverity === 2) return monacoInstance.MarkerSeverity.Warning;
   return monacoInstance.MarkerSeverity.Info;
+}
+
+function resolveCompletionItems(
+  monacoInstance: Monaco,
+  initialized: React.MutableRefObject<boolean>,
+  wsRef: React.MutableRefObject<WebSocket | null>,
+  pendingRequests: React.MutableRefObject<Map<number, (msg: any) => void>>,
+  sendLsp: (msg: object) => void,
+  getDocUri: () => string | null,
+  model: monaco.editor.ITextModel,
+  position: monaco.Position,
+): Promise<monaco.languages.CompletionList> {
+  if (!initialized.current || wsRef.current?.readyState !== WebSocket.OPEN) {
+    return Promise.resolve({ suggestions: [] });
+  }
+  return new Promise(resolve => {
+    const wordInfo = model.getWordUntilPosition(position);
+    const range = {
+      startLineNumber: position.lineNumber, endLineNumber: position.lineNumber,
+      startColumn: wordInfo.startColumn, endColumn: wordInfo.endColumn,
+    };
+    const id = nextLspRequestId();
+    const timeout = setTimeout(() => { pendingRequests.current.delete(id); resolve({ suggestions: [] }); }, 2000);
+    pendingRequests.current.set(id, msg => { clearTimeout(timeout); resolve(buildCompletionItems(msg, range, monacoInstance)); });
+    sendLsp({ jsonrpc: '2.0', id, method: 'textDocument/completion',
+      params: { textDocument: { uri: getDocUri() }, position: { line: position.lineNumber - 1, character: position.column - 1 } } });
+  });
 }
 
 function buildCompletionItems(
@@ -148,18 +175,8 @@ export function useOclLsp({ vsumId, documentId, languageId, getCode }: UseOclLsp
     completionDisposable.current?.dispose();
     completionDisposable.current = monacoInstance.languages.registerCompletionItemProvider(languageId, {
       triggerCharacters: ['.', ' ', ':'],
-      provideCompletionItems: (model, position) => new Promise(resolve => {
-        if (!initialized.current || wsRef.current?.readyState !== WebSocket.OPEN) {
-          resolve({ suggestions: [] }); return;
-        }
-        const wordInfo = model.getWordUntilPosition(position);
-        const range = { startLineNumber: position.lineNumber, endLineNumber: position.lineNumber, startColumn: wordInfo.startColumn, endColumn: wordInfo.endColumn };
-        const id = nextLspRequestId();
-        const timeout = setTimeout(() => { pendingRequests.current.delete(id); resolve({ suggestions: [] }); }, 2000);
-        pendingRequests.current.set(id, (msg) => { clearTimeout(timeout); resolve(buildCompletionItems(msg, range, monacoInstance)); });
-        sendLsp({ jsonrpc: '2.0', id, method: 'textDocument/completion',
-          params: { textDocument: { uri: getDocUri() }, position: { line: position.lineNumber - 1, character: position.column - 1 } } });
-      }),
+      provideCompletionItems: (model, position) =>
+        resolveCompletionItems(monacoInstance, initialized, wsRef, pendingRequests, sendLsp, getDocUri, model, position),
     });
   }, [vsumId, languageId, getDocUri, getCode, sendLsp, disconnect]);
 

--- a/src/hooks/useOclLsp.ts
+++ b/src/hooks/useOclLsp.ts
@@ -1,0 +1,168 @@
+import { useRef, useEffect, useCallback } from 'react';
+import { Monaco } from '@monaco-editor/react';
+import * as monaco from 'monaco-editor';
+
+interface UseOclLspOptions {
+  vsumId?: number;
+  documentId: string;
+  languageId: string;
+  getCode: () => string;
+}
+
+/**
+ * Connects to the VitruvOCL LSP via WebSocket and wires up
+ * diagnostics + completions for a Monaco editor instance.
+ * Returns an onMount handler to pass to <Editor onMount={...} />.
+ */
+export function useOclLsp({ vsumId, documentId, languageId, getCode }: UseOclLspOptions) {
+  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const monacoRef = useRef<Monaco | null>(null);
+  const workspaceUri = useRef<string | null>(null);
+  const initialized = useRef(false);
+  const versionRef = useRef(1);
+  const completionDisposable = useRef<monaco.IDisposable | null>(null);
+  const pendingRequests = useRef<Map<number, (msg: any) => void>>(new Map());
+
+  const getDocUri = useCallback(
+    () => workspaceUri.current ? `${workspaceUri.current}ocl-${documentId}.ocl` : null,
+    [documentId]
+  );
+
+  const sendLsp = useCallback((msg: object) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN)
+      wsRef.current.send(JSON.stringify(msg));
+  }, []);
+
+  const disconnect = useCallback(() => {
+    if (wsRef.current) {
+      const uri = getDocUri();
+      if (uri && initialized.current) {
+        sendLsp({ jsonrpc: '2.0', method: 'textDocument/didClose', params: { textDocument: { uri } } });
+      }
+      wsRef.current.close(1000, 'editor closed');
+      wsRef.current = null;
+    }
+    initialized.current = false;
+    workspaceUri.current = null;
+    pendingRequests.current.clear();
+    completionDisposable.current?.dispose();
+    completionDisposable.current = null;
+  }, [getDocUri, sendLsp]);
+
+  const connect = useCallback((monacoInstance: Monaco) => {
+    if (!vsumId) return;
+    disconnect();
+
+    const rawUser = localStorage.getItem('auth.user');
+    const userId = rawUser ? JSON.parse(rawUser).id : null;
+    if (!userId) return;
+
+    const apiBase = process.env.REACT_APP_API_BASE_URL || 'http://localhost:9811';
+    const wsBase = apiBase.replace('https://', 'wss://').replace('http://', 'ws://');
+    const ws = new WebSocket(`${wsBase}/ocl-lsp?userId=${encodeURIComponent(userId)}&vsumId=${encodeURIComponent(vsumId)}`);
+    wsRef.current = ws;
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data);
+
+        if (msg.id !== undefined && msg.id !== 1 && pendingRequests.current.has(msg.id)) {
+          pendingRequests.current.get(msg.id)!(msg);
+          pendingRequests.current.delete(msg.id);
+          return;
+        }
+
+        if (msg.type === 'workspaceReady') {
+          workspaceUri.current = msg.rootUri;
+          ws.send(JSON.stringify({
+            jsonrpc: '2.0', id: 1, method: 'initialize',
+            params: {
+              processId: null,
+              rootUri: msg.rootUri,
+              workspaceFolders: [{ uri: msg.rootUri, name: 'OclProject' }],
+              capabilities: { textDocument: { completion: { completionItem: { snippetSupport: true } }, publishDiagnostics: {} } },
+            },
+          }));
+          return;
+        }
+
+        if (msg.id === 1 && msg.result) {
+          ws.send(JSON.stringify({ jsonrpc: '2.0', method: 'initialized', params: {} }));
+          initialized.current = true;
+          const uri = getDocUri();
+          if (uri) {
+            ws.send(JSON.stringify({
+              jsonrpc: '2.0', method: 'textDocument/didOpen',
+              params: { textDocument: { uri, languageId, version: 1, text: getCode() } },
+            }));
+          }
+          return;
+        }
+
+        if (msg.method === 'textDocument/publishDiagnostics') {
+          const model = editorRef.current?.getModel();
+          if (!model) return;
+          const markers = (msg.params.diagnostics || []).map((d: any) => ({
+            severity: d.severity === 1 ? monacoInstance.MarkerSeverity.Error
+                    : d.severity === 2 ? monacoInstance.MarkerSeverity.Warning
+                    : monacoInstance.MarkerSeverity.Info,
+            startLineNumber: d.range.start.line + 1,
+            startColumn: d.range.start.character + 1,
+            endLineNumber: d.range.end.line + 1,
+            endColumn: d.range.end.character + 1,
+            message: d.message,
+          }));
+          monacoInstance.editor.setModelMarkers(model, languageId, markers);
+        }
+      } catch { /* ignore malformed messages */ }
+    };
+
+    ws.onclose = () => { initialized.current = false; };
+
+    // Register completion provider (dispose old one first)
+    completionDisposable.current?.dispose();
+    completionDisposable.current = monacoInstance.languages.registerCompletionItemProvider(languageId, {
+      triggerCharacters: ['.', ' ', ':'],
+      provideCompletionItems: (model, position) => new Promise(resolve => {
+        if (!initialized.current || wsRef.current?.readyState !== WebSocket.OPEN) {
+          resolve({ suggestions: [] }); return;
+        }
+        const wordInfo = model.getWordUntilPosition(position);
+        const range = { startLineNumber: position.lineNumber, endLineNumber: position.lineNumber, startColumn: wordInfo.startColumn, endColumn: wordInfo.endColumn };
+        const id = Math.floor(Math.random() * 2147483647);
+        const timeout = setTimeout(() => { pendingRequests.current.delete(id); resolve({ suggestions: [] }); }, 2000);
+        pendingRequests.current.set(id, (msg) => {
+          clearTimeout(timeout);
+          const items = Array.isArray(msg.result) ? msg.result : (msg.result?.items ?? []);
+          resolve({ suggestions: items.map((item: any) => ({
+            label: item.label,
+            kind: item.kind ?? monacoInstance.languages.CompletionItemKind.Text,
+            insertText: item.insertText ?? item.label,
+            range,
+          }))});
+        });
+        sendLsp({ jsonrpc: '2.0', id, method: 'textDocument/completion',
+          params: { textDocument: { uri: getDocUri() }, position: { line: position.lineNumber - 1, character: position.column - 1 } } });
+      }),
+    });
+  }, [vsumId, languageId, getDocUri, getCode, sendLsp, disconnect]);
+
+  // Disconnect on unmount
+  useEffect(() => () => disconnect(), [disconnect]);
+
+  const notifyChange = useCallback((text: string) => {
+    if (!initialized.current || wsRef.current?.readyState !== WebSocket.OPEN) return;
+    versionRef.current++;
+    sendLsp({ jsonrpc: '2.0', method: 'textDocument/didChange',
+      params: { textDocument: { uri: getDocUri(), version: versionRef.current }, contentChanges: [{ text }] } });
+  }, [getDocUri, sendLsp]);
+
+  const onMount = useCallback((editor: monaco.editor.IStandaloneCodeEditor, monacoInstance: Monaco) => {
+    editorRef.current = editor;
+    monacoRef.current = monacoInstance;
+    connect(monacoInstance);
+  }, [connect]);
+
+  return { onMount, notifyChange };
+}

--- a/src/hooks/useOclLsp.ts
+++ b/src/hooks/useOclLsp.ts
@@ -2,6 +2,26 @@ import { useRef, useEffect, useCallback } from 'react';
 import { Monaco } from '@monaco-editor/react';
 import * as monaco from 'monaco-editor';
 
+function markerSeverity(lspSeverity: number, monacoInstance: Monaco): monaco.MarkerSeverity {
+  if (lspSeverity === 1) return monacoInstance.MarkerSeverity.Error;
+  if (lspSeverity === 2) return monacoInstance.MarkerSeverity.Warning;
+  return monacoInstance.MarkerSeverity.Info;
+}
+
+function buildCompletionItems(
+  msg: any,
+  range: { startLineNumber: number; endLineNumber: number; startColumn: number; endColumn: number },
+  monacoInstance: Monaco,
+) {
+  const items = Array.isArray(msg.result) ? msg.result : (msg.result?.items ?? []);
+  return { suggestions: items.map((item: any) => ({
+    label: item.label,
+    kind: item.kind ?? monacoInstance.languages.CompletionItemKind.Text,
+    insertText: item.insertText ?? item.label,
+    range,
+  }))};
+}
+
 interface UseOclLspOptions {
   vsumId?: number;
   documentId: string;
@@ -104,9 +124,7 @@ export function useOclLsp({ vsumId, documentId, languageId, getCode }: UseOclLsp
           const model = editorRef.current?.getModel();
           if (!model) return;
           const markers = (msg.params.diagnostics || []).map((d: any) => ({
-            severity: d.severity === 1 ? monacoInstance.MarkerSeverity.Error
-                    : d.severity === 2 ? monacoInstance.MarkerSeverity.Warning
-                    : monacoInstance.MarkerSeverity.Info,
+            severity: markerSeverity(d.severity, monacoInstance),
             startLineNumber: d.range.start.line + 1,
             startColumn: d.range.start.character + 1,
             endLineNumber: d.range.end.line + 1,
@@ -130,18 +148,9 @@ export function useOclLsp({ vsumId, documentId, languageId, getCode }: UseOclLsp
         }
         const wordInfo = model.getWordUntilPosition(position);
         const range = { startLineNumber: position.lineNumber, endLineNumber: position.lineNumber, startColumn: wordInfo.startColumn, endColumn: wordInfo.endColumn };
-        const id = Math.floor(Math.random() * 2147483647);
+        const id = crypto.getRandomValues(new Uint32Array(1))[0] % 2147483647;
         const timeout = setTimeout(() => { pendingRequests.current.delete(id); resolve({ suggestions: [] }); }, 2000);
-        pendingRequests.current.set(id, (msg) => {
-          clearTimeout(timeout);
-          const items = Array.isArray(msg.result) ? msg.result : (msg.result?.items ?? []);
-          resolve({ suggestions: items.map((item: any) => ({
-            label: item.label,
-            kind: item.kind ?? monacoInstance.languages.CompletionItemKind.Text,
-            insertText: item.insertText ?? item.label,
-            range,
-          }))});
-        });
+        pendingRequests.current.set(id, (msg) => { clearTimeout(timeout); resolve(buildCompletionItems(msg, range, monacoInstance)); });
         sendLsp({ jsonrpc: '2.0', id, method: 'textDocument/completion',
           params: { textDocument: { uri: getDocUri() }, position: { line: position.lineNumber - 1, character: position.column - 1 } } });
       }),

--- a/src/hooks/useOclLsp.ts
+++ b/src/hooks/useOclLsp.ts
@@ -1,4 +1,5 @@
-import React, { useRef, useEffect, useCallback } from 'react';
+import { useRef, useEffect, useCallback } from 'react';
+import type { RefObject } from 'react';
 import { Monaco } from '@monaco-editor/react';
 import * as monaco from 'monaco-editor';
 
@@ -14,17 +15,21 @@ function markerSeverity(lspSeverity: number, monacoInstance: Monaco): monaco.Mar
   return monacoInstance.MarkerSeverity.Info;
 }
 
+interface CompletionCtx {
+  initialized: RefObject<boolean>;
+  wsRef: RefObject<WebSocket | null>;
+  pendingRequests: RefObject<Map<number, (msg: any) => void>>;
+  sendLsp: (msg: object) => void;
+  getDocUri: () => string | null;
+}
+
 function resolveCompletionItems(
   monacoInstance: Monaco,
-  initialized: React.MutableRefObject<boolean>,
-  wsRef: React.MutableRefObject<WebSocket | null>,
-  pendingRequests: React.MutableRefObject<Map<number, (msg: any) => void>>,
-  sendLsp: (msg: object) => void,
-  getDocUri: () => string | null,
+  ctx: CompletionCtx,
   model: monaco.editor.ITextModel,
   position: monaco.Position,
 ): Promise<monaco.languages.CompletionList> {
-  if (!initialized.current || wsRef.current?.readyState !== WebSocket.OPEN) {
+  if (!ctx.initialized.current || ctx.wsRef.current?.readyState !== WebSocket.OPEN) {
     return Promise.resolve({ suggestions: [] });
   }
   return new Promise(resolve => {
@@ -34,10 +39,10 @@ function resolveCompletionItems(
       startColumn: wordInfo.startColumn, endColumn: wordInfo.endColumn,
     };
     const id = nextLspRequestId();
-    const timeout = setTimeout(() => { pendingRequests.current.delete(id); resolve({ suggestions: [] }); }, 2000);
-    pendingRequests.current.set(id, msg => { clearTimeout(timeout); resolve(buildCompletionItems(msg, range, monacoInstance)); });
-    sendLsp({ jsonrpc: '2.0', id, method: 'textDocument/completion',
-      params: { textDocument: { uri: getDocUri() }, position: { line: position.lineNumber - 1, character: position.column - 1 } } });
+    const timeout = setTimeout(() => { ctx.pendingRequests.current.delete(id); resolve({ suggestions: [] }); }, 2000);
+    ctx.pendingRequests.current.set(id, msg => { clearTimeout(timeout); resolve(buildCompletionItems(msg, range, monacoInstance)); });
+    ctx.sendLsp({ jsonrpc: '2.0', id, method: 'textDocument/completion',
+      params: { textDocument: { uri: ctx.getDocUri() }, position: { line: position.lineNumber - 1, character: position.column - 1 } } });
   });
 }
 
@@ -176,7 +181,7 @@ export function useOclLsp({ vsumId, documentId, languageId, getCode }: UseOclLsp
     completionDisposable.current = monacoInstance.languages.registerCompletionItemProvider(languageId, {
       triggerCharacters: ['.', ' ', ':'],
       provideCompletionItems: (model, position) =>
-        resolveCompletionItems(monacoInstance, initialized, wsRef, pendingRequests, sendLsp, getDocUri, model, position),
+        resolveCompletionItems(monacoInstance, { initialized, wsRef, pendingRequests, sendLsp, getDocUri }, model, position),
     });
   }, [vsumId, languageId, getDocUri, getCode, sendLsp, disconnect]);
 

--- a/src/hooks/useOclLsp.ts
+++ b/src/hooks/useOclLsp.ts
@@ -2,6 +2,12 @@ import { useRef, useEffect, useCallback } from 'react';
 import { Monaco } from '@monaco-editor/react';
 import * as monaco from 'monaco-editor';
 
+let _lspRequestId = 2; // start at 2 — id 1 is reserved for LSP initialize
+function nextLspRequestId(): number {
+  _lspRequestId = (_lspRequestId % 2_147_483_646) + 1;
+  return _lspRequestId;
+}
+
 function markerSeverity(lspSeverity: number, monacoInstance: Monaco): monaco.MarkerSeverity {
   if (lspSeverity === 1) return monacoInstance.MarkerSeverity.Error;
   if (lspSeverity === 2) return monacoInstance.MarkerSeverity.Warning;
@@ -148,7 +154,7 @@ export function useOclLsp({ vsumId, documentId, languageId, getCode }: UseOclLsp
         }
         const wordInfo = model.getWordUntilPosition(position);
         const range = { startLineNumber: position.lineNumber, endLineNumber: position.lineNumber, startColumn: wordInfo.startColumn, endColumn: wordInfo.endColumn };
-        const id = crypto.getRandomValues(new Uint32Array(1))[0] % 2147483647;
+        const id = nextLspRequestId();
         const timeout = setTimeout(() => { pendingRequests.current.delete(id); resolve({ suggestions: [] }); }, 2000);
         pendingRequests.current.set(id, (msg) => { clearTimeout(timeout); resolve(buildCompletionItems(msg, range, monacoInstance)); });
         sendLsp({ jsonrpc: '2.0', id, method: 'textDocument/completion',

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -6,7 +6,8 @@ import { ProfileView } from '../components/ui/ProfileView';
 import ReactDOM from 'react-dom';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Node, Edge } from 'reactflow';
-import { FlowCanvas } from '../components/flow/FlowCanvas';
+import { CanvasMode, FlowCanvas } from '../components/flow/FlowCanvas';
+import { ConstraintsView } from '../components/constraints/ConstraintsView';
 import { FloatingUMLPanel } from '../components/canvas/FloatingUMLPanel';
 import { ModelDrawer, DrawerModel } from '../components/canvas/ModelDrawer';
 import { apiService } from '../services/api';
@@ -93,6 +94,25 @@ export const CanvasPage: React.FC = () => {
   const activeTab = openTabs.find(t => t.instanceId === activeInstanceId);
   const activeProjectId = activeTab?.projectId ?? (id ? Number(id) : undefined);
 
+  // Canvas mode (Modeling / Constraints / Views)
+  const [canvasMode, setCanvasMode] = useState<CanvasMode>('modeling');
+  const canvasModeRef = useRef<CanvasMode>('modeling');
+  const [constraintsNodes, setConstraintsNodes] = useState<Node[]>([]);
+  const [constraintHighlightNodeId, setConstraintHighlightNodeId] = useState<string | null>(null);
+  const [constraintFilterNodeId, setConstraintFilterNodeId] = useState<string | null>(null);
+
+  const handleCanvasModeChange = useCallback((mode: CanvasMode) => {
+    if (mode === 'constraints') {
+      setConstraintsNodes(flowCanvasRef.current?.getNodes?.() ?? []);
+    } else {
+      setConstraintHighlightNodeId(null);
+      setConstraintFilterNodeId(null);
+    }
+    canvasModeRef.current = mode;
+    setCanvasMode(mode);
+  }, []);
+
+
   // Add-reaction mode
   const [addReactionMode, setAddReactionMode] = useState(false);
 
@@ -156,6 +176,10 @@ export const CanvasPage: React.FC = () => {
     setShowDrawer(false);
     setEditingName(false);
     setLoadingProject(false);
+
+    if (canvasModeRef.current === 'constraints') {
+      setConstraintsNodes(session.nodes);
+    }
 
     const load = () => {
       flowCanvasRef.current?.loadDiagramData?.(session.nodes, session.edges);
@@ -385,6 +409,11 @@ export const CanvasPage: React.FC = () => {
 
       if (forInstanceId && activeInstanceIdRef.current !== forInstanceId) return;
 
+      // If the user is in constraints mode, re-snapshot now that the new project's nodes are ready.
+      if (canvasModeRef.current === 'constraints') {
+        setConstraintsNodes(flowCanvasRef.current?.getNodes?.() ?? []);
+      }
+
       if (details.metaModelsRelation?.length) {
         globalThis.dispatchEvent(new CustomEvent('vitruv.loadMetaModelRelations', {
           detail: {
@@ -431,6 +460,11 @@ export const CanvasPage: React.FC = () => {
 
       prevActiveInstanceIdRef.current = nextId;
       if (!nextId) return;
+
+      // Clear stale nodes so the new ConstraintsView instance mounts with a blank slate.
+      if (canvasModeRef.current === 'constraints') {
+        setConstraintsNodes([]);
+      }
 
       const cached = sessionsRef.current.get(nextId);
       if (cached && loadedTabsRef.current.has(nextId)) {
@@ -691,6 +725,10 @@ export const CanvasPage: React.FC = () => {
         addReactionMode={addReactionMode}
         onReactionModeEnd={() => setAddReactionMode(false)}
         onHistoryChange={(u, r) => { setCanUndo(u); setCanRedo(r); }}
+        onCanvasModeChange={handleCanvasModeChange}
+        constraintHighlightNodeId={constraintHighlightNodeId}
+        constraintFilterNodeId={constraintFilterNodeId}
+        onConstraintNodeFilter={setConstraintFilterNodeId}
         projectTabsBelowModeToggle={
           openTabs.length > 0 ? (
             <CanvasProjectTabs
@@ -768,8 +806,19 @@ export const CanvasPage: React.FC = () => {
         document.body
       )}
 
+      {/* Constraints overlay — always mounted to preserve state (edits, deletions).
+          Visibility toggled via display so the FlowCanvas mode-toggle remains
+          clickable through the transparent center gap when hidden. */}
+      <div style={{
+        position: 'absolute', top: 72, left: 0, right: 0, bottom: 0,
+        display: canvasMode === 'constraints' ? 'flex' : 'none',
+        zIndex: 100, pointerEvents: 'none',
+      }}>
+        <ConstraintsView key={activeProjectId ?? 'default'} vsumId={activeProjectId?.toString()} canvasNodes={constraintsNodes} onHighlightNode={setConstraintHighlightNodeId} filterNodeId={constraintFilterNodeId} />
+      </div>
+
       {/* Left sidebar toolbar */}
-      <LeftSidebar
+      {canvasMode !== 'constraints' && <LeftSidebar
         addReactionMode={addReactionMode}
         onToggleReactionMode={() => setAddReactionMode(v => !v)}
         onToggleModelDrawer={() => setShowDrawer(d => !d)}
@@ -783,7 +832,7 @@ export const CanvasPage: React.FC = () => {
         downloadingArtifact={downloadingArtifact}
         savingChanges={savingChanges}
         checkingBuild={checkingBuild}
-      />
+      />}
 
       <LeftPill
         projectName={vsumName || (loadingProject ? 'Loading…' : 'Project')}

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -551,17 +551,17 @@ export const CanvasPage: React.FC = () => {
     const edges = flowCanvasRef.current?.getEdges?.() ?? [];
     const removeIds = new Set(
       nodes
-        .filter((n: FlowNode) => {
+        .filter((n: Node) => {
           if (n.type !== 'ecoreFile') return false;
           const mmId = n.data?.metaModelId;
           const mmSourceId = n.data?.metaModelSourceId;
           return mmId === model.id || mmId === sourceId || mmSourceId === model.id || mmSourceId === sourceId;
         })
-        .map((n: FlowNode) => n.id),
+        .map((n: Node) => n.id),
     );
     if (removeIds.size > 0) {
       flowCanvasRef.current?.loadDiagramData?.(
-        nodes.filter((n: FlowNode) => !removeIds.has(n.id)),
+        nodes.filter((n: Node) => !removeIds.has(n.id)),
         edges.filter((e: Edge) => !removeIds.has(e.source) && !removeIds.has(e.target)),
       );
     }
@@ -590,7 +590,7 @@ export const CanvasPage: React.FC = () => {
 
     if (ecoreFileId == null || metaModelId == null) {
       const node = flowCanvasRef.current?.getNodes?.().find(
-        (n: FlowNode) => n.type === 'ecoreFile' && n.data.fileName === fileName,
+        (n: Node) => n.type === 'ecoreFile' && n.data.fileName === fileName,
       );
       if (node?.data) {
         metaModelId = metaModelId ?? (typeof node.data.metaModelId === 'number' ? node.data.metaModelId : undefined);
@@ -785,7 +785,7 @@ export const CanvasPage: React.FC = () => {
   }, [handleUmlPanelSaved]);
 
   const focusPanel = useCallback((panelId: string) => setTopPanelId(panelId), []);
-  const handleDiagramChange = useCallback((_nodes: FlowNode[], _edges: Edge[]) => {
+  const handleDiagramChange = useCallback((_nodes: Node[], _edges: Edge[]) => {
     const ids = new Set<number>();
     for (const n of _nodes) {
       if (n.type !== 'ecoreFile') continue;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -851,10 +851,63 @@ class ApiService {
   }
 
   // Removed unused getBaseURL and setBaseURL helpers
+
+  // ── Constraint Rule Sets ──────────────────────────────────────────────────
+
+  getRuleSets(vsumId: number): Promise<RuleSetResponse[]> {
+    return this.authenticatedRequest(`/api/v1/vsums/${vsumId}/rule-sets`);
+  }
+
+  createRuleSet(vsumId: number, body: RuleSetPostRequest): Promise<RuleSetResponse> {
+    return this.authenticatedRequest(`/api/v1/vsums/${vsumId}/rule-sets`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  updateRuleSet(vsumId: number, ruleSetId: number, body: RuleSetPutRequest): Promise<RuleSetResponse> {
+    return this.authenticatedRequest(`/api/v1/vsums/${vsumId}/rule-sets/${ruleSetId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  deleteRuleSet(vsumId: number, ruleSetId: number): Promise<void> {
+    return this.authenticatedRequest(`/api/v1/vsums/${vsumId}/rule-sets/${ruleSetId}`, {
+      method: 'DELETE',
+    });
+  }
 }
 
 // Export a singleton instance
 export const apiService = new ApiService();
+
+export interface RuleSetResponse {
+  id: number;
+  vsumId: number;
+  name: string;
+  color: string;
+  description: string | null;
+  oclContent: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RuleSetPostRequest {
+  name: string;
+  color?: string;
+  description?: string;
+  oclContent?: string;
+}
+
+export interface RuleSetPutRequest {
+  name: string;
+  color?: string;
+  description?: string;
+  oclContent?: string;
+}
 
 // Example API methods using the authenticated service
 // Removed unused userApi and projectApi helpers


### PR DESCRIPTION
- Add a dedicated Constraints view panel to the canvas with a left sidebar 
  for managing rule sets and rules, and a metrics panel on the right
- Implement an inline OCL editor with Monaco syntax highlighting, 
  live LSP diagnostics(lsp in backend, see https://github.com/vitruv-tools/methodologistUI-backend/pull/253), and autocompletion via WebSocket
- Support creating, editing, and deleting constraint rule sets and individual 
  OCL invariants with form-based field extraction (name, severity, message, 
  context class)
- Add detailed metrics modal with complexity (cyclomatic), severity breakdown, 
  and per-rule statistics
- Implement VitruvOCL Monarch grammar + theme for Monaco editor

Closes #308 