### PR TITLE
376 add showhide password controls to the sign upsing in forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/node": "^16.18.126",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "lucide-react": "^1.24.0",
         "monaco-editor": "^0.55.1",
         "monaco-languageclient": "^10.5.0",
         "react": "^19.1.0",
@@ -12315,6 +12316,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.24.0.tgz",
+      "integrity": "sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/node": "^16.18.126",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "lucide-react": "^1.24.0",
     "monaco-editor": "^0.55.1",
     "monaco-languageclient": "^10.5.0",
     "react": "^19.1.0",

--- a/src/__tests__/components/auth/SignIn.test.tsx
+++ b/src/__tests__/components/auth/SignIn.test.tsx
@@ -49,19 +49,17 @@ describe('SignIn component', () => {
     await userEvent.type(passwordInput, 'password123!');
 
     expect(passwordInput).toHaveAttribute('type', 'password');
-    expect(screen.getByRole('button', { name: 'Show password' })).toHaveAttribute(
-      'aria-pressed',
-      'false',
-    );
+    expect(
+      screen.getByRole('button', { name: 'Show password' }),
+    ).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: 'Show password' }));
 
     expect(passwordInput).toHaveAttribute('type', 'text');
     expect(passwordInput).toHaveValue('password123!');
-    expect(screen.getByRole('button', { name: 'Hide password' })).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    );
+    expect(
+      screen.getByRole('button', { name: 'Hide password' }),
+    ).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: 'Hide password' }));
 

--- a/src/__tests__/components/auth/SignIn.test.tsx
+++ b/src/__tests__/components/auth/SignIn.test.tsx
@@ -33,8 +33,40 @@ describe('SignIn component', () => {
     );
 
     expect(screen.getByLabelText(/Username or Email/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Password/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Password$/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Sign In/i })).toBeInTheDocument();
