### PR TITLE
Fix stale-closure bug deleting a just-created metamodel's files

### DIFF
--- a/src/components/ui/CreateModelModal.tsx
+++ b/src/components/ui/CreateModelModal.tsx
@@ -281,7 +281,10 @@ export const CreateModelModal: React.FC<CreateModelModalProps> = ({
     genmodel: { progress: 0, isUploading: false }
   });
   const [submitProgress, setSubmitProgress] = useState({ progress: 0, isSubmitting: false });
-  const [metaModelCreatedSuccessfully, setMetaModelCreatedSuccessfully] = useState(false);
+  // Tracked as a ref (not state) since it's only read inside async callbacks/closures that need
+  // the current value synchronously — state updates aren't visible to already-created closures
+  // until the next render.
+  const metaModelCreatedSuccessfullyRef = useRef(false);
 
   const ecoreFileInputRef = useRef<HTMLInputElement>(null);
   const genmodelFileInputRef = useRef<HTMLInputElement>(null);
@@ -495,7 +498,7 @@ export const CreateModelModal: React.FC<CreateModelModalProps> = ({
 
   const cleanupUploadedFiles = async () => {
     // Only delete files if meta model was not created successfully
-    if (metaModelCreatedSuccessfully) {
+    if (metaModelCreatedSuccessfullyRef.current) {
       return;
     }
 
@@ -565,7 +568,7 @@ export const CreateModelModal: React.FC<CreateModelModalProps> = ({
       const response = await apiService.createMetaModel(requestData);
 
       // If backend responds OK, fill to 100% and then close/reset
-      setMetaModelCreatedSuccessfully(true);
+      metaModelCreatedSuccessfullyRef.current = true;
       finishSubmitOverlay(() => {
         setIsLoading(false);
         setSuccess('Meta Model created successfully!');
@@ -621,7 +624,7 @@ export const CreateModelModal: React.FC<CreateModelModalProps> = ({
       ecore: { progress: 0, isUploading: false },
       genmodel: { progress: 0, isUploading: false }
     });
-    setMetaModelCreatedSuccessfully(false);
+    metaModelCreatedSuccessfullyRef.current = false;
     onClose();
   };
 


### PR DESCRIPTION
## Summary
- \`cleanupUploadedFiles()\` in \`CreateModelModal.tsx\` guarded on a \`useState\` flag read inside a callback closure captured *before* the corresponding state update was applied by React, so cleanup still ran after a successful metamodel creation and tried to delete the exact ecore/genmodel files that were just attached to the new \`MetaModel\` entity.
- The backend correctly rejects that delete (FK reference), but it surfaced as a confusing unhandled \`500 INTERNAL_SERVER_ERROR\` in the console right after "Meta Model created successfully!".
- Fix: track the flag with a \`useRef\` instead of \`useState\`, so the guard always reads the current value rather than a stale one — same pattern already used elsewhere in this file for values read inside async callbacks.

Closes #382

## Test plan
- [x] \`npx tsc --noEmit\` — no new errors introduced
- [x] Reproduced the original bug live (pre-fix): DELETE calls fired with errors right after a successful metamodel creation
- [x] Verified live post-fix: fresh metamodel import → \`POST /api/v1/meta-models → 200\` → zero \`DELETE /api/v1/files/...\` calls afterward
- [x] Verified the failure-path cleanup (metamodel creation rejected) still deletes the orphaned uploads correctly