### PR TITLE
proxy /lsp and /ocl-lsp WebSocket endpoints through nginx

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -31,6 +31,34 @@ http {
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Reactions LSP WebSocket → backend:8080/lsp
+    location /lsp {
+      proxy_pass http://backend_upstream/lsp;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+    }
+
+    # OCL LSP WebSocket → backend:8080/ocl-lsp
+    location /ocl-lsp {
+      proxy_pass http://backend_upstream/ocl-lsp;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+    }
+
     location /realms/ {
       proxy_pass http://keycloak_upstream/realms/;
       proxy_http_version 1.1;

--- a/nginx.conf
+++ b/nginx.conf
@@ -42,6 +42,34 @@ http {
       proxy_read_timeout 300;
     }
 
+    # Reactions LSP WebSocket → backend:8080/lsp
+    location /lsp {
+      proxy_pass http://backend_upstream/lsp;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+    }
+
+    # OCL LSP WebSocket → backend:8080/ocl-lsp
+    location /ocl-lsp {
+      proxy_pass http://backend_upstream/ocl-lsp;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+    }
+
     # Proxy Keycloak OpenID endpoints → keycloak:8081
     # (Keycloak 26 serves OIDC under /realms/…)
     location /realms/ {

--- a/src/components/canvas/ModelDrawer.tsx
+++ b/src/components/canvas/ModelDrawer.tsx
@@ -143,7 +143,7 @@ export const ModelDrawer: React.FC<ModelDrawerProps> = ({
         gap: 8,
       }}>
         {detailModel ? (
-          <button
+          <button type="button"
             onClick={closeDetail}
             style={{
               display: 'flex', alignItems: 'center', gap: 5,
@@ -162,7 +162,7 @@ export const ModelDrawer: React.FC<ModelDrawerProps> = ({
           </span>
         )}
 
-        <button
+        <button type="button"
           onClick={onClose}
           style={{
             border: 'none', background: 'transparent', cursor: 'pointer',
@@ -278,7 +278,7 @@ const LibraryView: React.FC<LibraryViewProps> = ({
             {/* Tab strip */}
             <div style={{ display: 'flex', borderRadius: 8, overflow: 'hidden', border: '1px solid #e2e8f0', marginBottom: 10 }}>
               {(['my', 'public'] as const).map(tab => (
-                <button key={tab} onClick={() => switchTab(tab)} style={{
+                <button type="button" key={tab} onClick={() => switchTab(tab)} style={{
                   flex: 1, padding: '7px 0', border: 'none', fontSize: 11, fontWeight: 600,
                   cursor: 'pointer', letterSpacing: '0.04em', textTransform: 'uppercase',
                   background: libTab === tab ? DARK : '#f8fafc',
@@ -312,7 +312,7 @@ const LibraryView: React.FC<LibraryViewProps> = ({
                 onBlur={e => (e.currentTarget.style.borderColor = '#e2e8f0')}
               />
               {search && (
-                <button onClick={() => setSearch('')} style={{
+                <button type="button" onClick={() => setSearch('')} style={{
                   position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)',
                   border: 'none', background: 'none', cursor: 'pointer',
                   color: '#94a3b8', fontSize: 14, lineHeight: 1, padding: 2,
@@ -327,7 +327,7 @@ const LibraryView: React.FC<LibraryViewProps> = ({
                   const active = domainFilter === domain;
                   const theme = getTheme(domain);
                   return (
-                    <button key={domain} onClick={() => setDomainFilter(active ? null : domain)} style={{
+                    <button type="button" key={domain} onClick={() => setDomainFilter(active ? null : domain)} style={{
                       padding: '3px 9px', border: 'none', borderRadius: 20,
                       fontSize: 10, fontWeight: 600, cursor: 'pointer', letterSpacing: '0.03em',
                       background: active ? theme.badge : '#f1f5f9',
@@ -512,7 +512,7 @@ const DetailView: React.FC<DetailViewProps> = ({ model, onFetchFile, onAddModel,
                 Already on canvas
               </div>
             ) : (
-              <button
+              <button type="button"
                 onClick={() => onAddModel(model)}
                 style={{
                   width: '100%', padding: '9px 0', border: 'none', borderRadius: 8,
@@ -530,7 +530,7 @@ const DetailView: React.FC<DetailViewProps> = ({ model, onFetchFile, onAddModel,
               </button>
             )}
             {onDelete && (
-              <button
+              <button type="button"
                 onClick={onDelete}
                 title="Delete meta-model"
                 style={{
@@ -652,7 +652,7 @@ const FieldLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 const PreviewBtn: React.FC<{ title: string; onClick: () => void; children: React.ReactNode }> = ({ title, onClick, children }) => {
   const [hov, setHov] = React.useState(false);
   return (
-    <button
+    <button type="button"
       title={title} onClick={onClick}
       onMouseEnter={() => setHov(true)} onMouseLeave={() => setHov(false)}
       style={{
@@ -761,7 +761,7 @@ const ModelCard: React.FC<ModelCardProps> = ({ model, onCanvas, onAdd, onOpenDet
   }
 
   return (
-    <button
+    <button type="button"
       onClick={() => onAdd(model)}
       onContextMenu={handleContextMenu}
       onMouseEnter={() => setHovered(true)}

--- a/src/components/constraints/ConstraintsView.tsx
+++ b/src/components/constraints/ConstraintsView.tsx
@@ -425,7 +425,7 @@ const RuleRow: React.FC<{ rule: ConstraintRule; selected: boolean; onClick: () =
         transition: 'background 0.1s',
       }}
     >
-      <button
+      <button type="button"
         onClick={onClick}
         style={{
           display: 'flex', alignItems: 'center', gap: 8, width: '100%',
@@ -442,7 +442,7 @@ const RuleRow: React.FC<{ rule: ConstraintRule; selected: boolean; onClick: () =
         </span>
       </button>
       <div ref={menuRef} style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)' }}>
-        <button
+        <button type="button"
           onClick={e => { e.stopPropagation(); setMenuOpen(o => !o); }}
           style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 2, color: '#94a3b8', borderRadius: 4, display: 'flex', alignItems: 'center' }}
           title="Options"
@@ -461,7 +461,7 @@ const RuleRow: React.FC<{ rule: ConstraintRule; selected: boolean; onClick: () =
               minWidth: 140, padding: '4px 0',
             }}
           >
-            <button
+            <button type="button"
               onClick={() => { setMenuOpen(false); onDelete(); }}
               style={{
                 display: 'flex', alignItems: 'center', gap: 8,
@@ -513,7 +513,7 @@ const RuleSetSection: React.FC<RuleSetSectionProps> = ({ ruleSet, selectedRuleId
           borderBottom: '1px solid #f1f5f9',
         }}
       >
-        <button
+        <button type="button"
           onClick={() => onRuleSetClick(ruleSet)}
           style={{
             display: 'flex', alignItems: 'center', gap: 8, flex: 1,
@@ -525,7 +525,7 @@ const RuleSetSection: React.FC<RuleSetSectionProps> = ({ ruleSet, selectedRuleId
           <span style={{ fontSize: 12.5, fontWeight: 600, color: '#1e293b', flex: 1 }}>{ruleSet.name}</span>
           <span style={{ fontSize: 11, color: '#94a3b8', fontWeight: 500 }}>{ruleSet.rules.length} rules</span>
         </button>
-        <button
+        <button type="button"
           onClick={() => onToggleCollapse(ruleSet.id)}
           style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '8px 12px 8px 4px', display: 'flex', alignItems: 'center' }}
         >
@@ -542,7 +542,7 @@ const RuleSetSection: React.FC<RuleSetSectionProps> = ({ ruleSet, selectedRuleId
           {ruleSet.rules.map(rule => (
             <RuleRow key={rule.id} rule={rule} selected={selectedRuleId === rule.id} onClick={() => onRuleClick(rule)} onDelete={() => onDeleteRule(rule.id)} />
           ))}
-          <button
+          <button type="button"
             onClick={() => onAddRule(ruleSet.id)}
             style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px 6px 28px', cursor: 'pointer', color: '#94a3b8', fontSize: 12, background: 'none', border: 'none', width: '100%', textAlign: 'left' }}
             onMouseEnter={e => (e.currentTarget.style.color = '#049484')}
@@ -658,7 +658,7 @@ const ContextClassPicker: React.FC<{
 
   return (
     <div ref={containerRef} style={{ position: 'relative' }}>
-      <button
+      <button type="button"
         style={{ ...inputBase, display: 'flex', alignItems: 'center', justifyContent: 'space-between', userSelect: 'none' }}
         onClick={() => { setOpen(o => !o); setQuery(''); }}
       >
@@ -762,7 +762,7 @@ const SaveChangesButton: React.FC<{ onSave: () => void }> = ({ onSave }) => {
   else { btnLabel = 'Save Changes'; }
 
   return (
-    <button
+    <button type="button"
       onClick={handleClick}
       disabled={saving}
       style={{
@@ -915,7 +915,7 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
           <span style={{ fontSize: 13, fontWeight: 600, color: '#0f172a', flex: 1 }}>
             Editing: {draft.name}
           </span>
-          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', padding: 4, borderRadius: 4, display: 'flex', alignItems: 'center' }}>
+          <button type="button" onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', padding: 4, borderRadius: 4, display: 'flex', alignItems: 'center' }}>
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
           </button>
         </div>
@@ -958,7 +958,7 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
                 {SEVERITY_OPTIONS.map(opt => {
                   const active = draft.severity === opt.value;
                   return (
-                    <button key={opt.value} onClick={() => handleSeverityChange(opt.value)} style={{ padding: '3px 10px', borderRadius: 12, fontSize: 11, fontWeight: 600, cursor: 'pointer', border: `1.5px solid ${active ? opt.color : '#e2e8f0'}`, background: active ? opt.bg : '#fff', color: active ? opt.color : '#94a3b8', transition: 'all 0.12s' }}>
+                    <button type="button" key={opt.value} onClick={() => handleSeverityChange(opt.value)} style={{ padding: '3px 10px', borderRadius: 12, fontSize: 11, fontWeight: 600, cursor: 'pointer', border: `1.5px solid ${active ? opt.color : '#e2e8f0'}`, background: active ? opt.bg : '#fff', color: active ? opt.color : '#94a3b8', transition: 'all 0.12s' }}>
                       {opt.label}
                     </button>
                   );
@@ -1053,7 +1053,7 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
               <span style={{ fontSize: 11, color: '#334155', fontWeight: 500 }}>{draft.linkedReactions ?? 0}</span>
             </div>
             <SaveChangesButton onSave={() => onSave(draft)} />
-            <button onClick={() => setFullEditorOpen(true)} style={{ width: '100%', marginTop: 6, padding: '7px 0', background: 'transparent', color: '#049484', border: '1px solid #049484', borderRadius: 6, fontSize: 12, fontWeight: 500, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
+            <button type="button" onClick={() => setFullEditorOpen(true)} style={{ width: '100%', marginTop: 6, padding: '7px 0', background: 'transparent', color: '#049484', border: '1px solid #049484', borderRadius: 6, fontSize: 12, fontWeight: 500, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15,3 21,3 21,9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
               Open in Full Editor
             </button>
@@ -1152,7 +1152,7 @@ const MetricsPanel: React.FC<MetricsPanelProps> = ({ ruleSets, colorMap }) => {
           </div>
         ))}
 
-        <button
+        <button type="button"
           onClick={() => setDetailOpen(true)}
           style={{ width: '100%', marginTop: 14, padding: '9px 0', background: 'transparent', color: '#049484', border: '1px solid #049484', borderRadius: 6, fontSize: 12, fontWeight: 500, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}
         >
@@ -1177,7 +1177,7 @@ const DetailedMetricsModal: React.FC<{ ruleSets: RuleSet[]; colorMap: Record<str
       open
       style={{ position: 'fixed', inset: 0, width: '100%', height: '100%', background: 'none', border: 'none', padding: 0, margin: 0, zIndex: 2000, display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden' }}
     >
-      <button onClick={onClose} aria-label="Close" style={{ position: 'absolute', inset: 0, background: 'rgba(15,23,42,0.35)', border: 'none', cursor: 'default', padding: 0 }} />
+      <button type="button" onClick={onClose} aria-label="Close" style={{ position: 'absolute', inset: 0, background: 'rgba(15,23,42,0.35)', border: 'none', cursor: 'default', padding: 0 }} />
       <div style={{
         position: 'relative', zIndex: 1,
         background: '#fff', borderRadius: 14, width: '88%', maxWidth: 1040,
@@ -1188,7 +1188,7 @@ const DetailedMetricsModal: React.FC<{ ruleSets: RuleSet[]; colorMap: Record<str
         {/* Header */}
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '16px 22px', borderBottom: '1px solid #f1f5f9', flexShrink: 0 }}>
           <span style={{ fontSize: 15, fontWeight: 700, color: '#0f172a' }}>Detailed Metrics</span>
-          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', fontSize: 20, lineHeight: 1 }}>×</button>
+          <button type="button" onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', fontSize: 20, lineHeight: 1 }}>×</button>
         </div>
 
         {/* Body — fixed height so scroll kicks in after ~2-3 rulesets */}
@@ -1335,7 +1335,7 @@ const RuleSetPanel: React.FC<{
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
           {onDelete && (
-            <button
+            <button type="button"
               onClick={() => { onDelete(); onClose(); }}
               style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#ef4444', fontSize: 11.5, fontWeight: 600, padding: '3px 8px', borderRadius: 5, fontFamily: APP_FONT }}
               onMouseEnter={e => (e.currentTarget.style.background = '#fef2f2')}
@@ -1343,7 +1343,7 @@ const RuleSetPanel: React.FC<{
               title="Delete Rule Set"
             >Delete</button>
           )}
-          <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', fontSize: 18, lineHeight: 1 }}>×</button>
+          <button type="button" onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', fontSize: 18, lineHeight: 1 }}>×</button>
         </div>
       </div>
 
@@ -1373,7 +1373,7 @@ const RuleSetPanel: React.FC<{
           <label htmlFor="rsp-color" style={labelStyle}>Color</label>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
             {PRESET_COLORS.map(c => (
-              <button
+              <button type="button"
                 key={c}
                 onClick={() => setDraft(d => ({ ...d, color: c }))}
                 style={{
@@ -1395,7 +1395,7 @@ const RuleSetPanel: React.FC<{
 
       {/* Footer with Save */}
       <div style={{ padding: '10px 16px', borderTop: '1px solid #f1f5f9', flexShrink: 0, display: 'flex', justifyContent: 'flex-end' }}>
-        <button
+        <button type="button"
           onClick={handleSave}
           disabled={saving}
           style={{
@@ -1468,7 +1468,7 @@ const LeftPanel: React.FC<LeftPanelProps> = ({
       <div style={{ padding: '14px 14px 10px', borderBottom: '1px solid #f1f5f9', flexShrink: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
           <span style={{ fontSize: 13, fontWeight: 700, color: '#0f172a' }}>Constraint Sets</span>
-          <button
+          <button type="button"
             onClick={onAddSet}
             style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 11.5, color: '#049484', background: 'none', border: 'none', cursor: 'pointer', fontWeight: 500, padding: '3px 6px', borderRadius: 5 }}
             onMouseEnter={e => (e.currentTarget.style.background = '#f0fdf9')}

--- a/src/components/flow/FlowCanvas.tsx
+++ b/src/components/flow/FlowCanvas.tsx
@@ -2569,7 +2569,7 @@ export const FlowCanvas = forwardRef<{
               ...(readOnly ? [] : [{ label: 'Constraints', mode: 'constraints' as CanvasMode, icon: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg> }]),
               { label: 'Views', mode: 'views' as CanvasMode, icon: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="9"/><line x1="12" y1="3" x2="12" y2="21"/><line x1="3" y1="12" x2="21" y2="12"/></svg> },
             ]).map(({ label, mode, icon }) => (
-              <button
+              <button type="button"
                 key={label}
                 onClick={() => {
                   setActiveCanvasMode(mode);

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -97,7 +97,7 @@ const NavItem: React.FC<NavItemProps> = ({ icon, label, active, onClick, badgeCo
   }
 
   return (
-    <button
+    <button type="button"
       onClick={onClick}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
@@ -179,7 +179,7 @@ const MenuItem: React.FC<MenuItemProps> = ({ icon, label, sublabel, danger = fal
   }
 
   return (
-    <button
+    <button type="button"
       onClick={onClick}
       onMouseEnter={() => setHov(true)}
       onMouseLeave={() => setHov(false)}
@@ -250,7 +250,7 @@ export const AppSidebar: React.FC<AppSidebarProps> = ({
 
       {/* Logo */}
       <div style={{ padding: '20px 16px 16px', borderBottom: '1px solid rgba(255,255,255,0.06)', flexShrink: 0 }}>
-        <button
+        <button type="button"
           onClick={() => onViewChange('home')}
           style={{
             display: 'flex', alignItems: 'center', gap: 6,
@@ -340,7 +340,7 @@ export const AppSidebar: React.FC<AppSidebarProps> = ({
         {/* Border above user card */}
         <div style={{ borderTop: '1px solid rgba(255,255,255,0.07)', padding: '10px 12px 12px' }}>
           {/* User card */}
-          <button
+          <button type="button"
             onClick={() => setMenuOpen(v => !v)}
             onMouseEnter={() => setUserHovered(true)}
             onMouseLeave={() => setUserHovered(false)}

--- a/src/components/ui/ChangePasswordModal.tsx
+++ b/src/components/ui/ChangePasswordModal.tsx
@@ -144,7 +144,7 @@ const ModalButton: React.FC<{
     opacity = 0.6;
   }
   return (
-    <button
+    <button type="button"
       onClick={onClick}
       disabled={isDisabled}
       onMouseEnter={() => setHov(true)}

--- a/src/components/ui/LandingView.tsx
+++ b/src/components/ui/LandingView.tsx
@@ -62,7 +62,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ title, subtitle, items, cta, 
   const [hovered, setHovered] = useState(false);
 
   return (
-    <button
+    <button type="button"
       onClick={onNavigate}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}

--- a/src/components/ui/ModelLibraryTable.tsx
+++ b/src/components/ui/ModelLibraryTable.tsx
@@ -113,7 +113,7 @@ const detailFieldLabelSt: React.CSSProperties = { display: 'block', fontSize: 11
 const DPreviewBtn: React.FC<{ title: string; onClick: () => void; children: React.ReactNode }> = ({ title, onClick, children }) => {
   const [hov, setHov] = React.useState(false);
   return (
-    <button title={title} onClick={onClick} onMouseEnter={() => setHov(true)} onMouseLeave={() => setHov(false)}
+    <button type="button" title={title} onClick={onClick} onMouseEnter={() => setHov(true)} onMouseLeave={() => setHov(false)}
       style={{ width: 24, height: 24, border: '1px solid #e2e8f0', borderRadius: 6, background: hov ? '#f1f5f9' : '#fff', color: hov ? '#0f172a' : '#64748b', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'all 0.12s' }}>
       {children}
     </button>
@@ -206,7 +206,7 @@ export const ModelDetailModal: React.FC<ModelDetailModalProps> = ({
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
             {!editing && (
-              <button
+              <button type="button"
                 onClick={() => {
                   setForm({ name: displayModel.name || '', description: displayModel.description || '', domain: displayModel.domain || '', keywords: displayModel.keyword || [] });
                   setEditing(true);
@@ -223,7 +223,7 @@ export const ModelDetailModal: React.FC<ModelDetailModalProps> = ({
                 Edit
               </button>
             )}
-            <button
+            <button type="button"
               onClick={onClose}
               style={{ border: 'none', background: 'transparent', cursor: 'pointer', color: '#94a3b8', fontSize: 16, width: 30, height: 30, borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'all 0.1s' }}
               onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = '#f1f5f9'; (e.currentTarget as HTMLButtonElement).style.color = '#374151'; }}
@@ -861,7 +861,7 @@ export const ModelLibraryTable: React.FC<ModelLibraryTableProps> = ({ onModelOpe
       {/* Page header */}
       <div style={{ padding: '32px 40px 0', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
         <h1 style={{ margin: 0, fontSize: 26, fontWeight: 700, color: '#111827', letterSpacing: '-0.02em' }}>Model Library</h1>
-        <button
+        <button type="button"
           onClick={() => setShowCreate(true)}
           style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '9px 18px', background: '#0B1720', color: '#fff', border: 'none', borderRadius: 9, fontSize: 14, fontWeight: 600, cursor: 'pointer', boxShadow: '0 1px 4px rgba(11,23,32,0.25)', transition: 'background 0.15s', fontFamily: 'ui-sans-serif, system-ui, sans-serif' }}
           onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = '#0B1720'; }}
@@ -1108,7 +1108,7 @@ const PageBtn: React.FC<PageBtnProps> = ({ children, active, disabled, onClick }
   }
 
   return (
-  <button
+  <button type="button"
     onClick={onClick}
     disabled={disabled}
     style={{

--- a/src/components/ui/ProfileView.tsx
+++ b/src/components/ui/ProfileView.tsx
@@ -238,7 +238,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <div style={{ fontSize: 14, fontWeight: 700, color: '#111827' }}>Account Details</div>
             {!editing && (
-              <button
+              <button type="button"
                 onClick={handleEditOpen}
                 style={{
                   display: 'flex', alignItems: 'center', gap: 6,
@@ -280,7 +280,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
               )}
 
               <div style={{ display: 'flex', gap: 10 }}>
-                <button
+                <button type="button"
                   onClick={handleSave}
                   disabled={saving}
                   style={{
@@ -293,7 +293,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
                 >
                   <CheckIcon /> {saving ? 'Saving…' : 'Save changes'}
                 </button>
-                <button
+                <button type="button"
                   onClick={handleCancel}
                   disabled={saving}
                   style={{
@@ -357,7 +357,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
               Min. 8 characters · uppercase · lowercase · digit · special character
             </div>
           </div>
-          <button
+          <button type="button"
             onClick={changePassword.open}
             style={{
               display: 'flex', alignItems: 'center', gap: 7,

--- a/src/components/ui/ProjectsView.tsx
+++ b/src/components/ui/ProjectsView.tsx
@@ -182,7 +182,7 @@ const ProjectRow: React.FC<ProjectRowProps> = ({
       {/* Actions */}
       <td style={{ padding: '13px 16px' }} onClick={e => e.stopPropagation()}>
         {showDeleted ? (
-          <button
+          <button type="button"
             onClick={onRecover}
             style={{ padding: '6px 14px', border: 'none', borderRadius: 7, background: '#10b981', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer', transition: 'background 0.15s' }}
             onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = '#059669'; }}
@@ -433,7 +433,7 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({
       {/* Page header */}
       <div style={{ padding: '32px 40px 0', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
         <h1 style={{ margin: 0, fontSize: 26, fontWeight: 700, color: '#111827', letterSpacing: '-0.02em' }}>Dashboard / Projects</h1>
-        <button
+        <button type="button"
           onClick={() => setShowCreate(true)}
           disabled={projectView === 'shared' || projectView === 'deleted'}
           style={{
@@ -476,7 +476,7 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({
             { key: 'shared' as const, label: 'Shared with me' },
             { key: 'deleted' as const, label: 'Deleted projects' },
           ]).map(({ key, label }) => (
-            <button
+            <button type="button"
               key={key}
               onClick={() => setProjectView(key)}
               style={{

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -3061,7 +3061,7 @@ function getPillBtnColor(active: boolean | undefined, hovered: boolean): string 
 const PillBtn: React.FC<PillBtnProps> = ({ onClick, title, children, active, spinning }) => {
   const [hov, setHov] = useState(false);
   return (
-    <button
+    <button type="button"
       onClick={onClick}
       title={title}
       onMouseEnter={() => setHov(true)}


### PR DESCRIPTION
The deployed nginx config only proxied /api/ and /realms/ to their upstreams. Requests to /lsp and /ocl-lsp fell through to the SPA static-file handler.
The browser then aborted the connection with close code 1006, breaking LSP diagnostics/completion in the Constraint editor on staging/production.
Add dedicated location blocks for /lsp and /ocl-lsp that forward the
Upgrade/Connection headers to backend:8080, matching the WebSocket
handlers registered in WebSocketConfig.java.
