### PR TITLE
Fix visual gap in UML relationship markers (composition/inheritance)

### DIFF
--- a/src/__tests__/components/canvas/UMLDiagram.directionMarker.test.tsx
+++ b/src/__tests__/components/canvas/UMLDiagram.directionMarker.test.tsx
@@ -1,0 +1,90 @@
+jest.mock('../../../utils/ecoreToUml', () => require('../../../testSupport/umlDiagram/mockFactories').ecoreToUmlMock());
+jest.mock('../../../utils/saveMetaModelEcore', () => require('../../../testSupport/umlDiagram/mockFactories').saveMetaModelEcoreMock());
+jest.mock('../../../utils/umlValidation', () => require('../../../testSupport/umlDiagram/mockFactories').umlValidationMock());
+jest.mock('../../../utils/reactionFile', () => require('../../../testSupport/umlDiagram/mockFactories').reactionFileMock());
+jest.mock('../../../components/canvas/UMLDiagramMinimap', () => require('../../../testSupport/umlDiagram/mockFactories').umlDiagramMinimapMock());
+jest.mock('../../../components/flow/ReactionEditorModal', () => require('../../../testSupport/umlDiagram/mockFactories').reactionEditorModalMock());
+jest.mock('../../../components/canvas/ReactionConfigPopup', () => require('../../../testSupport/umlDiagram/mockFactories').reactionConfigPopupMock());
+jest.mock('../../../utils/umlDiagramGeometry', () => require('../../../testSupport/umlDiagram/mockFactories').umlDiagramGeometryMock());
+jest.mock('../../../utils/umlClassLayout', () => require('../../../testSupport/umlDiagram/mockFactories').umlClassLayoutMock());
+jest.mock('../../../utils/umlLayoutStorage', () => require('../../../testSupport/umlDiagram/mockFactories').umlLayoutStorageMock());
+
+import { screen } from '@testing-library/react';
+import { renderDiagram } from '../../../testSupport/umlDiagram/renderUtils';
+
+// Mirrors the private BW/boxH constants in UMLDiagram.tsx for the fixed "Employee -> Person"
+// inheritance relationship used by the default (SIMPLE_ECORE) mock model. See mockFactories.ts.
+const BW = 190;
+const NAME_H = 36;
+const ATTR_ROW = 22;
+const ATTR_PAD = 10;
+const ADD_BTN_H = 22;
+const METH_H = 26;
+
+function boxH(attributeCount: number): number {
+  const ah = attributeCount * ATTR_ROW + ATTR_PAD + ADD_BTN_H;
+  const oh = ADD_BTN_H; // no operations
+  const mh = Math.max(METH_H, oh);
+  return NAME_H + 1 + ah + 1 + mh;
+}
+
+/** Same algorithm as UMLDiagram.tsx's private edgePt(): where a box's border intersects the line to a point. */
+function edgePt(bx: number, by: number, h: number, tx: number, ty: number) {
+  const cx = bx + BW / 2;
+  const cy = by + h / 2;
+  const dx = tx - cx;
+  const dy = ty - cy;
+  const hw = BW / 2;
+  const hh = h / 2;
+  const t = Math.abs(dx) * hh > Math.abs(dy) * hw ? hw / Math.abs(dx) : hh / Math.abs(dy);
+  return { x: cx + dx * t, y: cy + dy * t };
+}
+
+function parseLeftTop(style: CSSStyleDeclaration): { left: number; top: number } {
+  return { left: parseFloat(style.left), top: parseFloat(style.top) };
+}
+
+function parseMarkerTranslate(style: string): { x: number; y: number } {
+  // e.g. "translate(-50%, -50%) translate(123.45px, 67.8px) rotate(0deg)"
+  const match = style.match(/translate\(([-\d.]+)px,\s*([-\d.]+)px\)\s*rotate/);
+  if (!match) throw new Error(`Could not parse marker transform: ${style}`);
+  return { x: parseFloat(match[1]), y: parseFloat(match[2]) };
+}
+
+describe('UMLDiagram direction marker anchoring', () => {
+  it('anchors the inheritance triangle at the true class-box edge, not the inset line endpoint', () => {
+    const { container } = renderDiagram();
+
+    const personBox = screen.getByText('Person').closest('[data-classbox]');
+    const employeeBox = screen.getByText('Employee').closest('[data-classbox]');
+    expect(personBox).toBeTruthy();
+    expect(employeeBox).toBeTruthy();
+
+    const personWrapper = personBox!.parentElement as HTMLElement;
+    const employeeWrapper = employeeBox!.parentElement as HTMLElement;
+    const person = parseLeftTop(personWrapper.style);
+    const employee = parseLeftTop(employeeWrapper.style);
+
+    // Employee (source) --inheritance--> Person (target); the triangle anchors on the
+    // 'end' side, i.e. at Person's edge facing Employee.
+    const personH = boxH(1); // Person has 1 attribute ("name")
+    const employeeH = boxH(0); // Employee has 0 attributes
+    const expected = edgePt(
+      person.left, person.top, personH,
+      employee.left + BW / 2, employee.top + employeeH / 2,
+    );
+
+    const marker = container.querySelector('[data-rel-direction-marker]');
+    expect(marker).toBeTruthy();
+    const actual = parseMarkerTranslate((marker as HTMLElement).style.transform);
+
+    expect(actual.x).toBeCloseTo(expected.x, 1);
+    expect(actual.y).toBeCloseTo(expected.y, 1);
+
+    // Regression guard: the marker must NOT sit at the old (buggy) 10px-inset point, which
+    // would leave a visible gap between the marker and the class box border.
+    const EDGE_ENDPOINT_INSET = 10;
+    const insetX = expected.x - EDGE_ENDPOINT_INSET; // inset moves along the line, toward Employee (lower x)
+    expect(Math.abs(actual.x - insetX)).toBeGreaterThan(5);
+  });
+});

