### PR TITLE
Add UI to link meta models and a reaction file to a project

### DIFF
--- a/src/__tests__/components/ui/LinkMetaModelsPanel.test.tsx
+++ b/src/__tests__/components/ui/LinkMetaModelsPanel.test.tsx
@@ -1,0 +1,255 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { LinkMetaModelsPanel } from '../../../components/ui/LinkMetaModelsPanel';
+import { VsumMetaModelRef, VsumMetaModelRelation } from '../../../types';
+
+jest.mock('../../../services/api', () => ({
+  apiService: {
+    findMetaModels: jest.fn(),
+    uploadFile: jest.fn(),
+    syncVsumChanges: jest.fn(),
+  },
+}));
+
+const { apiService } = require('../../../services/api') as {
+  apiService: {
+    findMetaModels: jest.Mock;
+    uploadFile: jest.Mock;
+    syncVsumChanges: jest.Mock;
+  };
+};
+
+const existingMetaModels: VsumMetaModelRef[] = [
+  {
+    id: 101,
+    sourceId: 2,
+    name: 'System Infrastructure Demo',
+    description: '',
+    domain: 'Infrastructure',
+    keyword: [],
+    createdAt: '',
+    updatedAt: '',
+    ecoreFileId: 1,
+    genModelFileId: 2,
+  },
+  {
+    id: 102,
+    sourceId: 5,
+    name: 'Vitruv CLI Model2',
+    description: '',
+    domain: 'Entities',
+    keyword: [],
+    createdAt: '',
+    updatedAt: '',
+    ecoreFileId: 3,
+    genModelFileId: 4,
+  },
+];
+
+const existingRelations: VsumMetaModelRelation[] = [
+  { id: 1, sourceId: 2, targetId: 5, reactionFileStorageId: 35 },
+];
+
+const catalogMetaModels = [
+  { id: 2, name: 'System Infrastructure Demo' },
+  { id: 5, name: 'Vitruv CLI Model2' },
+  { id: 4, name: 'Vitruv CLI Model' },
+];
+
+const reactionsFile = new File(['reactions: x in reaction to changes in a execute actions in b'], 'x.reactions');
+
+const waitForOptionsLoaded = async () => {
+  await waitFor(() => {
+    const [sourceSelect] = screen.getAllByRole('combobox');
+    expect(sourceSelect.querySelectorAll('option').length).toBeGreaterThan(1);
+  });
+};
+
+describe('LinkMetaModelsPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    apiService.findMetaModels.mockResolvedValue({ data: catalogMetaModels, message: null });
+  });
+
+  it('renders existing relations resolved through sourceId, not the vsum-scoped clone id', () => {
+    render(
+      <LinkMetaModelsPanel
+        vsumId={1}
+        existingMetaModels={existingMetaModels}
+        existingRelations={existingRelations}
+        onLinked={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('System Infrastructure Demo')).toBeInTheDocument();
+    expect(screen.getByText('Vitruv CLI Model2')).toBeInTheDocument();
+    expect(screen.getByText('reactions linked')).toBeInTheDocument();
+  });
+
+  it('renders nothing extra when there are no existing relations', () => {
+    render(
+      <LinkMetaModelsPanel
+        vsumId={1}
+        existingMetaModels={[]}
+        existingRelations={[]}
+        onLinked={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByText('Meta Model Relations')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+ Link Meta Models' })).toBeInTheDocument();
+  });
+
+  it('opens the form and loads catalog meta models on demand', async () => {
+    render(
+      <LinkMetaModelsPanel
+        vsumId={1}
+        existingMetaModels={existingMetaModels}
+        existingRelations={existingRelations}
+        onLinked={jest.fn()}
+      />,
+    );
+
+    expect(apiService.findMetaModels).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Link Meta Models' }));
+
+    await waitFor(() => expect(apiService.findMetaModels).toHaveBeenCalled());
+    await waitForOptionsLoaded();
+  });
+
+  it('shows a validation error when submitting without selecting both meta models', async () => {
+    render(
+      <LinkMetaModelsPanel
+        vsumId={1}
+        existingMetaModels={existingMetaModels}
+        existingRelations={existingRelations}
+        onLinked={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Link Meta Models' }));
+    await waitForOptionsLoaded();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Link' }));
+
+    expect(
+      await screen.findByText('Please select both a source and a target meta model.'),
+    ).toBeInTheDocument();
+    expect(apiService.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('shows a validation error when source and target are the same meta model', async () => {
+    render(
+      <LinkMetaModelsPanel
+        vsumId={1}
+        existingMetaModels={existingMetaModels}
+        existingRelations={existingRelations}
+        onLinked={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Link Meta Models' }));
+    await waitForOptionsLoaded();
+
+    const [sourceSelect, targetSelect] = screen.getAllByRole('combobox');
+    fireEvent.change(sourceSelect, { target: { value: '4' } });
+    fireEvent.change(targetSelect, { target: { value: '4' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Link' }));
+
+    expect(
+      await screen.findByText('Source and target meta models must be different.'),
+    ).toBeInTheDocument();
+    expect(apiService.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('uploads the reactions file and merges the new relation with the existing ones on submit', async () => {
+    apiService.uploadFile.mockResolvedValue({ data: { id: 99 }, message: 'ok' });
+    apiService.syncVsumChanges.mockResolvedValue({ data: null, message: 'ok' });
+    const onLinked = jest.fn();
+
+    render(
+      <LinkMetaModelsPanel
+        vsumId={1}
+        existingMetaModels={existingMetaModels}
+        existingRelations={existingRelations}
+        onLinked={onLinked}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Link Meta Models' }));
+    await waitForOptionsLoaded();
+
+    const [sourceSelect, targetSelect] = screen.getAllByRole('combobox');
+    fireEvent.change(sourceSelect, { target: { value: '2' } });
+    fireEvent.change(targetSelect, { target: { value: '4' } });
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [reactionsFile] } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Link' }));
+
+    await waitFor(() => expect(onLinked).toHaveBeenCalled());
+
+    expect(apiService.uploadFile).toHaveBeenCalledWith(reactionsFile, 'REACTION');
+    expect(apiService.syncVsumChanges).toHaveBeenCalledWith(1, {
+      metaModelIds: [2, 5, 4],
+      metaModelRelationRequests: [
+        { sourceId: 2, targetId: 5, reactionFileId: 35 },
+        { sourceId: 2, targetId: 4, reactionFileId: 99 },
+      ],
+    });
+  });
+
+  it('surfaces an error and does not call onLinked when the sync request fails', async () => {
+    apiService.uploadFile.mockResolvedValue({ data: { id: 99 }, message: 'ok' });
+    apiService.syncVsumChanges.mockRejectedValue(new Error('MetaModel Ids not found in this VSUM'));
+    const onLinked = jest.fn();
+
+    render(
+      <LinkMetaModelsPanel
+        vsumId={1}
+        existingMetaModels={existingMetaModels}
+        existingRelations={existingRelations}
+        onLinked={onLinked}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Link Meta Models' }));
+    await waitForOptionsLoaded();
+
+    const [sourceSelect, targetSelect] = screen.getAllByRole('combobox');
+    fireEvent.change(sourceSelect, { target: { value: '2' } });
+    fireEvent.change(targetSelect, { target: { value: '4' } });
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [reactionsFile] } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Link' }));
+
+    expect(
+      await screen.findByText('MetaModel Ids not found in this VSUM'),
+    ).toBeInTheDocument();
+    expect(onLinked).not.toHaveBeenCalled();
+  });
+
+  it('cancel hides the form and resets its state', async () => {
+    render(
+      <LinkMetaModelsPanel
+        vsumId={1}
+        existingMetaModels={existingMetaModels}
+        existingRelations={existingRelations}
+        onLinked={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Link Meta Models' }));
+    await waitForOptionsLoaded();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.queryByRole('button', { name: 'Link' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+ Link Meta Models' })).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/LinkMetaModelsPanel.tsx
+++ b/src/components/ui/LinkMetaModelsPanel.tsx
@@ -1,0 +1,310 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { apiService } from '../../services/api';
+import { VsumMetaModelRef, VsumMetaModelRelation } from '../../types';
+
+interface MetaModelOption {
+  id: number;
+  name: string;
+}
+
+interface Props {
+  vsumId: number;
+  existingMetaModels: VsumMetaModelRef[];
+  existingRelations: VsumMetaModelRelation[];
+  onLinked: () => void;
+}
+
+const sectionLabel: React.CSSProperties = {
+  fontSize: 13,
+  fontWeight: 700,
+  color: '#2c3e50',
+  marginTop: 16,
+  marginBottom: 8,
+  fontFamily: 'Georgia, serif',
+  letterSpacing: '0.01em',
+};
+
+const relationRow: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '8px 12px',
+  borderRadius: 8,
+  border: '1px solid #e9ecef',
+  background: '#f8f9fa',
+  fontSize: 13,
+  marginBottom: 6,
+};
+
+const addButton: React.CSSProperties = {
+  padding: '8px 16px',
+  borderRadius: 8,
+  border: '1px dashed #049484',
+  background: '#f0faf8',
+  color: '#049484',
+  fontWeight: 600,
+  fontSize: 13,
+  cursor: 'pointer',
+  fontFamily: 'Georgia, serif',
+};
+
+const formBox: React.CSSProperties = {
+  marginTop: 12,
+  padding: 16,
+  borderRadius: 10,
+  border: '2px dashed #049484',
+  background: '#f8fcff',
+};
+
+const selectStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '10px 12px',
+  border: '2px solid #e9ecef',
+  borderRadius: 8,
+  fontSize: 14,
+  fontFamily: 'Georgia, serif',
+  background: '#fff',
+  marginBottom: 12,
+};
+
+const fileButton: React.CSSProperties = {
+  padding: '10px 14px',
+  border: '2px solid #049484',
+  borderRadius: 8,
+  background: '#fff',
+  color: '#2c3e50',
+  fontSize: 13,
+  fontWeight: 600,
+  cursor: 'pointer',
+  fontFamily: 'Georgia, serif',
+};
+
+export const LinkMetaModelsPanel: React.FC<Props> = ({
+  vsumId,
+  existingMetaModels,
+  existingRelations,
+  onLinked,
+}) => {
+  const [showForm, setShowForm] = useState(false);
+  const [options, setOptions] = useState<MetaModelOption[]>([]);
+  const [optionsLoading, setOptionsLoading] = useState(false);
+  const [optionsError, setOptionsError] = useState('');
+  const [sourceId, setSourceId] = useState<number | ''>('');
+  const [targetId, setTargetId] = useState<number | ''>('');
+  const [reactionFile, setReactionFile] = useState<File | null>(null);
+  const [linking, setLinking] = useState(false);
+  const [linkError, setLinkError] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!showForm) return;
+    let cancelled = false;
+    const load = async () => {
+      setOptionsLoading(true);
+      setOptionsError('');
+      try {
+        const res = await apiService.findMetaModels({ pageSize: 200 });
+        if (!cancelled) {
+          setOptions((res.data || []).map((m: any) => ({ id: m.id, name: m.name })));
+        }
+      } catch (e: any) {
+        if (!cancelled) setOptionsError(e?.message || 'Failed to load meta models');
+      } finally {
+        if (!cancelled) setOptionsLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [showForm]);
+
+  const nameFor = (id: number): string =>
+    existingMetaModels.find((m) => m.id === id)?.name ?? `#${id}`;
+
+  const resetForm = () => {
+    setSourceId('');
+    setTargetId('');
+    setReactionFile(null);
+    setLinkError('');
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleLink = async () => {
+    if (!sourceId || !targetId) {
+      setLinkError('Please select both a source and a target meta model.');
+      return;
+    }
+    if (sourceId === targetId) {
+      setLinkError('Source and target meta models must be different.');
+      return;
+    }
+    if (!reactionFile) {
+      setLinkError('Please upload a .reactions file.');
+      return;
+    }
+
+    setLinking(true);
+    setLinkError('');
+    try {
+      const uploadRes = await apiService.uploadFile(reactionFile, 'REACTION');
+      const rawData: any = uploadRes.data;
+      const reactionFileId =
+        rawData && typeof rawData === 'object' && 'id' in rawData
+          ? Number(rawData.id)
+          : Number(rawData);
+      if (!Number.isFinite(reactionFileId)) {
+        throw new Error('Reaction file upload did not return a valid file id.');
+      }
+
+      const metaModelIds = Array.from(
+        new Set([...existingMetaModels.map((m) => m.id), sourceId, targetId])
+      );
+      const metaModelRelationRequests = [
+        ...existingRelations.map((r) => ({
+          sourceId: r.sourceId,
+          targetId: r.targetId,
+          reactionFileId: (r.reactionFileId ?? r.reactionFileStorageId) as number,
+        })),
+        { sourceId, targetId, reactionFileId },
+      ];
+
+      await apiService.syncVsumChanges(vsumId, { metaModelIds, metaModelRelationRequests });
+
+      resetForm();
+      setShowForm(false);
+      onLinked();
+    } catch (e: any) {
+      setLinkError(e?.response?.data?.message || e?.message || 'Failed to link meta models');
+    } finally {
+      setLinking(false);
+    }
+  };
+
+  return (
+    <div>
+      {existingRelations.length > 0 && (
+        <>
+          <div style={sectionLabel}>Meta Model Relations</div>
+          {existingRelations.map((r) => (
+            <div key={r.id} style={relationRow}>
+              <span style={{ fontWeight: 700, color: '#2c3e50' }}>{nameFor(r.sourceId)}</span>
+              <span style={{ color: '#049484' }}>→</span>
+              <span style={{ fontWeight: 700, color: '#2c3e50' }}>{nameFor(r.targetId)}</span>
+              {(r.reactionFileId ?? r.reactionFileStorageId) && (
+                <span style={{ marginLeft: 'auto', color: '#6c757d', fontStyle: 'italic' }}>
+                  reactions linked
+                </span>
+              )}
+            </div>
+          ))}
+        </>
+      )}
+
+      {!showForm && (
+        <button style={addButton} onClick={() => setShowForm(true)}>
+          + Link Meta Models
+        </button>
+      )}
+
+      {showForm && (
+        <div style={formBox}>
+          {optionsLoading && (
+            <div style={{ fontSize: 13, color: '#6c757d', fontStyle: 'italic', marginBottom: 12 }}>
+              Loading meta models…
+            </div>
+          )}
+          {optionsError && (
+            <div style={{ fontSize: 13, color: '#721c24', marginBottom: 12 }}>{optionsError}</div>
+          )}
+
+          <div style={sectionLabel}>Source Meta Model</div>
+          <select
+            style={selectStyle}
+            value={sourceId}
+            onChange={(e) => setSourceId(e.target.value ? Number(e.target.value) : '')}
+          >
+            <option value="">Select source meta model…</option>
+            {options.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.name}
+              </option>
+            ))}
+          </select>
+
+          <div style={sectionLabel}>Target Meta Model</div>
+          <select
+            style={selectStyle}
+            value={targetId}
+            onChange={(e) => setTargetId(e.target.value ? Number(e.target.value) : '')}
+          >
+            <option value="">Select target meta model…</option>
+            {options.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.name}
+              </option>
+            ))}
+          </select>
+
+          <div style={sectionLabel}>Reactions File</div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".reactions"
+            style={{ display: 'none' }}
+            onChange={(e) => setReactionFile(e.target.files?.[0] ?? null)}
+          />
+          <button style={fileButton} onClick={() => fileInputRef.current?.click()}>
+            {reactionFile ? `✓ ${reactionFile.name}` : 'Upload .reactions'}
+          </button>
+
+          {linkError && (
+            <div style={{ marginTop: 12, fontSize: 13, color: '#721c24' }}>{linkError}</div>
+          )}
+
+          <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
+            <button
+              style={{
+                padding: '10px 20px',
+                borderRadius: 8,
+                border: 'none',
+                background: linking
+                  ? '#a5d6d3'
+                  : 'linear-gradient(135deg, #049484 0%, #037368 100%)',
+                color: '#fff',
+                fontWeight: 600,
+                fontSize: 14,
+                cursor: linking ? 'not-allowed' : 'pointer',
+                fontFamily: 'Georgia, serif',
+              }}
+              onClick={handleLink}
+              disabled={linking}
+            >
+              {linking ? 'Linking…' : 'Link'}
+            </button>
+            <button
+              style={{
+                padding: '10px 20px',
+                borderRadius: 8,
+                border: '1px solid #dee2e6',
+                background: '#fff',
+                color: '#495057',
+                fontWeight: 600,
+                fontSize: 14,
+                cursor: 'pointer',
+                fontFamily: 'Georgia, serif',
+              }}
+              onClick={() => {
+                resetForm();
+                setShowForm(false);
+              }}
+              disabled={linking}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/ui/LinkMetaModelsPanel.tsx
+++ b/src/components/ui/LinkMetaModelsPanel.tsx
@@ -119,8 +119,12 @@ export const LinkMetaModelsPanel: React.FC<Props> = ({
     };
   }, [showForm]);
 
+  // existingMetaModels[].id is the VSUM-scoped clone id created when the metamodel was linked
+  // (see VsumMetaModelService#create on the backend); relations and the catalog (findMetaModels,
+  // the select options below) all speak in terms of the original metamodel's id, exposed here as
+  // sourceId. Matching must go through sourceId, not id.
   const nameFor = (id: number): string =>
-    existingMetaModels.find((m) => m.id === id)?.name ?? `#${id}`;
+    existingMetaModels.find((m) => m.sourceId === id)?.name ?? `#${id}`;
 
   const resetForm = () => {
     setSourceId('');
@@ -157,8 +161,10 @@ export const LinkMetaModelsPanel: React.FC<Props> = ({
         throw new Error('Reaction file upload did not return a valid file id.');
       }
 
+      // sync-changes expects catalog metamodel ids (the same ones the select options above use),
+      // not the VSUM-scoped clone ids in existingMetaModels[].id -- see the note on nameFor above.
       const metaModelIds = Array.from(
-        new Set([...existingMetaModels.map((m) => m.id), sourceId, targetId])
+        new Set([...existingMetaModels.map((m) => m.sourceId), sourceId, targetId])
       );
       const metaModelRelationRequests = [
         ...existingRelations.map((r) => ({

--- a/src/components/ui/VsumDetailsModal.tsx
+++ b/src/components/ui/VsumDetailsModal.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { apiService } from '../../services/api';
 import { VsumDetails } from '../../types';
 import { VsumUsersTab } from './VsumUsersTab';
+import { LinkMetaModelsPanel } from './LinkMetaModelsPanel';
 
 interface Props {
   isOpen: boolean;
@@ -662,23 +663,26 @@ export const VsumDetailsModal: React.FC<Props> = ({ isOpen, vsumId, onClose, onS
     };
   }, [isOpen]);
 
+  const reloadDetails = async () => {
+    if (!vsumId) return;
+    setLoading(true);
+    setError('');
+    try {
+      const res = await apiService.getVsumDetails(vsumId);
+      const d = res.data;
+      setDetails(d);
+      setName(d.name ?? '');
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load details');
+    } finally {
+      setLoading(false);
+    }
+  };
+
   useEffect(() => {
     if (!isOpen || !vsumId) return;
-    const load = async () => {
-      setLoading(true);
-      setError('');
-      try {
-        const res = await apiService.getVsumDetails(vsumId);
-        const d = res.data;
-        setDetails(d);
-        setName(d.name ?? '');
-      } catch (e: any) {
-        setError(e?.message || 'Failed to load details');
-      } finally {
-        setLoading(false);
-      }
-    };
-    load();
+    reloadDetails();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, vsumId]);
 
   useEffect(() => {
@@ -792,9 +796,18 @@ export const VsumDetailsModal: React.FC<Props> = ({ isOpen, vsumId, onClose, onS
             ))}
           </ul>
         ) : (
-          <div style={{ fontSize: 12, color: '#6c757d', fontStyle: 'italic' }}>
+          <div style={{ fontSize: 12, color: '#6c757d', fontStyle: 'italic', marginBottom: 8 }}>
             No meta models linked.
           </div>
+        )}
+
+        {vsumId && (
+          <LinkMetaModelsPanel
+            vsumId={vsumId}
+            existingMetaModels={details.metaModels ?? []}
+            existingRelations={details.metaModelsRelation ?? []}
+            onLinked={reloadDetails}
+          />
         )}
       </>
     );


### PR DESCRIPTION
## Summary
- The backend has fully supported linking two meta models plus a reaction file to a VSUM via `PUT /sync-changes` for a while, but there was no UI to reach it — a project's detail panel just said "No meta models linked." with no way to change that.
- Adds `LinkMetaModelsPanel`: pick a source and target meta model from the ones already imported, upload a `.reactions` file, and save.
- The project details panel now also renders existing meta model relations (source → target, with a "reactions linked" indicator) instead of just a flat list of names.
- Since `sync-changes` treats its payload as the desired full state rather than an incremental add, linking a new relation preserves and merges in the full existing set of linked meta models/relations rather than replacing them.

Closes #386

## Depends on
This surfaced a real backend bug when linking a relation for a meta model that's being added to the VSUM in the *same* request (a brand-new project with nothing linked yet, picking two never-before-linked meta models) — see vitruv-tools/methodologistUI-backend#266, fixed there. Adding a relation between meta models that are already linked to the project works regardless.

## Test plan
- [x] `npx tsc --noEmit` — no new errors introduced
- [x] Verified live end-to-end: existing relation data (created via direct API calls in an earlier session) renders correctly as "SourceName → TargetName (reactions linked)"
- [x] Verified live end-to-end: fresh project, pick two never-before-linked meta models, upload a `.reactions` file, click Link — succeeds in one request and the relation renders immediately (requires the backend fix above)