### PR TITLE
Align Model Library metadata field order in preview and edit modes

### DIFF
--- a/src/__tests__/components/ui/ModelLibraryTable.test.tsx
+++ b/src/__tests__/components/ui/ModelLibraryTable.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
-import { ModelLibraryTable } from '../../../components/ui/ModelLibraryTable';
+import { ModelDetailModal, ModelLibraryTable } from '../../../components/ui/ModelLibraryTable';
 
 jest.mock('../../../services/api', () => ({
   apiService: {
@@ -79,5 +79,33 @@ describe('ModelLibraryTable', () => {
     fireEvent.change(screen.getByRole('combobox'), { target: { value: 'month' } });
 
     await waitFor(() => expect(apiService.findMetaModels).toHaveBeenCalledTimes(3));
+  });
+
+  it('keeps shared metadata fields in the same order when editing', () => {
+    render(
+      <ModelDetailModal
+        model={{
+          id: 1,
+          name: 'Existing Model',
+          description: 'A description',
+          domain: 'Testing',
+          keyword: ['uml'],
+        }}
+        onClose={jest.fn()}
+        onUpdated={jest.fn()}
+      />,
+    );
+
+    const name = screen.getByText('Name');
+    const keywords = screen.getByText('Keywords');
+    const description = screen.getByText('Description');
+    expect(name.compareDocumentPosition(keywords) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(keywords.compareDocumentPosition(description) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const formLabels = Array.from(document.querySelector('form')!.querySelectorAll('label'))
+      .map((label) => label.textContent);
+    expect(formLabels).toEqual(['Name', 'Keywords', 'Description', 'Domain']);
   });
 });

--- a/src/components/ui/ModelLibraryTable.tsx
+++ b/src/components/ui/ModelLibraryTable.tsx
@@ -244,16 +244,16 @@ export const ModelDetailModal: React.FC<ModelDetailModalProps> = ({
                   <input id="model-detail-name" value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} style={detailInputSt} onFocus={e => (e.currentTarget.style.borderColor = '#049484')} onBlur={e => (e.currentTarget.style.borderColor = '#e2e8f0')} />
                 </div>
                 <div>
+                  <label htmlFor="model-detail-keywords" style={detailFieldLabelSt}>Keywords</label>
+                  <KeywordTagsInput id="model-detail-keywords" keywords={form.keywords} onChange={kws => setForm(f => ({ ...f, keywords: kws }))} />
+                </div>
+                <div>
                   <label htmlFor="model-detail-description" style={detailFieldLabelSt}>Description</label>
                   <textarea id="model-detail-description" value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))} rows={3} style={{ ...detailInputSt, resize: 'vertical', minHeight: 72 }} onFocus={e => (e.currentTarget.style.borderColor = '#049484')} onBlur={e => (e.currentTarget.style.borderColor = '#e2e8f0')} />
                 </div>
                 <div>
                   <label htmlFor="model-detail-domain" style={detailFieldLabelSt}>Domain</label>
                   <input id="model-detail-domain" value={form.domain} onChange={e => setForm(f => ({ ...f, domain: e.target.value }))} style={detailInputSt} onFocus={e => (e.currentTarget.style.borderColor = '#049484')} onBlur={e => (e.currentTarget.style.borderColor = '#e2e8f0')} />
-                </div>
-                <div>
-                  <label htmlFor="model-detail-keywords" style={detailFieldLabelSt}>Keywords</label>
-                  <KeywordTagsInput id="model-detail-keywords" keywords={form.keywords} onChange={kws => setForm(f => ({ ...f, keywords: kws }))} />
                 </div>
                 {error   && <div style={{ padding: '8px 12px', background: '#fef2f2', border: '1px solid #fecaca', borderRadius: 8, fontSize: 12, color: '#dc2626' }}>{error}</div>}
                 {success && <div style={{ padding: '8px 12px', background: '#f0fdf4', border: '1px solid #86efac', borderRadius: 8, fontSize: 12, color: '#15803d' }}>{success}</div>}


### PR DESCRIPTION
## Summary

Aligns Model Library metadata fields when switching from preview to edit mode.

- Reorders edit fields to `Name → Keywords → Description → Domain`.
- Keeps shared fields in the same positions as the read-only preview.
- Adds regression coverage for the field order.

## Testing

CI=true npm test -- --watchAll=false --runInBand src/__tests__/components/ui/ModelLibraryTable.test.tsx

## Images 

<img width="1536" height="769" alt="Screenshot 2026-07-18 at 16 21 17" src="https://github.com/user-attachments/assets/669034bb-86ae-4f1c-b955-ef47a44a91ef" />

<img width="1539" height="771" alt="Screenshot 2026-07-18 at 16 21 41" src="https://github.com/user-attachments/assets/deadbaf3-5c96-478c-9308-ad7b32b59ead" />