--- a/src/components/canvas/UMLDiagram.tsx
+++ b/src/components/canvas/UMLDiagram.tsx
@@ -2580,7 +2580,7 @@ export const UMLDiagram = forwardRef<UMLDiagramHandle, UMLDiagramProps>(({
 
       {/* Direction markers above class boxes */}
       {edgeLayouts.map(layout => {
-        const { rel, drawP1, drawP2 } = layout;
+        const { rel, p1, p2 } = layout;
         const reactionEdge = reactionEdgeById.get(rel.id);
         const state = edgeState(selectedRelId === rel.id, hoveredRelId === rel.id);
         const color = reactionEdge ? REACTION_EDGE_COLOR[state] : EDGE_COLOR[state];
@@ -2590,8 +2590,11 @@ export const UMLDiagram = forwardRef<UMLDiagramHandle, UMLDiagramProps>(({
             key={`${rel.id}-direction`}
             rel={rel}
             reactionEdge={reactionEdge}
-            lineStart={drawP1}
-            lineEnd={drawP2}
+            // Anchor at the true class-box edge (p1/p2), not the inset line endpoints
+            // (drawP1/drawP2) used only for the line stroke -- otherwise the marker floats
+            // in the gap left for it instead of touching the box it belongs to.
+            lineStart={p1}
+            lineEnd={p2}
             color={color}
             onRelClick={e => handleRelationshipClick(rel.id, e)}
             onMouseEnter={() => setHoveredRelId(rel.id)}


### PR DESCRIPTION
## Summary

Fixes #389. In the Model Library's UML preview, composition (diamond) and inheritance (triangle) relationship markers rendered with a visible gap instead of touching the class box they belong to.

**Root cause**: `RelationDirectionMarker` was anchored at `drawP1`/`drawP2` — the line endpoints already inset 10px (`EDGE_ENDPOINT_INSET`) from the class box, meant only for the plain line stroke — instead of `p1`/`p2`, the actual box-edge points. Since each marker already has its own footprint (~18-20px, centered on its anchor), this left a visible gap between the box and the marker instead of the marker touching the box.

**Fix**: anchor at `p1`/`p2` instead. The marker now spans from the box edge right up to where the inset line begins, closing the gap.