+  });
+
+  it('toggles password visibility without changing the password value', async () => {
+    render(
+      <SignIn
+        onSignInSuccess={mockOnSignInSuccess}
+        onSwitchToSignUp={mockOnSwitchToSignUp}
+      />,
+    );
+
+    const passwordInput = screen.getByLabelText(/^Password$/i);
+    await userEvent.type(passwordInput, 'password123!');
+
+    expect(passwordInput).toHaveAttribute('type', 'password');
+    expect(screen.getByRole('button', { name: 'Show password' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show password' }));
+
+    expect(passwordInput).toHaveAttribute('type', 'text');
+    expect(passwordInput).toHaveValue('password123!');
+    expect(screen.getByRole('button', { name: 'Hide password' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Hide password' }));
+
+    expect(passwordInput).toHaveAttribute('type', 'password');
+    expect(passwordInput).toHaveValue('password123!');
   });
 
   it('shows validation error when submitting with empty fields', async () => {
@@ -68,7 +100,7 @@ describe('SignIn component', () => {
       screen.getByLabelText(/Username or Email/i),
       'john@example.com',
     );
-    await userEvent.type(screen.getByLabelText(/Password/i), 'password123!');
+    await userEvent.type(screen.getByLabelText(/^Password$/i), 'password123!');
     await userEvent.click(screen.getByRole('button', { name: /Sign In/i }));
 
     await waitFor(() => {
@@ -94,7 +126,7 @@ describe('SignIn component', () => {
       screen.getByLabelText(/Username or Email/i),
       'john@example.com',
     );
-    await userEvent.type(screen.getByLabelText(/Password/i), 'wrong');
+    await userEvent.type(screen.getByLabelText(/^Password$/i), 'wrong');
     await userEvent.click(screen.getByRole('button', { name: /Sign In/i }));
 
     expect(
@@ -145,4 +177,3 @@ describe('SignIn component', () => {
     });
   });
 });
-

--- a/src/__tests__/components/auth/SignUp.test.tsx
+++ b/src/__tests__/components/auth/SignUp.test.tsx
@@ -58,10 +58,9 @@ describe('SignUp component', () => {
 
     expect(passwordInput).toHaveAttribute('type', 'text');
     expect(confirmPasswordInput).toHaveAttribute('type', 'password');
-    expect(screen.getByRole('button', { name: 'Hide password' })).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    );
+    expect(
+      screen.getByRole('button', { name: 'Hide password' }),
+    ).toBeInTheDocument();
 
     await userEvent.click(
       screen.getByRole('button', { name: 'Show confirm password' }),
@@ -70,7 +69,7 @@ describe('SignUp component', () => {
     expect(confirmPasswordInput).toHaveAttribute('type', 'text');
     expect(
       screen.getByRole('button', { name: 'Hide confirm password' }),
-    ).toHaveAttribute('aria-pressed', 'true');
+    ).toBeInTheDocument();
   });
 
   it('shows validation error for too short first name', async () => {

--- a/src/__tests__/components/auth/SignUp.test.tsx
+++ b/src/__tests__/components/auth/SignUp.test.tsx
@@ -40,6 +40,39 @@ describe('SignUp component', () => {
     ).toBeInTheDocument();
   });
 
+  it('toggles sign-up password fields independently', async () => {
+    render(
+      <SignUp
+        onSignUpSuccess={jest.fn()}
+        onSwitchToSignIn={jest.fn()}
+      />,
+    );
+
+    const passwordInput = screen.getByLabelText(/^Password \*$/i);
+    const confirmPasswordInput = screen.getByLabelText(/^Confirm Password \*$/i);
+
+    expect(passwordInput).toHaveAttribute('type', 'password');
+    expect(confirmPasswordInput).toHaveAttribute('type', 'password');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show password' }));
+
+    expect(passwordInput).toHaveAttribute('type', 'text');
+    expect(confirmPasswordInput).toHaveAttribute('type', 'password');
+    expect(screen.getByRole('button', { name: 'Hide password' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Show confirm password' }),
+    );
+
+    expect(confirmPasswordInput).toHaveAttribute('type', 'text');
+    expect(
+      screen.getByRole('button', { name: 'Hide confirm password' }),
+    ).toHaveAttribute('aria-pressed', 'true');
+  });
+
   it('shows validation error for too short first name', async () => {
     render(
       <SignUp
@@ -115,4 +148,3 @@ describe('SignUp component', () => {
     expect(onSignUpSuccess).toHaveBeenCalled();
   });
 });
-

--- a/src/components/auth/Auth.css
+++ b/src/components/auth/Auth.css
@@ -118,6 +118,45 @@
   font-weight: 400;
 }
 
+.password-input-wrapper {
+  position: relative;
+}
+
+.password-input-wrapper input {
+  padding-right: 3.5rem;
+}
+
+.password-visibility-toggle {
+  position: absolute;
+  top: 50%;
+  right: 2px;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: #047857;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transform: translateY(-50%);
+}
+
+.password-visibility-toggle:hover:not(:disabled) {
+  color: #065f46;
+}
+
+.password-visibility-toggle:focus-visible {
+  outline: 2px solid #06b5a0;
+  outline-offset: -2px;
+}
+
+.password-visibility-toggle:disabled {
+  color: #64748b;
+  cursor: not-allowed;
+}
+
 .auth-button {
   width: 100%;
   padding: 14px;
@@ -417,6 +456,10 @@
   .form-group input {
     padding: 11px 13px;
     font-size: 14px;
+  }
+
+  .password-input-wrapper input {
+    padding-right: 3.25rem;
   }
   
   .auth-button {

--- a/src/components/auth/PasswordVisibilityToggle.tsx
+++ b/src/components/auth/PasswordVisibilityToggle.tsx
@@ -25,7 +25,6 @@ export function PasswordVisibilityToggle({
       className="password-visibility-toggle"
       aria-controls={inputId}
       aria-label={accessibleLabel}
-      aria-pressed={isVisible}
       title={accessibleLabel}
       onClick={onToggle}
       disabled={disabled}

--- a/src/components/auth/PasswordVisibilityToggle.tsx
+++ b/src/components/auth/PasswordVisibilityToggle.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+
+interface PasswordVisibilityToggleProps {
+  inputId: string;
+  fieldLabel: string;
+  isVisible: boolean;
+  onToggle: () => void;
+  disabled?: boolean;
+}
+
+export function PasswordVisibilityToggle({
+  inputId,
+  fieldLabel,
+  isVisible,
+  onToggle,
+  disabled = false,
+}: Readonly<PasswordVisibilityToggleProps>) {
+  const action = isVisible ? 'Hide' : 'Show';
+  const accessibleLabel = `${action} ${fieldLabel}`;
+
+  return (
+    <button
+      type="button"
+      className="password-visibility-toggle"
+      aria-controls={inputId}
+      aria-label={accessibleLabel}
+      aria-pressed={isVisible}
+      title={accessibleLabel}
+      onClick={onToggle}
+      disabled={disabled}
+    >
+      {isVisible ? (
+        <EyeOff aria-hidden="true" size={18} />
+      ) : (
+        <Eye aria-hidden="true" size={18} />
+      )}
+    </button>
+  );
+}

--- a/src/components/auth/SignIn.tsx
+++ b/src/components/auth/SignIn.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { SignInCredentials } from '../../services/auth';
 import { useAuth } from '../../contexts/AuthContext';
 import { apiService } from '../../services/api';
+import { PasswordVisibilityToggle } from './PasswordVisibilityToggle';
 import './Auth.css';
 
 interface SignInProps {
@@ -17,6 +18,7 @@ export function SignIn({ onSignInSuccess, onSwitchToSignUp }: Readonly<SignInPro
   });
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   
   // Forgot password states
   const [isForgotPasswordOpen, setIsForgotPasswordOpen] = useState(false);
@@ -125,16 +127,25 @@ export function SignIn({ onSignInSuccess, onSwitchToSignUp }: Readonly<SignInPro
 
           <div className="form-group">
             <label htmlFor="password">Password</label>
-            <input
-              type="password"
-              id="password"
-              name="password"
-              value={credentials.password}
-              onChange={handleInputChange}
-              placeholder="Enter your password"
-              disabled={isLoading}
-              required
-            />
+            <div className="password-input-wrapper">
+              <input
+                type={isPasswordVisible ? 'text' : 'password'}
+                id="password"
+                name="password"
+                value={credentials.password}
+                onChange={handleInputChange}
+                placeholder="Enter your password"
+                disabled={isLoading}
+                required
+              />
+              <PasswordVisibilityToggle
+                inputId="password"
+                fieldLabel="password"
+                isVisible={isPasswordVisible}
+                onToggle={() => setIsPasswordVisible(visible => !visible)}
+                disabled={isLoading}
+              />
+            </div>
           </div>
 
           <div style={{ 

--- a/src/components/auth/SignUp.tsx
+++ b/src/components/auth/SignUp.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { SignUpCredentials } from '../../services/auth';
+import { PasswordVisibilityToggle } from './PasswordVisibilityToggle';
 import './Auth.css';
 
 interface SignUpProps {
@@ -151,6 +152,8 @@ export function SignUp({ onSignUpSuccess, onSwitchToSignIn }: Readonly<SignUpPro
   });
 
   const [confirmPassword, setConfirmPassword] = useState('');
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isSuccess, setIsSuccess] = useState(false);
@@ -402,16 +405,25 @@ export function SignUp({ onSignUpSuccess, onSwitchToSignIn }: Readonly<SignUpPro
 
             <div className="form-group">
               <label htmlFor="password">Password *</label>
-              <input
-                  id="password"
-                  name="password"
-                  type="password"
-                  value={formData.password}
-                  onChange={handleInputChange}
-                  placeholder="Create a strong password"
+              <div className="password-input-wrapper">
+                <input
+                    id="password"
+                    name="password"
+                    type={isPasswordVisible ? 'text' : 'password'}
+                    value={formData.password}
+                    onChange={handleInputChange}
+                    placeholder="Create a strong password"
+                    disabled={isLoading || isSuccess}
+                    required
+                />
+                <PasswordVisibilityToggle
+                  inputId="password"
+                  fieldLabel="password"
+                  isVisible={isPasswordVisible}
+                  onToggle={() => setIsPasswordVisible(visible => !visible)}
                   disabled={isLoading || isSuccess}
-                  required
-              />
+                />
+              </div>
 
               {/* PASSWORD STRENGTH METER + REQUIREMENTS */}
               {formData.password && (
@@ -460,19 +472,28 @@ export function SignUp({ onSignUpSuccess, onSwitchToSignIn }: Readonly<SignUpPro
 
             <div className="form-group">
               <label htmlFor="confirmPassword">Confirm Password *</label>
-              <input
-                  id="confirmPassword"
-                  name="confirmPassword"
-                  type="password"
-                  value={confirmPassword}
-                  onChange={e => {
-                    setConfirmPassword(e.target.value);
-                    if (error) setError(null);
-                  }}
-                  placeholder="Confirm your password"
+              <div className="password-input-wrapper">
+                <input
+                    id="confirmPassword"
+                    name="confirmPassword"
+                    type={isConfirmPasswordVisible ? 'text' : 'password'}
+                    value={confirmPassword}
+                    onChange={e => {
+                      setConfirmPassword(e.target.value);
+                      if (error) setError(null);
+                    }}
+                    placeholder="Confirm your password"
+                    disabled={isLoading || isSuccess}
+                    required
+                />
+                <PasswordVisibilityToggle
+                  inputId="confirmPassword"
+                  fieldLabel="confirm password"
+                  isVisible={isConfirmPasswordVisible}
+                  onToggle={() => setIsConfirmPasswordVisible(visible => !visible)}
                   disabled={isLoading || isSuccess}
-                  required
-              />
+                />
+              </div>
             </div>
 
             <button


### PR DESCRIPTION
## Summary

Adds accessible password visibility controls to the sign-in and sign-up forms.

## Changes

- Added eye icons for showing and hiding passwords.
- Added independent visibility controls for Password and Confirm Password.
- Created a reusable `PasswordVisibilityToggle` component.
- Added accessible `Show password` and `Hide password` labels.
- Added responsive styling for the visibility controls.
- Added tests for toggling password visibility without changing entered values.

## Testing

- All 10 authentication component tests pass.
- Production build compiles successfully.

