### PR TITLE
Cherry-pick #383 and #387 onto develop

### DIFF
--- a/src/__tests__/components/ui/LinkMetaModelsPanel.test.tsx
+++ b/src/__tests__/components/ui/LinkMetaModelsPanel.test.tsx
@@ -1,0 +1,255 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { LinkMetaModelsPanel } from '../../../components/ui/LinkMetaModelsPanel';
+import { VsumMetaModelRef, VsumMetaModelRelation } from '../../../types';
+
+jest.mock('../../../services/api', () => ({
+  apiService: {
+    findMetaModels: jest.fn(),
+    uploadFile: jest.fn(),
+    syncVsumChanges: jest.fn(),
+  },
+}));
+
+const { apiService } = require('../../../services/api') as {
+  apiService: {
+    findMetaModels: jest.Mock;
+    uploadFile: jest.Mock;
+    syncVsumChanges: jest.Mock;
+  };
+};
+
+const existingMetaModels: VsumMetaModelRef[] = [
+  {
+    id: 101,
+    sourceId: 2,
+    name: 'System Infrastructure Demo',
+    description: '',
+    domain: 'Infrastructure',
+    keyword: [],
+    createdAt: '',
+    updatedAt: '',
+    ecoreFileId: 1,
+    genModelFileId: 2,
+  },
+  {
+    id: 102,
+    sourceId: 5,
+    name: 'Vitruv CLI Model2',
+    description: '',
+    domain: 'Entities',
+    keyword: [],
+    createdAt: '',
+    updatedAt: '',
+    ecoreFileId: 3,
+    genModelFileId: 4,
+  },
+];
+
+const existingRelations: VsumMetaModelRelation[] = [
+  { id: 1, sourceId: 2, targetId: 5, reactionFileStorageId: 35 },
+];
+
+const catalogMetaModels = [
+  { id: 2, name: 'System Infrastructure Demo' },
+  { id: 5, name: 'Vitruv CLI Model2' },
+  { id: 4, name: 'Vitruv CLI Model' },
+];
+
+const reactionsFile = new File(['reactions: x in reaction to changes in a execute actions in b'], 'x.reactions');
+
+const waitForOptionsLoaded = async () => {
+  await waitFor(() => {
+    const [sourceSelect] = screen.getAllByRole('combobox');
+    expect(sourceSelect.querySelectorAll('option').length).toBeGreaterThan(1);
+  });
+};
+
+describe('LinkMetaModelsPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    apiService.findMetaModels.mockResolvedValue({ data: catalogMetaModels, message: null });
+  });
+
+  it('renders existing relations resolved through sourceId, not the vsum-scoped clone id', () => {
+    render(
+      <LinkMetaModelsPanel
+        vsumId={1}
+        existingMetaModels={existingMetaModels}
+        existingRelations={existingRelations}
+        onLinked={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('System Infrastructure Demo')).toBeInTheDocument();
+    expect(screen.getByText('Vitruv CLI Model2')).toBeInTheDocument();
+    expect(screen.getByText('reactions linked')).toBeInTheDocument();
+  });
+
+  it('renders nothing extra when there are no existing relations', () => {
+    render(
+      <LinkMetaModelsPanel
+        vsumId={1}
+        existingMetaModels={[]}
+        existingRelations={[]}
+        onLinked={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByText('Meta Model Relations')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+ Link Meta Models' })).toBeInTheDocument();
+  });
+
+  it('opens the form and loads catalog meta models on demand', async () => {
+    render(
+      <LinkMetaModelsPanel
+        vsumId={1}
+        existingMetaModels={existingMetaModels}
+        existingRelations={existingRelations}
+        onLinked={jest.fn()}
+      />,
+    );
+
+    expect(apiService.findMetaModels).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Link Meta Models' }));
+
+    await waitFor(() => expect(apiService.findMetaModels).toHaveBeenCalled());
+    await waitForOptionsLoaded();
+  });
+
+  it('shows a validation error when submitting without selecting both meta models', async () => {
+    render(
+      <LinkMetaModelsPanel
+        vsumId={1}
+        existingMetaModels={existingMetaModels}
+        existingRelations={existingRelations}
+        onLinked={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Link Meta Models' }));
+    await waitForOptionsLoaded();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Link' }));
+
+    expect(
+      await screen.findByText('Please select both a source and a target meta model.'),
+    ).toBeInTheDocument();
+    expect(apiService.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('shows a validation error when source and target are the same meta model', async () => {
+    render(
+      <LinkMetaModelsPanel
+        vsumId={1}
+        existingMetaModels={existingMetaModels}
+        existingRelations={existingRelations}
+        onLinked={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Link Meta Models' }));
+    await waitForOptionsLoaded();
+
+    const [sourceSelect, targetSelect] = screen.getAllByRole('combobox');
+    fireEvent.change(sourceSelect, { target: { value: '4' } });
+    fireEvent.change(targetSelect, { target: { value: '4' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Link' }));
+
+    expect(
+      await screen.findByText('Source and target meta models must be different.'),
+    ).toBeInTheDocument();
+    expect(apiService.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('uploads the reactions file and merges the new relation with the existing ones on submit', async () => {
+    apiService.uploadFile.mockResolvedValue({ data: { id: 99 }, message: 'ok' });
+    apiService.syncVsumChanges.mockResolvedValue({ data: null, message: 'ok' });
+    const onLinked = jest.fn();
+
+    render(
+      <LinkMetaModelsPanel
+        vsumId={1}
+        existingMetaModels={existingMetaModels}
+        existingRelations={existingRelations}
+        onLinked={onLinked}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Link Meta Models' }));
+    await waitForOptionsLoaded();
+
+    const [sourceSelect, targetSelect] = screen.getAllByRole('combobox');
+    fireEvent.change(sourceSelect, { target: { value: '2' } });
+    fireEvent.change(targetSelect, { target: { value: '4' } });
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [reactionsFile] } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Link' }));
+
+    await waitFor(() => expect(onLinked).toHaveBeenCalled());
+
+    expect(apiService.uploadFile).toHaveBeenCalledWith(reactionsFile, 'REACTION');
+    expect(apiService.syncVsumChanges).toHaveBeenCalledWith(1, {
+      metaModelIds: [2, 5, 4],
+      metaModelRelationRequests: [
+        { sourceId: 2, targetId: 5, reactionFileId: 35 },
+        { sourceId: 2, targetId: 4, reactionFileId: 99 },
+      ],
+    });
+  });
+
+  it('surfaces an error and does not call onLinked when the sync request fails', async () => {
+    apiService.uploadFile.mockResolvedValue({ data: { id: 99 }, message: 'ok' });
+    apiService.syncVsumChanges.mockRejectedValue(new Error('MetaModel Ids not found in this VSUM'));
+    const onLinked = jest.fn();
+
+    render(
+      <LinkMetaModelsPanel
+        vsumId={1}
+        existingMetaModels={existingMetaModels}
+        existingRelations={existingRelations}
+        onLinked={onLinked}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Link Meta Models' }));
+    await waitForOptionsLoaded();
+
+    const [sourceSelect, targetSelect] = screen.getAllByRole('combobox');
+    fireEvent.change(sourceSelect, { target: { value: '2' } });
+    fireEvent.change(targetSelect, { target: { value: '4' } });
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [reactionsFile] } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Link' }));
+
+    expect(
+      await screen.findByText('MetaModel Ids not found in this VSUM'),
+    ).toBeInTheDocument();
+    expect(onLinked).not.toHaveBeenCalled();
+  });
+
+  it('cancel hides the form and resets its state', async () => {
+    render(
+      <LinkMetaModelsPanel
+        vsumId={1}
+        existingMetaModels={existingMetaModels}
+        existingRelations={existingRelations}
+        onLinked={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Link Meta Models' }));
+    await waitForOptionsLoaded();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.queryByRole('button', { name: 'Link' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+ Link Meta Models' })).toBeInTheDocument();
+  });
+});

--- a/src/components/canvas/ModelDrawer.tsx
+++ b/src/components/canvas/ModelDrawer.tsx
@@ -143,7 +143,7 @@ export const ModelDrawer: React.FC<ModelDrawerProps> = ({
         gap: 8,
       }}>
         {detailModel ? (
-          <button
+          <button type="button"
             onClick={closeDetail}
             style={{
               display: 'flex', alignItems: 'center', gap: 5,
@@ -162,7 +162,7 @@ export const ModelDrawer: React.FC<ModelDrawerProps> = ({
           </span>
         )}
 
-        <button
+        <button type="button"
           onClick={onClose}
           style={{
             border: 'none', background: 'transparent', cursor: 'pointer',
@@ -278,7 +278,7 @@ const LibraryView: React.FC<LibraryViewProps> = ({
             {/* Tab strip */}
             <div style={{ display: 'flex', borderRadius: 8, overflow: 'hidden', border: '1px solid #e2e8f0', marginBottom: 10 }}>
               {(['my', 'public'] as const).map(tab => (
-                <button key={tab} onClick={() => switchTab(tab)} style={{
+                <button type="button" key={tab} onClick={() => switchTab(tab)} style={{
                   flex: 1, padding: '7px 0', border: 'none', fontSize: 11, fontWeight: 600,
                   cursor: 'pointer', letterSpacing: '0.04em', textTransform: 'uppercase',
                   background: libTab === tab ? DARK : '#f8fafc',
@@ -312,7 +312,7 @@ const LibraryView: React.FC<LibraryViewProps> = ({
                 onBlur={e => (e.currentTarget.style.borderColor = '#e2e8f0')}
               />
               {search && (
-                <button onClick={() => setSearch('')} style={{
+                <button type="button" onClick={() => setSearch('')} style={{
                   position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)',
                   border: 'none', background: 'none', cursor: 'pointer',
                   color: '#94a3b8', fontSize: 14, lineHeight: 1, padding: 2,
@@ -327,7 +327,7 @@ const LibraryView: React.FC<LibraryViewProps> = ({
                   const active = domainFilter === domain;
                   const theme = getTheme(domain);
                   return (
-                    <button key={domain} onClick={() => setDomainFilter(active ? null : domain)} style={{
+                    <button type="button" key={domain} onClick={() => setDomainFilter(active ? null : domain)} style={{
                       padding: '3px 9px', border: 'none', borderRadius: 20,
                       fontSize: 10, fontWeight: 600, cursor: 'pointer', letterSpacing: '0.03em',
                       background: active ? theme.badge : '#f1f5f9',
@@ -512,7 +512,7 @@ const DetailView: React.FC<DetailViewProps> = ({ model, onFetchFile, onAddModel,
                 Already on canvas
               </div>
             ) : (
-              <button
+              <button type="button"
                 onClick={() => onAddModel(model)}
                 style={{
                   width: '100%', padding: '9px 0', border: 'none', borderRadius: 8,
@@ -530,7 +530,7 @@ const DetailView: React.FC<DetailViewProps> = ({ model, onFetchFile, onAddModel,
               </button>
             )}
             {onDelete && (
-              <button
+              <button type="button"
                 onClick={onDelete}
                 title="Delete meta-model"
                 style={{
@@ -652,7 +652,7 @@ const FieldLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 const PreviewBtn: React.FC<{ title: string; onClick: () => void; children: React.ReactNode }> = ({ title, onClick, children }) => {
   const [hov, setHov] = React.useState(false);
   return (
-    <button
+    <button type="button"
       title={title} onClick={onClick}
       onMouseEnter={() => setHov(true)} onMouseLeave={() => setHov(false)}
       style={{
@@ -761,7 +761,7 @@ const ModelCard: React.FC<ModelCardProps> = ({ model, onCanvas, onAdd, onOpenDet
   }
 
   return (
-    <button
+    <button type="button"
       onClick={() => onAdd(model)}
       onContextMenu={handleContextMenu}
       onMouseEnter={() => setHovered(true)}

--- a/src/components/constraints/ConstraintsView.tsx
+++ b/src/components/constraints/ConstraintsView.tsx
@@ -425,7 +425,7 @@ const RuleRow: React.FC<{ rule: ConstraintRule; selected: boolean; onClick: () =
         transition: 'background 0.1s',
       }}
     >
-      <button
+      <button type="button"
         onClick={onClick}
         style={{
           display: 'flex', alignItems: 'center', gap: 8, width: '100%',
@@ -442,7 +442,7 @@ const RuleRow: React.FC<{ rule: ConstraintRule; selected: boolean; onClick: () =
         </span>
       </button>
       <div ref={menuRef} style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)' }}>
-        <button
+        <button type="button"
           onClick={e => { e.stopPropagation(); setMenuOpen(o => !o); }}
           style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 2, color: '#94a3b8', borderRadius: 4, display: 'flex', alignItems: 'center' }}
           title="Options"
@@ -461,7 +461,7 @@ const RuleRow: React.FC<{ rule: ConstraintRule; selected: boolean; onClick: () =
               minWidth: 140, padding: '4px 0',
             }}
           >
-            <button
+            <button type="button"
               onClick={() => { setMenuOpen(false); onDelete(); }}
               style={{
                 display: 'flex', alignItems: 'center', gap: 8,
@@ -513,7 +513,7 @@ const RuleSetSection: React.FC<RuleSetSectionProps> = ({ ruleSet, selectedRuleId
           borderBottom: '1px solid #f1f5f9',
         }}
       >
-        <button
+        <button type="button"
           onClick={() => onRuleSetClick(ruleSet)}
           style={{
             display: 'flex', alignItems: 'center', gap: 8, flex: 1,
@@ -525,7 +525,7 @@ const RuleSetSection: React.FC<RuleSetSectionProps> = ({ ruleSet, selectedRuleId
           <span style={{ fontSize: 12.5, fontWeight: 600, color: '#1e293b', flex: 1 }}>{ruleSet.name}</span>
           <span style={{ fontSize: 11, color: '#94a3b8', fontWeight: 500 }}>{ruleSet.rules.length} rules</span>
         </button>
-        <button
+        <button type="button"
           onClick={() => onToggleCollapse(ruleSet.id)}
           style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '8px 12px 8px 4px', display: 'flex', alignItems: 'center' }}
         >
@@ -542,7 +542,7 @@ const RuleSetSection: React.FC<RuleSetSectionProps> = ({ ruleSet, selectedRuleId
           {ruleSet.rules.map(rule => (
             <RuleRow key={rule.id} rule={rule} selected={selectedRuleId === rule.id} onClick={() => onRuleClick(rule)} onDelete={() => onDeleteRule(rule.id)} />
           ))}
-          <button
+          <button type="button"
             onClick={() => onAddRule(ruleSet.id)}
             style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px 6px 28px', cursor: 'pointer', color: '#94a3b8', fontSize: 12, background: 'none', border: 'none', width: '100%', textAlign: 'left' }}
             onMouseEnter={e => (e.currentTarget.style.color = '#049484')}
@@ -658,7 +658,7 @@ const ContextClassPicker: React.FC<{
 
   return (
     <div ref={containerRef} style={{ position: 'relative' }}>
-      <button
+      <button type="button"
         style={{ ...inputBase, display: 'flex', alignItems: 'center', justifyContent: 'space-between', userSelect: 'none' }}
         onClick={() => { setOpen(o => !o); setQuery(''); }}
       >
@@ -762,7 +762,7 @@ const SaveChangesButton: React.FC<{ onSave: () => void }> = ({ onSave }) => {
   else { btnLabel = 'Save Changes'; }
 
   return (
-    <button
+    <button type="button"
       onClick={handleClick}
       disabled={saving}
       style={{
@@ -915,7 +915,7 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
           <span style={{ fontSize: 13, fontWeight: 600, color: '#0f172a', flex: 1 }}>
             Editing: {draft.name}
           </span>
-          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', padding: 4, borderRadius: 4, display: 'flex', alignItems: 'center' }}>
+          <button type="button" onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', padding: 4, borderRadius: 4, display: 'flex', alignItems: 'center' }}>
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
           </button>
         </div>
@@ -958,7 +958,7 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
                 {SEVERITY_OPTIONS.map(opt => {
                   const active = draft.severity === opt.value;
                   return (
-                    <button key={opt.value} onClick={() => handleSeverityChange(opt.value)} style={{ padding: '3px 10px', borderRadius: 12, fontSize: 11, fontWeight: 600, cursor: 'pointer', border: `1.5px solid ${active ? opt.color : '#e2e8f0'}`, background: active ? opt.bg : '#fff', color: active ? opt.color : '#94a3b8', transition: 'all 0.12s' }}>
+                    <button type="button" key={opt.value} onClick={() => handleSeverityChange(opt.value)} style={{ padding: '3px 10px', borderRadius: 12, fontSize: 11, fontWeight: 600, cursor: 'pointer', border: `1.5px solid ${active ? opt.color : '#e2e8f0'}`, background: active ? opt.bg : '#fff', color: active ? opt.color : '#94a3b8', transition: 'all 0.12s' }}>
                       {opt.label}
                     </button>
                   );
@@ -1053,7 +1053,7 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
               <span style={{ fontSize: 11, color: '#334155', fontWeight: 500 }}>{draft.linkedReactions ?? 0}</span>
             </div>
             <SaveChangesButton onSave={() => onSave(draft)} />
-            <button onClick={() => setFullEditorOpen(true)} style={{ width: '100%', marginTop: 6, padding: '7px 0', background: 'transparent', color: '#049484', border: '1px solid #049484', borderRadius: 6, fontSize: 12, fontWeight: 500, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
+            <button type="button" onClick={() => setFullEditorOpen(true)} style={{ width: '100%', marginTop: 6, padding: '7px 0', background: 'transparent', color: '#049484', border: '1px solid #049484', borderRadius: 6, fontSize: 12, fontWeight: 500, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15,3 21,3 21,9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
               Open in Full Editor
             </button>
@@ -1152,7 +1152,7 @@ const MetricsPanel: React.FC<MetricsPanelProps> = ({ ruleSets, colorMap }) => {
           </div>
         ))}
 
-        <button
+        <button type="button"
           onClick={() => setDetailOpen(true)}
           style={{ width: '100%', marginTop: 14, padding: '9px 0', background: 'transparent', color: '#049484', border: '1px solid #049484', borderRadius: 6, fontSize: 12, fontWeight: 500, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}
         >
@@ -1177,7 +1177,7 @@ const DetailedMetricsModal: React.FC<{ ruleSets: RuleSet[]; colorMap: Record<str
       open
       style={{ position: 'fixed', inset: 0, width: '100%', height: '100%', background: 'none', border: 'none', padding: 0, margin: 0, zIndex: 2000, display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden' }}
     >
-      <button onClick={onClose} aria-label="Close" style={{ position: 'absolute', inset: 0, background: 'rgba(15,23,42,0.35)', border: 'none', cursor: 'default', padding: 0 }} />
+      <button type="button" onClick={onClose} aria-label="Close" style={{ position: 'absolute', inset: 0, background: 'rgba(15,23,42,0.35)', border: 'none', cursor: 'default', padding: 0 }} />
       <div style={{
         position: 'relative', zIndex: 1,
         background: '#fff', borderRadius: 14, width: '88%', maxWidth: 1040,
@@ -1188,7 +1188,7 @@ const DetailedMetricsModal: React.FC<{ ruleSets: RuleSet[]; colorMap: Record<str
         {/* Header */}
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '16px 22px', borderBottom: '1px solid #f1f5f9', flexShrink: 0 }}>
           <span style={{ fontSize: 15, fontWeight: 700, color: '#0f172a' }}>Detailed Metrics</span>
-          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', fontSize: 20, lineHeight: 1 }}>×</button>
+          <button type="button" onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', fontSize: 20, lineHeight: 1 }}>×</button>
         </div>
 
         {/* Body — fixed height so scroll kicks in after ~2-3 rulesets */}
@@ -1335,7 +1335,7 @@ const RuleSetPanel: React.FC<{
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
           {onDelete && (
-            <button
+            <button type="button"
               onClick={() => { onDelete(); onClose(); }}
               style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#ef4444', fontSize: 11.5, fontWeight: 600, padding: '3px 8px', borderRadius: 5, fontFamily: APP_FONT }}
               onMouseEnter={e => (e.currentTarget.style.background = '#fef2f2')}
@@ -1343,7 +1343,7 @@ const RuleSetPanel: React.FC<{
               title="Delete Rule Set"
             >Delete</button>
           )}
-          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', fontSize: 18, lineHeight: 1 }}>×</button>
+          <button type="button" onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', fontSize: 18, lineHeight: 1 }}>×</button>
         </div>
       </div>
 
@@ -1373,7 +1373,7 @@ const RuleSetPanel: React.FC<{
           <label htmlFor="rsp-color" style={labelStyle}>Color</label>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
             {PRESET_COLORS.map(c => (
-              <button
+              <button type="button"
                 key={c}
                 onClick={() => setDraft(d => ({ ...d, color: c }))}
                 style={{
@@ -1395,7 +1395,7 @@ const RuleSetPanel: React.FC<{
 
       {/* Footer with Save */}
       <div style={{ padding: '10px 16px', borderTop: '1px solid #f1f5f9', flexShrink: 0, display: 'flex', justifyContent: 'flex-end' }}>
-        <button
+        <button type="button"
           onClick={handleSave}
           disabled={saving}
           style={{
@@ -1468,7 +1468,7 @@ const LeftPanel: React.FC<LeftPanelProps> = ({
       <div style={{ padding: '14px 14px 10px', borderBottom: '1px solid #f1f5f9', flexShrink: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
           <span style={{ fontSize: 13, fontWeight: 700, color: '#0f172a' }}>Constraint Sets</span>
-          <button
+          <button type="button"
             onClick={onAddSet}
             style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 11.5, color: '#049484', background: 'none', border: 'none', cursor: 'pointer', fontWeight: 500, padding: '3px 6px', borderRadius: 5 }}
             onMouseEnter={e => (e.currentTarget.style.background = '#f0fdf9')}

--- a/src/components/flow/FlowCanvas.tsx
+++ b/src/components/flow/FlowCanvas.tsx
@@ -2569,7 +2569,7 @@ export const FlowCanvas = forwardRef<{
               ...(readOnly ? [] : [{ label: 'Constraints', mode: 'constraints' as CanvasMode, icon: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg> }]),
               { label: 'Views', mode: 'views' as CanvasMode, icon: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="9"/><line x1="12" y1="3" x2="12" y2="21"/><line x1="3" y1="12" x2="21" y2="12"/></svg> },
             ]).map(({ label, mode, icon }) => (
-              <button
+              <button type="button"
                 key={label}
                 onClick={() => {
                   setActiveCanvasMode(mode);

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -97,7 +97,7 @@ const NavItem: React.FC<NavItemProps> = ({ icon, label, active, onClick, badgeCo
   }
 
   return (
-    <button
+    <button type="button"
       onClick={onClick}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
@@ -179,7 +179,7 @@ const MenuItem: React.FC<MenuItemProps> = ({ icon, label, sublabel, danger = fal
   }
 
   return (
-    <button
+    <button type="button"
       onClick={onClick}
       onMouseEnter={() => setHov(true)}
       onMouseLeave={() => setHov(false)}
@@ -250,7 +250,7 @@ export const AppSidebar: React.FC<AppSidebarProps> = ({
 
       {/* Logo */}
       <div style={{ padding: '20px 16px 16px', borderBottom: '1px solid rgba(255,255,255,0.06)', flexShrink: 0 }}>
-        <button
+        <button type="button"
           onClick={() => onViewChange('home')}
           style={{
             display: 'flex', alignItems: 'center', gap: 6,
@@ -340,7 +340,7 @@ export const AppSidebar: React.FC<AppSidebarProps> = ({
         {/* Border above user card */}
         <div style={{ borderTop: '1px solid rgba(255,255,255,0.07)', padding: '10px 12px 12px' }}>
           {/* User card */}
-          <button
+          <button type="button"
             onClick={() => setMenuOpen(v => !v)}
             onMouseEnter={() => setUserHovered(true)}
             onMouseLeave={() => setUserHovered(false)}

--- a/src/components/ui/ChangePasswordModal.tsx
+++ b/src/components/ui/ChangePasswordModal.tsx
@@ -144,7 +144,7 @@ const ModalButton: React.FC<{
     opacity = 0.6;
   }
   return (
-    <button
+    <button type="button"
       onClick={onClick}
       disabled={isDisabled}
       onMouseEnter={() => setHov(true)}

--- a/src/components/ui/CreateModelModal.tsx
+++ b/src/components/ui/CreateModelModal.tsx
@@ -788,7 +788,10 @@ function useCreateModelForm({ isOpen, onClose, onSuccess }: CreateModelModalProp
     genmodel: { progress: 0, isUploading: false },
   });
   const [submitProgress, setSubmitProgress] = useState({ progress: 0, isSubmitting: false });
-  const [metaModelCreatedSuccessfully, setMetaModelCreatedSuccessfully] = useState(false);
+  // Tracked as a ref (not state) since it's only read inside async callbacks/closures that need
+  // the current value synchronously — state updates aren't visible to already-created closures
+  // until the next render.
+  const metaModelCreatedSuccessfullyRef = useRef(false);
   const [showGenModelFixPrompt, setShowGenModelFixPrompt] = useState(false);
   const [pendingCreateRequest, setPendingCreateRequest] = useState<CreateModelRequest | null>(null);
   const [scrollTarget, setScrollTarget] = useState<CreateModelFieldKey | null>(null);
@@ -951,7 +954,7 @@ function useCreateModelForm({ isOpen, onClose, onSuccess }: CreateModelModalProp
     responseData: any,
     requestData?: CreateModelRequest,
   ) => {
-    setMetaModelCreatedSuccessfully(true);
+    metaModelCreatedSuccessfullyRef.current = true;
     finishSubmitOverlay(() => {
       setIsLoading(false);
       setSuccess(message);
@@ -965,7 +968,7 @@ function useCreateModelForm({ isOpen, onClose, onSuccess }: CreateModelModalProp
   // ── File cleanup ──────────────────────────────────────────────────────────
 
   const cleanupUploadedFiles = async () => {
-    if (metaModelCreatedSuccessfully) return;
+    if (metaModelCreatedSuccessfullyRef.current) return;
     const filesToDelete = [uploadedFileIds.ecoreFileId, uploadedFileIds.genModelFileId].filter(id => id > 0);
     await Promise.all(
       filesToDelete.map(fileId =>
@@ -1003,7 +1006,7 @@ function useCreateModelForm({ isOpen, onClose, onSuccess }: CreateModelModalProp
     setSuccess('');
     setIsLoading(false);
     setUploadProgress({ ecore: { progress: 0, isUploading: false }, genmodel: { progress: 0, isUploading: false } });
-    setMetaModelCreatedSuccessfully(false);
+    metaModelCreatedSuccessfullyRef.current = false;
     setShowGenModelFixPrompt(false);
     setPendingCreateRequest(null);
     setPerKind(EMPTY_PER_KIND);

--- a/src/components/ui/LandingView.tsx
+++ b/src/components/ui/LandingView.tsx
@@ -62,7 +62,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ title, subtitle, items, cta, 
   const [hovered, setHovered] = useState(false);
 
   return (
-    <button
+    <button type="button"
       onClick={onNavigate}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}

--- a/src/components/ui/LinkMetaModelsPanel.tsx
+++ b/src/components/ui/LinkMetaModelsPanel.tsx
@@ -1,0 +1,310 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { apiService } from '../../services/api';
+import { VsumMetaModelRef, VsumMetaModelRelation } from '../../types';
+
+interface MetaModelOption {
+  id: number;
+  name: string;
+}
+
+interface Props {
+  vsumId: number;
+  existingMetaModels: VsumMetaModelRef[];
+  existingRelations: VsumMetaModelRelation[];
+  onLinked: () => void;
+}
+
+const sectionLabel: React.CSSProperties = {
+  fontSize: 13,
+  fontWeight: 700,
+  color: '#2c3e50',
+  marginTop: 16,
+  marginBottom: 8,
+  fontFamily: 'Georgia, serif',
+  letterSpacing: '0.01em',
+};
+
+const relationRow: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '8px 12px',
+  borderRadius: 8,
+  border: '1px solid #e9ecef',
+  background: '#f8f9fa',
+  fontSize: 13,
+  marginBottom: 6,
+};
+
+const addButton: React.CSSProperties = {
+  padding: '8px 16px',
+  borderRadius: 8,
+  border: '1px dashed #049484',
+  background: '#f0faf8',
+  color: '#049484',
+  fontWeight: 600,
+  fontSize: 13,
+  cursor: 'pointer',
+  fontFamily: 'Georgia, serif',
+};
+
+const formBox: React.CSSProperties = {
+  marginTop: 12,
+  padding: 16,
+  borderRadius: 10,
+  border: '2px dashed #049484',
+  background: '#f8fcff',
+};
+
+const selectStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '10px 12px',
+  border: '2px solid #e9ecef',
+  borderRadius: 8,
+  fontSize: 14,
+  fontFamily: 'Georgia, serif',
+  background: '#fff',
+  marginBottom: 12,
+};
+
+const fileButton: React.CSSProperties = {
+  padding: '10px 14px',
+  border: '2px solid #049484',
+  borderRadius: 8,
+  background: '#fff',
+  color: '#2c3e50',
+  fontSize: 13,
+  fontWeight: 600,
+  cursor: 'pointer',
+  fontFamily: 'Georgia, serif',
+};
+
+export const LinkMetaModelsPanel: React.FC<Props> = ({
+  vsumId,
+  existingMetaModels,
+  existingRelations,
+  onLinked,
+}) => {
+  const [showForm, setShowForm] = useState(false);
+  const [options, setOptions] = useState<MetaModelOption[]>([]);
+  const [optionsLoading, setOptionsLoading] = useState(false);
+  const [optionsError, setOptionsError] = useState('');
+  const [sourceId, setSourceId] = useState<number | ''>('');
+  const [targetId, setTargetId] = useState<number | ''>('');
+  const [reactionFile, setReactionFile] = useState<File | null>(null);
+  const [linking, setLinking] = useState(false);
+  const [linkError, setLinkError] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!showForm) return;
+    let cancelled = false;
+    const load = async () => {
+      setOptionsLoading(true);
+      setOptionsError('');
+      try {
+        const res = await apiService.findMetaModels({ pageSize: 200 });
+        if (!cancelled) {
+          setOptions((res.data || []).map((m: any) => ({ id: m.id, name: m.name })));
+        }
+      } catch (e: any) {
+        if (!cancelled) setOptionsError(e?.message || 'Failed to load meta models');
+      } finally {
+        if (!cancelled) setOptionsLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [showForm]);
+
+  const nameFor = (id: number): string =>
+    existingMetaModels.find((m) => m.id === id)?.name ?? `#${id}`;
+
+  const resetForm = () => {
+    setSourceId('');
+    setTargetId('');
+    setReactionFile(null);
+    setLinkError('');
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleLink = async () => {
+    if (!sourceId || !targetId) {
+      setLinkError('Please select both a source and a target meta model.');
+      return;
+    }
+    if (sourceId === targetId) {
+      setLinkError('Source and target meta models must be different.');
+      return;
+    }
+    if (!reactionFile) {
+      setLinkError('Please upload a .reactions file.');
+      return;
+    }
+
+    setLinking(true);
+    setLinkError('');
+    try {
+      const uploadRes = await apiService.uploadFile(reactionFile, 'REACTION');
+      const rawData: any = uploadRes.data;
+      const reactionFileId =
+        rawData && typeof rawData === 'object' && 'id' in rawData
+          ? Number(rawData.id)
+          : Number(rawData);
+      if (!Number.isFinite(reactionFileId)) {
+        throw new Error('Reaction file upload did not return a valid file id.');
+      }
+
+      const metaModelIds = Array.from(
+        new Set([...existingMetaModels.map((m) => m.id), sourceId, targetId])
+      );
+      const metaModelRelationRequests = [
+        ...existingRelations.map((r) => ({
+          sourceId: r.sourceId,
+          targetId: r.targetId,
+          reactionFileId: (r.reactionFileId ?? r.reactionFileStorageId) as number,
+        })),
+        { sourceId, targetId, reactionFileId },
+      ];
+
+      await apiService.syncVsumChanges(vsumId, { metaModelIds, metaModelRelationRequests });
+
+      resetForm();
+      setShowForm(false);
+      onLinked();
+    } catch (e: any) {
+      setLinkError(e?.response?.data?.message || e?.message || 'Failed to link meta models');
+    } finally {
+      setLinking(false);
+    }
+  };
+
+  return (
+    <div>
+      {existingRelations.length > 0 && (
+        <>
+          <div style={sectionLabel}>Meta Model Relations</div>
+          {existingRelations.map((r) => (
+            <div key={r.id} style={relationRow}>
+              <span style={{ fontWeight: 700, color: '#2c3e50' }}>{nameFor(r.sourceId)}</span>
+              <span style={{ color: '#049484' }}>→</span>
+              <span style={{ fontWeight: 700, color: '#2c3e50' }}>{nameFor(r.targetId)}</span>
+              {(r.reactionFileId ?? r.reactionFileStorageId) && (
+                <span style={{ marginLeft: 'auto', color: '#6c757d', fontStyle: 'italic' }}>
+                  reactions linked
+                </span>
+              )}
+            </div>
+          ))}
+        </>
+      )}
+
+      {!showForm && (
+        <button style={addButton} onClick={() => setShowForm(true)}>
+          + Link Meta Models
+        </button>
+      )}
+
+      {showForm && (
+        <div style={formBox}>
+          {optionsLoading && (
+            <div style={{ fontSize: 13, color: '#6c757d', fontStyle: 'italic', marginBottom: 12 }}>
+              Loading meta models…
+            </div>
+          )}
+          {optionsError && (
+            <div style={{ fontSize: 13, color: '#721c24', marginBottom: 12 }}>{optionsError}</div>
+          )}
+
+          <div style={sectionLabel}>Source Meta Model</div>
+          <select
+            style={selectStyle}
+            value={sourceId}
+            onChange={(e) => setSourceId(e.target.value ? Number(e.target.value) : '')}
+          >
+            <option value="">Select source meta model…</option>
+            {options.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.name}
+              </option>
+            ))}
+          </select>
+
+          <div style={sectionLabel}>Target Meta Model</div>
+          <select
+            style={selectStyle}
+            value={targetId}
+            onChange={(e) => setTargetId(e.target.value ? Number(e.target.value) : '')}
+          >
+            <option value="">Select target meta model…</option>
+            {options.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.name}
+              </option>
+            ))}
+          </select>
+
+          <div style={sectionLabel}>Reactions File</div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".reactions"
+            style={{ display: 'none' }}
+            onChange={(e) => setReactionFile(e.target.files?.[0] ?? null)}
+          />
+          <button style={fileButton} onClick={() => fileInputRef.current?.click()}>
+            {reactionFile ? `✓ ${reactionFile.name}` : 'Upload .reactions'}
+          </button>
+
+          {linkError && (
+            <div style={{ marginTop: 12, fontSize: 13, color: '#721c24' }}>{linkError}</div>
+          )}
+
+          <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
+            <button
+              style={{
+                padding: '10px 20px',
+                borderRadius: 8,
+                border: 'none',
+                background: linking
+                  ? '#a5d6d3'
+                  : 'linear-gradient(135deg, #049484 0%, #037368 100%)',
+                color: '#fff',
+                fontWeight: 600,
+                fontSize: 14,
+                cursor: linking ? 'not-allowed' : 'pointer',
+                fontFamily: 'Georgia, serif',
+              }}
+              onClick={handleLink}
+              disabled={linking}
+            >
+              {linking ? 'Linking…' : 'Link'}
+            </button>
+            <button
+              style={{
+                padding: '10px 20px',
+                borderRadius: 8,
+                border: '1px solid #dee2e6',
+                background: '#fff',
+                color: '#495057',
+                fontWeight: 600,
+                fontSize: 14,
+                cursor: 'pointer',
+                fontFamily: 'Georgia, serif',
+              }}
+              onClick={() => {
+                resetForm();
+                setShowForm(false);
+              }}
+              disabled={linking}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/ui/LinkMetaModelsPanel.tsx
+++ b/src/components/ui/LinkMetaModelsPanel.tsx
@@ -119,8 +119,12 @@ export const LinkMetaModelsPanel: React.FC<Props> = ({
     };
   }, [showForm]);
 
+  // existingMetaModels[].id is the VSUM-scoped clone id created when the metamodel was linked
+  // (see VsumMetaModelService#create on the backend); relations and the catalog (findMetaModels,
+  // the select options below) all speak in terms of the original metamodel's id, exposed here as
+  // sourceId. Matching must go through sourceId, not id.
   const nameFor = (id: number): string =>
-    existingMetaModels.find((m) => m.id === id)?.name ?? `#${id}`;
+    existingMetaModels.find((m) => m.sourceId === id)?.name ?? `#${id}`;
 
   const resetForm = () => {
     setSourceId('');
@@ -157,8 +161,10 @@ export const LinkMetaModelsPanel: React.FC<Props> = ({
         throw new Error('Reaction file upload did not return a valid file id.');
       }
 
+      // sync-changes expects catalog metamodel ids (the same ones the select options above use),
+      // not the VSUM-scoped clone ids in existingMetaModels[].id -- see the note on nameFor above.
       const metaModelIds = Array.from(
-        new Set([...existingMetaModels.map((m) => m.id), sourceId, targetId])
+        new Set([...existingMetaModels.map((m) => m.sourceId), sourceId, targetId])
       );
       const metaModelRelationRequests = [
         ...existingRelations.map((r) => ({

--- a/src/components/ui/LinkMetaModelsPanel.tsx
+++ b/src/components/ui/LinkMetaModelsPanel.tsx
@@ -158,7 +158,7 @@ export const LinkMetaModelsPanel: React.FC<Props> = ({
           ? Number(rawData.id)
           : Number(rawData);
       if (!Number.isFinite(reactionFileId)) {
-        throw new Error('Reaction file upload did not return a valid file id.');
+        throw new TypeError('Reaction file upload did not return a valid file id.');
       }
 
       // sync-changes expects catalog metamodel ids (the same ones the select options above use),
@@ -208,7 +208,7 @@ export const LinkMetaModelsPanel: React.FC<Props> = ({
       )}
 
       {!showForm && (
-        <button style={addButton} onClick={() => setShowForm(true)}>
+        <button type="button" style={addButton} onClick={() => setShowForm(true)}>
           + Link Meta Models
         </button>
       )}
@@ -260,7 +260,7 @@ export const LinkMetaModelsPanel: React.FC<Props> = ({
             style={{ display: 'none' }}
             onChange={(e) => setReactionFile(e.target.files?.[0] ?? null)}
           />
-          <button style={fileButton} onClick={() => fileInputRef.current?.click()}>
+          <button type="button" style={fileButton} onClick={() => fileInputRef.current?.click()}>
             {reactionFile ? `✓ ${reactionFile.name}` : 'Upload .reactions'}
           </button>
 
@@ -270,6 +270,7 @@ export const LinkMetaModelsPanel: React.FC<Props> = ({
 
           <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
             <button
+              type="button"
               style={{
                 padding: '10px 20px',
                 borderRadius: 8,
@@ -289,6 +290,7 @@ export const LinkMetaModelsPanel: React.FC<Props> = ({
               {linking ? 'Linking…' : 'Link'}
             </button>
             <button
+              type="button"
               style={{
                 padding: '10px 20px',
                 borderRadius: 8,

--- a/src/components/ui/ModelLibraryTable.tsx
+++ b/src/components/ui/ModelLibraryTable.tsx
@@ -113,7 +113,7 @@ const detailFieldLabelSt: React.CSSProperties = { display: 'block', fontSize: 11
 const DPreviewBtn: React.FC<{ title: string; onClick: () => void; children: React.ReactNode }> = ({ title, onClick, children }) => {
   const [hov, setHov] = React.useState(false);
   return (
-    <button title={title} onClick={onClick} onMouseEnter={() => setHov(true)} onMouseLeave={() => setHov(false)}
+    <button type="button" title={title} onClick={onClick} onMouseEnter={() => setHov(true)} onMouseLeave={() => setHov(false)}
       style={{ width: 24, height: 24, border: '1px solid #e2e8f0', borderRadius: 6, background: hov ? '#f1f5f9' : '#fff', color: hov ? '#0f172a' : '#64748b', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'all 0.12s' }}>
       {children}
     </button>
@@ -206,7 +206,7 @@ export const ModelDetailModal: React.FC<ModelDetailModalProps> = ({
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
             {!editing && (
-              <button
+              <button type="button"
                 onClick={() => {
                   setForm({ name: displayModel.name || '', description: displayModel.description || '', domain: displayModel.domain || '', keywords: displayModel.keyword || [] });
                   setEditing(true);
@@ -223,7 +223,7 @@ export const ModelDetailModal: React.FC<ModelDetailModalProps> = ({
                 Edit
               </button>
             )}
-            <button
+            <button type="button"
               onClick={onClose}
               style={{ border: 'none', background: 'transparent', cursor: 'pointer', color: '#94a3b8', fontSize: 16, width: 30, height: 30, borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'all 0.1s' }}
               onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = '#f1f5f9'; (e.currentTarget as HTMLButtonElement).style.color = '#374151'; }}
@@ -861,7 +861,7 @@ export const ModelLibraryTable: React.FC<ModelLibraryTableProps> = ({ onModelOpe
       {/* Page header */}
       <div style={{ padding: '32px 40px 0', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
         <h1 style={{ margin: 0, fontSize: 26, fontWeight: 700, color: '#111827', letterSpacing: '-0.02em' }}>Model Library</h1>
-        <button
+        <button type="button"
           onClick={() => setShowCreate(true)}
           style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '9px 18px', background: '#0B1720', color: '#fff', border: 'none', borderRadius: 9, fontSize: 14, fontWeight: 600, cursor: 'pointer', boxShadow: '0 1px 4px rgba(11,23,32,0.25)', transition: 'background 0.15s', fontFamily: 'ui-sans-serif, system-ui, sans-serif' }}
           onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = '#0B1720'; }}
@@ -1108,7 +1108,7 @@ const PageBtn: React.FC<PageBtnProps> = ({ children, active, disabled, onClick }
   }
 
   return (
-  <button
+  <button type="button"
     onClick={onClick}
     disabled={disabled}
     style={{

--- a/src/components/ui/ProfileView.tsx
+++ b/src/components/ui/ProfileView.tsx
@@ -238,7 +238,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <div style={{ fontSize: 14, fontWeight: 700, color: '#111827' }}>Account Details</div>
             {!editing && (
-              <button
+              <button type="button"
                 onClick={handleEditOpen}
                 style={{
                   display: 'flex', alignItems: 'center', gap: 6,
@@ -280,7 +280,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
               )}
 
               <div style={{ display: 'flex', gap: 10 }}>
-                <button
+                <button type="button"
                   onClick={handleSave}
                   disabled={saving}
                   style={{
@@ -293,7 +293,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
                 >
                   <CheckIcon /> {saving ? 'Saving…' : 'Save changes'}
                 </button>
-                <button
+                <button type="button"
                   onClick={handleCancel}
                   disabled={saving}
                   style={{
@@ -357,7 +357,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
               Min. 8 characters · uppercase · lowercase · digit · special character
             </div>
           </div>
-          <button
+          <button type="button"
             onClick={changePassword.open}
             style={{
               display: 'flex', alignItems: 'center', gap: 7,

--- a/src/components/ui/ProjectsView.tsx
+++ b/src/components/ui/ProjectsView.tsx
@@ -182,7 +182,7 @@ const ProjectRow: React.FC<ProjectRowProps> = ({
       {/* Actions */}
       <td style={{ padding: '13px 16px' }} onClick={e => e.stopPropagation()}>
         {showDeleted ? (
-          <button
+          <button type="button"
             onClick={onRecover}
             style={{ padding: '6px 14px', border: 'none', borderRadius: 7, background: '#10b981', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer', transition: 'background 0.15s' }}
             onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = '#059669'; }}
@@ -433,7 +433,7 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({
       {/* Page header */}
       <div style={{ padding: '32px 40px 0', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
         <h1 style={{ margin: 0, fontSize: 26, fontWeight: 700, color: '#111827', letterSpacing: '-0.02em' }}>Dashboard / Projects</h1>
-        <button
+        <button type="button"
           onClick={() => setShowCreate(true)}
           disabled={projectView === 'shared' || projectView === 'deleted'}
           style={{
@@ -476,7 +476,7 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({
             { key: 'shared' as const, label: 'Shared with me' },
             { key: 'deleted' as const, label: 'Deleted projects' },
           ]).map(({ key, label }) => (
-            <button
+            <button type="button"
               key={key}
               onClick={() => setProjectView(key)}
               style={{

--- a/src/components/ui/VsumDetailsModal.tsx
+++ b/src/components/ui/VsumDetailsModal.tsx
@@ -4,6 +4,7 @@ import { apiService } from '../../services/api';
 import { VsumDetails } from '../../types';
 import { VsumUsersTab } from './VsumUsersTab';
 import { MODAL_Z_INDEX, useModalBodyLock } from './modalUtils';
+import { LinkMetaModelsPanel } from './LinkMetaModelsPanel';
 
 interface Props {
   isOpen: boolean;
@@ -619,23 +620,26 @@ export const VsumDetailsModal: React.FC<Props> = ({ isOpen, vsumId, onClose, onS
     };
   }, [isOpen]);
 
+  const reloadDetails = async () => {
+    if (!vsumId) return;
+    setLoading(true);
+    setError('');
+    try {
+      const res = await apiService.getVsumDetails(vsumId);
+      const d = res.data;
+      setDetails(d);
+      setName(d.name ?? '');
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load details');
+    } finally {
+      setLoading(false);
+    }
+  };
+
   useEffect(() => {
     if (!isOpen || !vsumId) return;
-    const load = async () => {
-      setLoading(true);
-      setError('');
-      try {
-        const res = await apiService.getVsumDetails(vsumId);
-        const d = res.data;
-        setDetails(d);
-        setName(d.name ?? '');
-      } catch (e: any) {
-        setError(e?.message || 'Failed to load details');
-      } finally {
-        setLoading(false);
-      }
-    };
-    load();
+    reloadDetails();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, vsumId]);
 
   useEffect(() => {
@@ -753,9 +757,18 @@ export const VsumDetailsModal: React.FC<Props> = ({ isOpen, vsumId, onClose, onS
             ))}
           </ul>
         ) : (
-          <div style={{ fontSize: 12, color: '#6c757d', fontStyle: 'italic' }}>
+          <div style={{ fontSize: 12, color: '#6c757d', fontStyle: 'italic', marginBottom: 8 }}>
             No meta models linked.
           </div>
+        )}
+
+        {vsumId && (
+          <LinkMetaModelsPanel
+            vsumId={vsumId}
+            existingMetaModels={details.metaModels ?? []}
+            existingRelations={details.metaModelsRelation ?? []}
+            onLinked={reloadDetails}
+          />
         )}
       </>
     );

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -3061,7 +3061,7 @@ function getPillBtnColor(active: boolean | undefined, hovered: boolean): string 
 const PillBtn: React.FC<PillBtnProps> = ({ onClick, title, children, active, spinning }) => {
   const [hov, setHov] = useState(false);
   return (
-    <button
+    <button type="button"
       onClick={onClick}
       title={title}
       onMouseEnter={() => setHov(true)}


### PR DESCRIPTION
## Summary

Ports the two already-merged \`main\` fixes onto \`develop\`, which has diverged significantly (146 commits ahead / 49 behind \`main\`) so a straight merge of \`main\` isn't appropriate here — this only carries these two specific fixes.

- #383 — stale-closure bug that deleted a just-created metamodel's own files right after a successful create. \`develop\` has since restructured \`CreateModelModal\`'s submit flow into shared \`prepareSubmit()\`/\`onSubmitSuccess()\` helpers, so the original commit didn't apply directly — reapplied the same fix (ref instead of state, read synchronously) onto the current structure.
- #387 — adds the "Link Meta Models" UI (source/target meta model + \`.reactions\` upload) to the project details panel, replacing the static "No meta models linked." message. Cherry-picked cleanly except for one import-line conflict in \`VsumDetailsModal.tsx\` (develop had independently added a \`modalUtils\` import in the same spot).

## Test plan
- [x] \`npx tsc --noEmit\` — clean on all touched files
- [x] Full test suite for the three affected files: 50/50 passing (\`LinkMetaModelsPanel\`, \`VsumDetailsModal\`, \`CreateModelModal\`)