### PR TITLE
Frontend UI/UX fixes for password visibility, upload cancel handling, workspace persistence, and invalid canvas routes

### DIFF
--- a/src/__tests__/components/flow/FlowCanvas.test.tsx
+++ b/src/__tests__/components/flow/FlowCanvas.test.tsx
@@ -914,5 +914,20 @@ describe('handleEdgeDoubleClick logic', () => {
       render(<FlowCanvas ref={ref} />);
       expect(screen.queryByTestId('circle-overlay')).not.toBeInTheDocument();
     });
+
+    it('renders CircleOverlay when canvasMode is restored as Views', () => {
+      const ref = createRef<any>();
+      render(<FlowCanvas ref={ref} canvasMode="views" />);
+      expect(screen.getByTestId('circle-overlay')).toBeInTheDocument();
+    });
+
+    it('syncs CircleOverlay when canvasMode changes', () => {
+      const ref = createRef<any>();
+      const { rerender } = render(<FlowCanvas ref={ref} canvasMode="views" />);
+      expect(screen.getByTestId('circle-overlay')).toBeInTheDocument();
+
+      rerender(<FlowCanvas ref={ref} canvasMode="modeling" />);
+      expect(screen.queryByTestId('circle-overlay')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/__tests__/components/ui/ChangePasswordModal.test.tsx
+++ b/src/__tests__/components/ui/ChangePasswordModal.test.tsx
@@ -1,4 +1,7 @@
-import { validatePassword } from '../../../components/ui/ChangePasswordModal';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChangePasswordModal, validatePassword } from '../../../components/ui/ChangePasswordModal';
 
 describe('validatePassword', () => {
   it('accepts a password that meets all rules', () => {
@@ -17,5 +20,40 @@ describe('validatePassword', () => {
     expect(validatePassword('ALLUPPERCASE1!').hasLowercase).toBe(false);
     expect(validatePassword('NoNumbers!').hasNumber).toBe(false);
     expect(validatePassword('NoSymbols1a').hasSymbol).toBe(false);
+  });
+});
+
+describe('ChangePasswordModal', () => {
+  it('toggles password field visibility independently', async () => {
+    render(
+      <ChangePasswordModal
+        isOpen
+        onClose={jest.fn()}
+        newPassword="Secure1!"
+        confirmPassword="Secure1!"
+        onNewPasswordChange={jest.fn()}
+        onConfirmPasswordChange={jest.fn()}
+        validation={validatePassword('Secure1!')}
+        isConfirmValid
+        isChanging={false}
+        error=""
+        success=""
+        onSubmit={jest.fn()}
+        canSubmit
+      />,
+    );
+
+    const newPasswordInput = screen.getByLabelText('New Password');
+    const confirmPasswordInput = screen.getByLabelText('Confirm Password');
+    const showPasswordButtons = screen.getAllByRole('button', { name: 'Show password' });
+
+    expect(newPasswordInput).toHaveAttribute('type', 'password');
+    expect(confirmPasswordInput).toHaveAttribute('type', 'password');
+
+    await userEvent.click(showPasswordButtons[0]);
+
+    expect(newPasswordInput).toHaveAttribute('type', 'text');
+    expect(confirmPasswordInput).toHaveAttribute('type', 'password');
+    expect(screen.getByRole('button', { name: 'Hide password' })).toHaveAttribute('aria-pressed', 'true');
   });
 });

--- a/src/__tests__/components/ui/CreateModelModal.test.tsx
+++ b/src/__tests__/components/ui/CreateModelModal.test.tsx
@@ -162,6 +162,26 @@ describe('CreateModelModal', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps the modal open when the .ecore file picker is canceled', () => {
+    const onClose = jest.fn();
+    render(<CreateModelModal isOpen onClose={onClose} />);
+    const ecoreInput = document.querySelector('input[accept=".ecore"]') as HTMLInputElement;
+
+    fireEvent(ecoreInput, new Event('cancel', { bubbles: true, cancelable: true }));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('keeps the modal open when the .genmodel file picker is canceled', () => {
+    const onClose = jest.fn();
+    render(<CreateModelModal isOpen onClose={onClose} />);
+    const genmodelInput = document.querySelector('input[accept=".genmodel"]') as HTMLInputElement;
+
+    fireEvent(genmodelInput, new Event('cancel', { bubbles: true, cancelable: true }));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   // ── file upload mode ─────────────────────────────────────────────────────────
 
   describe('file upload mode', () => {

--- a/src/__tests__/pages/CanvasPage.test.tsx
+++ b/src/__tests__/pages/CanvasPage.test.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { CanvasPage } from '../../pages/CanvasPage';
+import { apiService } from '../../services/api';
+
+const mockNavigate = jest.fn();
+let mockRouteId = '10';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ id: mockRouteId }),
+  useLocation: () => ({ state: null }),
+}));
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: {
+      id: '1',
+      username: 'tester',
+      email: 'tester@example.com',
+      givenName: 'Test',
+      familyName: 'User',
+      emailVerified: true,
+    },
+  }),
+}));
+
+jest.mock('../../components/flow/FlowCanvas', () => {
+  const React = require('react');
+  return {
+    FlowCanvas: React.forwardRef((_props: any, ref: any) => {
+      React.useImperativeHandle(ref, () => ({
+        loadDiagramData: jest.fn(),
+        getNodes: jest.fn(() => []),
+        getEdges: jest.fn(() => []),
+        addEcoreFile: jest.fn(),
+        updateEcoreFileData: jest.fn(),
+        resetExpandedFile: jest.fn(),
+        undo: jest.fn(),
+        redo: jest.fn(),
+        canUndo: false,
+        canRedo: false,
+        getReactionEdges: jest.fn(() => []),
+        getWorkspaceSnapshot: jest.fn(() => ({
+          metaModelIds: [],
+          metaModelRelationRequests: [],
+        })),
+        fitUmlView: jest.fn(),
+        openSelectedReactionEditor: jest.fn(() => false),
+      }));
+      return <div data-testid="flow-canvas" />;
+    }),
+  };
+});
+
+jest.mock('../../components/constraints/ConstraintsView', () => ({
+  ConstraintsView: () => <div data-testid="constraints-view" />,
+}));
+
+jest.mock('../../services/api', () => ({
+  apiService: {
+    getVsumDetails: jest.fn(),
+    getVsum: jest.fn(),
+    getVsumMembers: jest.fn(),
+    getVsumsPaginated: jest.fn(),
+    findMetaModels: jest.fn(),
+    getFile: jest.fn(),
+    removeVsumMember: jest.fn(),
+    buildVsum: jest.fn(),
+    downloadVsumArtifact: jest.fn(),
+    renameVsum: jest.fn(),
+    deleteMetaModel: jest.fn(),
+  },
+}));
+
+const apiError = (status: number, message: string) =>
+  Object.assign(new Error(message), {
+    status,
+    response: {
+      status,
+      data: { message },
+    },
+  });
+
+describe('CanvasPage invalid project routes', () => {
+  let consoleErrorSpy: jest.SpyInstance | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRouteId = '10';
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    (apiService.findMetaModels as jest.Mock).mockResolvedValue({ data: [] });
+    (apiService.getVsumMembers as jest.Mock).mockResolvedValue({ data: [] });
+    (apiService.getVsum as jest.Mock).mockResolvedValue({ data: {} });
+    (apiService.getVsumsPaginated as jest.Mock).mockResolvedValue({ data: [] });
+  });
+
+  afterEach(() => {
+    consoleErrorSpy?.mockRestore();
+  });
+
+  it('shows access denied and removes the canvas when details returns 403', async () => {
+    (apiService.getVsumDetails as jest.Mock).mockRejectedValueOnce(
+      apiError(403, 'Forbidden'),
+    );
+
+    render(<CanvasPage />);
+
+    expect(await screen.findByRole('heading', { name: /access denied/i })).toBeInTheDocument();
+    expect(screen.getByText(/do not have access/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('flow-canvas')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows not found and removes the canvas when details returns 404', async () => {
+    mockRouteId = '100';
+    (apiService.getVsumDetails as jest.Mock).mockRejectedValueOnce(
+      apiError(404, 'Not found'),
+    );
+
+    render(<CanvasPage />);
+
+    expect(await screen.findByRole('heading', { name: /project not found/i })).toBeInTheDocument();
+    expect(screen.getByText(/does not exist/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('flow-canvas')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/__tests__/services/api.test.ts
+++ b/src/__tests__/services/api.test.ts
@@ -94,7 +94,13 @@ describe('ApiService – authenticatedRequest', () => {
 
   it('throws on 4xx error response', async () => {
     mockFetch({ message: 'Forbidden' }, 403);
-    await expect((apiService as any).authenticatedRequest('/forbidden')).rejects.toThrow();
+    await expect((apiService as any).authenticatedRequest('/forbidden')).rejects.toMatchObject({
+      status: 403,
+      response: {
+        status: 403,
+        data: { message: 'Forbidden' },
+      },
+    });
   });
 
   it('retries with refreshed token on 401', async () => {
@@ -352,4 +358,3 @@ describe('ApiService – updateUserName', () => {
     await expect(apiService.updateUserName('99', 'A', 'B')).rejects.toThrow();
   });
 });
-

--- a/src/__tests__/utils/canvasModeStorage.test.ts
+++ b/src/__tests__/utils/canvasModeStorage.test.ts
@@ -1,0 +1,35 @@
+import {
+  canvasModeStorageKey,
+  readStoredCanvasMode,
+  writeStoredCanvasMode,
+} from '../../utils/canvasModeStorage';
+
+describe('canvasModeStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults to modeling when no mode is stored', () => {
+    expect(readStoredCanvasMode(1)).toBe('modeling');
+  });
+
+  it('reads a valid stored mode', () => {
+    localStorage.setItem(canvasModeStorageKey(1), 'constraints');
+
+    expect(readStoredCanvasMode(1)).toBe('constraints');
+  });
+
+  it('ignores invalid stored values', () => {
+    localStorage.setItem(canvasModeStorageKey(1), 'invalid');
+
+    expect(readStoredCanvasMode(1)).toBe('modeling');
+  });
+
+  it('writes modes per project', () => {
+    writeStoredCanvasMode(1, 'constraints');
+    writeStoredCanvasMode(2, 'views');
+
+    expect(readStoredCanvasMode(1)).toBe('constraints');
+    expect(readStoredCanvasMode(2)).toBe('views');
+  });
+});

--- a/src/components/auth/PasswordInput.tsx
+++ b/src/components/auth/PasswordInput.tsx
@@ -1,20 +1,5 @@
 import React, { useState } from 'react';
-
-const EyeIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-    <circle cx="12" cy="12" r="3" />
-  </svg>
-);
-
-const EyeOffIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
-    <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
-    <path d="M1 1l22 22" />
-    <path d="M14.12 14.12a3 3 0 1 1-4.24-4.24" />
-  </svg>
-);
+import { EyeIcon, EyeOffIcon } from '../ui/PasswordVisibilityIcons';
 
 interface PasswordInputProps {
   id: string;

--- a/src/components/flow/FlowCanvas.tsx
+++ b/src/components/flow/FlowCanvas.tsx
@@ -189,6 +189,7 @@ interface FlowCanvasProps {
   projectTabsBelowModeToggle?: React.ReactNode;
   /** Called when the user switches between Modeling / Constraints / Views tabs. */
   onCanvasModeChange?: (mode: CanvasMode) => void;
+  canvasMode?: CanvasMode;
   /** Node ID to highlight as the active constraint context (teal glow). */
   constraintHighlightNodeId?: string | null;
   /** Node ID currently selected as a constraint filter (stronger teal border). */
@@ -431,6 +432,7 @@ export const FlowCanvas = forwardRef<{
     onHistoryChange,
     projectTabsBelowModeToggle,
     onCanvasModeChange,
+    canvasMode: canvasModeProp = 'modeling',
     constraintHighlightNodeId,
     constraintFilterNodeId,
     onConstraintNodeFilter,
@@ -489,8 +491,13 @@ export const FlowCanvas = forwardRef<{
 
     // Canvas center in flow coordinates — fixed at origin, ReactFlow's default fitView center
     const [circleSelected, setCircleSelected] = useState(false);
-    const [activeCanvasMode, setActiveCanvasMode] = useState<CanvasMode>('modeling');
+    const [activeCanvasMode, setActiveCanvasMode] = useState<CanvasMode>(canvasModeProp);
     const circleVisible = activeCanvasMode === 'views';
+
+    useEffect(() => {
+      setActiveCanvasMode(canvasModeProp);
+      if (canvasModeProp !== 'views') setCircleSelected(false);
+    }, [canvasModeProp]);
 
     useEffect(() => {
       if (readOnly && activeCanvasMode === 'constraints') {

--- a/src/components/ui/ChangePasswordModal.tsx
+++ b/src/components/ui/ChangePasswordModal.tsx
@@ -46,6 +46,22 @@ const PasswordRequirements: React.FC<{ validation: PasswordValidation; showRequi
   );
 };
 
+const EyeIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+const EyeOffIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+    <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+    <path d="M1 1l22 22" />
+    <path d="M14.12 14.12a3 3 0 1 1-4.24-4.24" />
+  </svg>
+);
+
 const PasswordInput: React.FC<{
   label: string;
   value: string;
@@ -58,30 +74,63 @@ const PasswordInput: React.FC<{
   onKeyDown?: (e: React.KeyboardEvent) => void;
 }> = ({ label, value, onChange, placeholder, disabled, showError, errorMessage, successMessage, onKeyDown }) => {
   const [isFocused, setIsFocused] = useState(false);
+  const [isToggleHovered, setIsToggleHovered] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
   const inputId = React.useId();
   return (
     <div style={{ marginBottom: 20 }}>
       <label htmlFor={inputId} style={{ display: 'block', marginBottom: 10, fontSize: 14, fontWeight: 600, color: '#1f2937' }}>
         {label}
       </label>
-      <input
-        id={inputId}
-        type="password"
-        value={value}
-        onChange={e => onChange(e.target.value)}
-        placeholder={placeholder}
-        disabled={disabled}
-        style={{
-          width: '100%', padding: '12px 14px',
-          border: showError ? '2px solid #dc2626' : '2px solid #e5e7eb',
-          borderRadius: 8, fontSize: 14, boxSizing: 'border-box', outline: 'none',
-          background: isFocused ? '#ffffff' : '#f9fafb',
-          boxShadow: isFocused ? '0 0 0 3px rgba(4, 148, 132, 0.1)' : 'none',
-        }}
-        onFocus={() => setIsFocused(true)}
-        onBlur={() => setIsFocused(false)}
-        onKeyDown={onKeyDown}
-      />
+      <div style={{ position: 'relative' }}>
+        <input
+          id={inputId}
+          type={isVisible ? 'text' : 'password'}
+          value={value}
+          onChange={event => onChange(event.target.value)}
+          placeholder={placeholder}
+          disabled={disabled}
+          style={{
+            width: '100%', padding: '12px 48px 12px 14px',
+            border: showError ? '2px solid #dc2626' : '2px solid #e5e7eb',
+            borderRadius: 8, fontSize: 14, boxSizing: 'border-box', outline: 'none',
+            background: isFocused ? '#ffffff' : '#f9fafb',
+            boxShadow: isFocused ? '0 0 0 3px rgba(4, 148, 132, 0.1)' : 'none',
+          }}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+          onKeyDown={onKeyDown}
+        />
+        <button
+          type="button"
+          onClick={() => setIsVisible(prev => !prev)}
+          onMouseEnter={() => setIsToggleHovered(true)}
+          onMouseLeave={() => setIsToggleHovered(false)}
+          disabled={disabled}
+          aria-label={isVisible ? 'Hide password' : 'Show password'}
+          aria-pressed={isVisible}
+          style={{
+            position: 'absolute',
+            right: 10,
+            top: '50%',
+            transform: 'translateY(-50%)',
+            width: 32,
+            height: 32,
+            border: 'none',
+            borderRadius: 6,
+            background: isToggleHovered && !disabled ? '#f0fdfa' : 'transparent',
+            color: isToggleHovered && !disabled ? '#1f9f92' : '#64748b',
+            cursor: disabled ? 'not-allowed' : 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 0,
+            opacity: disabled ? 0.5 : 1,
+          }}
+        >
+          {isVisible ? <EyeOffIcon /> : <EyeIcon />}
+        </button>
+      </div>
       {errorMessage && (
         <div style={{ marginTop: 6, fontSize: 12, color: '#dc2626', display: 'flex', alignItems: 'center', gap: 4 }}>
           <span style={{ fontWeight: 700 }}>×</span>

--- a/src/components/ui/ChangePasswordModal.tsx
+++ b/src/components/ui/ChangePasswordModal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useModalBodyLock } from './modalUtils';
+import { EyeIcon, EyeOffIcon } from './PasswordVisibilityIcons';
 
 export interface PasswordValidation {
   hasMinLength: boolean;
@@ -45,22 +46,6 @@ const PasswordRequirements: React.FC<{ validation: PasswordValidation; showRequi
     </div>
   );
 };
-
-const EyeIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-    <circle cx="12" cy="12" r="3" />
-  </svg>
-);
-
-const EyeOffIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
-    <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
-    <path d="M1 1l22 22" />
-    <path d="M14.12 14.12a3 3 0 1 1-4.24-4.24" />
-  </svg>
-);
 
 const PasswordInput: React.FC<{
   label: string;

--- a/src/components/ui/CreateModelModal.tsx
+++ b/src/components/ui/CreateModelModal.tsx
@@ -1283,7 +1283,10 @@ export const CreateModelModal: React.FC<CreateModelModalProps> = ({
           placeItems: 'center',
         }}
         onClose={form.handleClose}
-        onCancel={form.handleClose}
+        onCancel={(event) => {
+          if (event.target !== event.currentTarget) return;
+          void form.handleClose();
+        }}
       >
         <button
           type="button"

--- a/src/components/ui/PasswordVisibilityIcons.tsx
+++ b/src/components/ui/PasswordVisibilityIcons.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export const EyeIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+export const EyeOffIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+    <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+    <path d="M1 1l22 22" />
+    <path d="M14.12 14.12a3 3 0 1 1-4.24-4.24" />
+  </svg>
+);

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -52,6 +52,7 @@ import {
   workspaceSnapshotFromVsumDetails,
   workspaceSnapshotsEqual,
 } from '../utils/workspaceSnapshotUtils';
+import { readStoredCanvasMode, writeStoredCanvasMode } from '../utils/canvasModeStorage';
 import { downloadBlobAsFile } from '../utils/downloadFile';
 import { syncVsumWorkspaceChanges } from '../utils/vsumSyncSave';
 import { USER_PROFILE_DESCRIPTION, USER_PROFILE_LABEL } from '../constants/accountLabels';
@@ -737,8 +738,8 @@ export const CanvasPage: React.FC = () => {
   }, [activeProjectId, isSharedAccess]);
 
   // Canvas mode (Modeling / Constraints / Views)
-  const [canvasMode, setCanvasMode] = useState<CanvasMode>('modeling');
-  const canvasModeRef = useRef<CanvasMode>('modeling');
+  const [canvasMode, setCanvasMode] = useState<CanvasMode>(() => readStoredCanvasMode(activeProjectId));
+  const canvasModeRef = useRef<CanvasMode>(canvasMode);
   const [constraintsNodes, setConstraintsNodes] = useState<Node[]>([]);
   useEffect(() => {
     if (isViewOnly) setAddReactionMode(false);
@@ -751,8 +752,18 @@ export const CanvasPage: React.FC = () => {
     if (isViewOnly && canvasMode === 'constraints') {
       setCanvasMode('modeling');
       canvasModeRef.current = 'modeling';
+      writeStoredCanvasMode(activeProjectId, 'modeling');
     }
-  }, [isViewOnly, canvasMode]);
+  }, [activeProjectId, isViewOnly, canvasMode]);
+
+  useEffect(() => {
+    if (!activeProjectId) return;
+    const storedMode = readStoredCanvasMode(activeProjectId);
+    const nextMode = isViewOnly && storedMode === 'constraints' ? 'modeling' : storedMode;
+    canvasModeRef.current = nextMode;
+    setCanvasMode(nextMode);
+    if (nextMode !== storedMode) writeStoredCanvasMode(activeProjectId, nextMode);
+  }, [activeProjectId, isViewOnly]);
 
   const handleCanvasModeChange = useCallback((mode: CanvasMode) => {
     if (mode === 'constraints' && isViewOnly) return;
@@ -764,7 +775,8 @@ export const CanvasPage: React.FC = () => {
     }
     canvasModeRef.current = mode;
     setCanvasMode(mode);
-  }, [isViewOnly]);
+    writeStoredCanvasMode(activeProjectId, mode);
+  }, [activeProjectId, isViewOnly]);
 
 
   // Add-reaction mode
@@ -1551,6 +1563,7 @@ export const CanvasPage: React.FC = () => {
         ref={flowCanvasRef}
         vsumId={activeProjectId?.toString()}
         readOnly={isViewOnly}
+        canvasMode={canvasMode}
         onDiagramChange={handleDiagramChange}
         onEcoreFileExpand={handleEcoreFileExpand}
         umlModalOpen={umlPanels.length > 0}
@@ -3167,4 +3180,3 @@ const SaveIcon = () => (
     <rect x="7" y="13" width="10" height="8" />
   </svg>
 );
-

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -569,20 +569,17 @@ const CanvasProjectLoadStateOverlay: React.FC<CanvasProjectLoadStateOverlayProps
     notFound: 'This project does not exist or may have been deleted.',
     error: 'The project could not be loaded. Please try again.',
   };
+  const overlayStyle: React.CSSProperties = {
+    position: 'absolute',
+    inset: 0,
+    zIndex: 5000,
+    display: 'grid',
+    placeItems: 'center',
+    background: '#f8fafc',
+    fontFamily: 'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
+  };
 
-  return (
-    <div
-      role={isLoading ? 'status' : 'alert'}
-      style={{
-        position: 'absolute',
-        inset: 0,
-        zIndex: 5000,
-        display: 'grid',
-        placeItems: 'center',
-        background: '#f8fafc',
-        fontFamily: 'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
-      }}
-    >
+  const content = (
       <div style={{
         width: 'min(420px, calc(100vw - 32px))',
         padding: '28px 30px',
@@ -676,6 +673,15 @@ const CanvasProjectLoadStateOverlay: React.FC<CanvasProjectLoadStateOverlayProps
           </div>
         )}
       </div>
+  );
+
+  if (isLoading) {
+    return <output style={overlayStyle}>{content}</output>;
+  }
+
+  return (
+    <div role="alert" style={overlayStyle}>
+      {content}
     </div>
   );
 };

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -64,8 +64,55 @@ const CENTER_STACK_BOTTOM = MODE_TOGGLE_TOP + MODE_TOGGLE_HEIGHT + 4 + PROJECT_T
 
 type UMLPanel = CanvasUmlPanelState;
 
+type CanvasProjectLoadStatus = 'loading' | 'hydrating' | 'ready' | 'forbidden' | 'notFound' | 'error';
+
+interface CanvasProjectLoadState {
+  status: CanvasProjectLoadStatus;
+  message?: string;
+}
+
 function isStaleTabLoad(forInstanceId: string | undefined, activeInstanceId: string | null): boolean {
   return Boolean(forInstanceId && activeInstanceId !== forInstanceId);
+}
+
+function getErrorStatus(error: unknown): number | undefined {
+  const apiError = error as {
+    status?: unknown;
+    response?: {
+      status?: unknown;
+      data?: {
+        status?: unknown;
+        statusCode?: unknown;
+      };
+    };
+  };
+  const rawStatus =
+    apiError?.status ??
+    apiError?.response?.status ??
+    apiError?.response?.data?.status ??
+    apiError?.response?.data?.statusCode;
+  const status = typeof rawStatus === 'number' ? rawStatus : Number(rawStatus);
+  return Number.isFinite(status) ? status : undefined;
+}
+
+function getCanvasProjectLoadFailureState(error: unknown): CanvasProjectLoadState {
+  const status = getErrorStatus(error);
+  if (status === 403) {
+    return {
+      status: 'forbidden',
+      message: 'You do not have access to this project.',
+    };
+  }
+  if (status === 404) {
+    return {
+      status: 'notFound',
+      message: 'This project does not exist or may have been deleted.',
+    };
+  }
+  return {
+    status: 'error',
+    message: error instanceof Error && error.message ? error.message : 'Unable to load this project.',
+  };
 }
 
 function clearVsumTabSessions(
@@ -492,6 +539,147 @@ const ModelDrawerModal: React.FC<ModelDrawerModalProps> = ({
   document.body,
 );
 
+interface CanvasProjectLoadStateOverlayProps {
+  state: CanvasProjectLoadState;
+  projectId?: number;
+  onBack: () => void;
+  onRetry: () => void;
+}
+
+const CanvasProjectLoadStateOverlay: React.FC<CanvasProjectLoadStateOverlayProps> = ({
+  state,
+  projectId,
+  onBack,
+  onRetry,
+}) => {
+  const isLoading = state.status === 'loading' || state.status === 'hydrating';
+  const titleByStatus: Record<CanvasProjectLoadStatus, string> = {
+    loading: 'Loading project…',
+    hydrating: 'Opening workspace…',
+    ready: '',
+    forbidden: 'Access denied',
+    notFound: 'Project not found',
+    error: 'Unable to open project',
+  };
+  const defaultMessageByStatus: Record<CanvasProjectLoadStatus, string> = {
+    loading: projectId ? `Checking access for project ${projectId}.` : 'Checking project access.',
+    hydrating: 'Preparing the workspace.',
+    ready: '',
+    forbidden: 'You do not have permission to open this project.',
+    notFound: 'This project does not exist or may have been deleted.',
+    error: 'The project could not be loaded. Please try again.',
+  };
+
+  return (
+    <div
+      role={isLoading ? 'status' : 'alert'}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        zIndex: 5000,
+        display: 'grid',
+        placeItems: 'center',
+        background: '#f8fafc',
+        fontFamily: 'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
+      }}
+    >
+      <div style={{
+        width: 'min(420px, calc(100vw - 32px))',
+        padding: '28px 30px',
+        background: '#ffffff',
+        border: '1px solid #e2e8f0',
+        borderRadius: 14,
+        boxShadow: '0 20px 60px rgba(15, 23, 42, 0.12)',
+        textAlign: 'center',
+      }}>
+        <div style={{
+          width: 44,
+          height: 44,
+          margin: '0 auto 16px',
+          borderRadius: 999,
+          display: 'grid',
+          placeItems: 'center',
+          background: isLoading ? '#e6f7f5' : '#fef2f2',
+          color: isLoading ? '#049484' : '#b91c1c',
+          fontSize: 22,
+          fontWeight: 700,
+        }}>
+          {isLoading ? (
+            <span style={{
+              width: 20,
+              height: 20,
+              border: '3px solid rgba(4, 148, 132, 0.22)',
+              borderTopColor: '#049484',
+              borderRadius: '50%',
+              animation: 'spin 0.8s linear infinite',
+            }} />
+          ) : '!' }
+        </div>
+        <h1 style={{
+          margin: '0 0 8px',
+          color: '#0f172a',
+          fontSize: 22,
+          lineHeight: 1.2,
+        }}>
+          {titleByStatus[state.status]}
+        </h1>
+        <p style={{
+          margin: 0,
+          color: '#64748b',
+          fontSize: 14,
+          lineHeight: 1.6,
+        }}>
+          {state.message || defaultMessageByStatus[state.status]}
+        </p>
+        {!isLoading && (
+          <div style={{
+            display: 'flex',
+            justifyContent: 'center',
+            gap: 10,
+            marginTop: 22,
+            flexWrap: 'wrap',
+          }}>
+            <button
+              type="button"
+              onClick={onBack}
+              style={{
+                border: '1px solid #cbd5e1',
+                background: '#ffffff',
+                color: '#334155',
+                borderRadius: 8,
+                padding: '10px 16px',
+                fontSize: 14,
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            >
+              Back to project list
+            </button>
+            {state.status === 'error' && (
+              <button
+                type="button"
+                onClick={onRetry}
+                style={{
+                  border: '1px solid #037368',
+                  background: '#049484',
+                  color: '#ffffff',
+                  borderRadius: 8,
+                  padding: '10px 16px',
+                  fontSize: 14,
+                  fontWeight: 700,
+                  cursor: 'pointer',
+                }}
+              >
+                Try again
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
 // ── CanvasPage ────────────────────────────────────────────────────────────────
 
 export const CanvasPage: React.FC = () => {
@@ -556,6 +744,7 @@ export const CanvasPage: React.FC = () => {
 
   const activeTab = openTabs.find(t => t.instanceId === activeInstanceId);
   const activeProjectId = activeTab?.projectId ?? (id ? Number(id) : undefined);
+  const [projectLoadState, setProjectLoadState] = useState<CanvasProjectLoadState>({ status: 'loading' });
 
   const navAccess = React.useMemo(() => {
     const projectId = activeProjectId ?? (id ? Number(id) : undefined);
@@ -977,7 +1166,13 @@ export const CanvasPage: React.FC = () => {
   useEffect(() => {
     if (!id) return;
     const projectId = Number(id);
-    if (!Number.isFinite(projectId)) return;
+    if (!Number.isFinite(projectId)) {
+      setProjectLoadState({
+        status: 'notFound',
+        message: 'This project URL is invalid.',
+      });
+      return;
+    }
 
     setOpenTabs(prev => {
       const existing = prev.find(t => t.projectId === projectId);
@@ -992,6 +1187,7 @@ export const CanvasPage: React.FC = () => {
   }, [id, createInstanceId]);
 
   const loadVsum = useCallback(async (vsumId: number, forInstanceId?: string) => {
+    setProjectLoadState({ status: 'loading' });
     setLoadingProject(true);
     clearCanvasWorkspace();
     globalThis.dispatchEvent(new CustomEvent('vitruv.resetWorkspace'));
@@ -1010,6 +1206,7 @@ export const CanvasPage: React.FC = () => {
     try {
       const response = await apiService.getVsumDetails(vsumId);
       if (isStaleTabLoad(forInstanceId, activeInstanceIdRef.current)) return;
+      setProjectLoadState({ status: 'hydrating' });
 
       const details: VsumDetails = response.data;
       setVsumName(details.name);
@@ -1061,8 +1258,11 @@ export const CanvasPage: React.FC = () => {
         setBaselineForInstance,
         loadedTabsRef.current,
       );
+      setProjectLoadState({ status: 'ready' });
     } catch (e) {
       console.error('Failed to load VSUM:', e);
+      if (isStaleTabLoad(forInstanceId, activeInstanceIdRef.current)) return;
+      setProjectLoadState(getCanvasProjectLoadFailureState(e));
     } finally {
       if (!forInstanceId || activeInstanceIdRef.current === forInstanceId) {
         setLoadingProject(false);
@@ -1153,6 +1353,7 @@ export const CanvasPage: React.FC = () => {
       if (cached && loadedTabsRef.current.has(nextId)) {
         if (openTabsRef.current.some(t => t.instanceId === nextId)) bumpProjectRole();
         applyRef.current(cached);
+        setProjectLoadState({ status: 'ready' });
         return;
       }
       sessionsRef.current.delete(nextId);
@@ -1552,12 +1753,27 @@ export const CanvasPage: React.FC = () => {
 
   const handleCloseConfirmCancel = useCallback(() => setCloseConfirmInstanceId(null), []);
 
+  const handleRetryProjectLoad = useCallback(() => {
+    if (activeProjectId) void loadVsum(activeProjectId, activeInstanceId ?? undefined);
+  }, [activeProjectId, activeInstanceId, loadVsum]);
+
+  const shouldRenderCanvasShell =
+    projectLoadState.status === 'loading' ||
+    projectLoadState.status === 'hydrating' ||
+    projectLoadState.status === 'ready';
+
   // ── render ────────────────────────────────────────────────────────────────
 
   return (
     <div style={{ width: '100vw', height: '100vh', position: 'relative', overflow: 'hidden' }}>
       <style>{`@keyframes spin{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}`}</style>
 
+      {shouldRenderCanvasShell && (
+      <div style={{
+        width: '100%',
+        height: '100%',
+        visibility: projectLoadState.status === 'ready' ? 'visible' : 'hidden',
+      }}>
       <FlowCanvas
         key={activeInstanceId ?? `canvas-${activeProjectId ?? 'new'}`}
         ref={flowCanvasRef}
@@ -1704,6 +1920,17 @@ export const CanvasPage: React.FC = () => {
         onClose={() => setShowShareModal(false)}
         onInvited={refreshProjectMembers}
       />
+      )}
+      </div>
+      )}
+
+      {projectLoadState.status !== 'ready' && (
+        <CanvasProjectLoadStateOverlay
+          state={projectLoadState}
+          projectId={activeProjectId}
+          onBack={() => navigate('/')}
+          onRetry={handleRetryProjectLoad}
+        />
       )}
 
       {/* Popup notification */}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -34,7 +34,7 @@ class ApiService {
   /**
    * Build an Error that keeps backend payload on response.data
    */
-  private createApiError(errorText: string, fallbackMessage: string): Error & { response?: { data: any } } {
+  private createApiError(errorText: string, fallbackMessage: string, status?: number): Error & { status?: number; response?: { status?: number; data: any } } {
     const parsed = this.parseErrorPayload(errorText);
     const message =
       (typeof parsed?.message === 'string' && parsed.message) ||
@@ -42,8 +42,10 @@ class ApiService {
       this.extractErrorMessage(errorText) ||
       fallbackMessage;
 
-    const err = new Error(message) as Error & { response?: { data: any } };
+    const err = new Error(message) as Error & { status?: number; response?: { status?: number; data: any } };
+    err.status = status;
     err.response = {
+      status,
       data: Object.keys(parsed).length > 0
         ? parsed
         : {
@@ -105,7 +107,7 @@ class ApiService {
   ): Promise<never> {
     const errorText = await this.getResponseText(response);
     console.error(context, { status: response.status });
-    throw this.createApiError(errorText, `${method} ${url} failed`);
+    throw this.createApiError(errorText, `${method} ${url} failed`, response.status);
   }
 
   /**

--- a/src/utils/canvasModeStorage.ts
+++ b/src/utils/canvasModeStorage.ts
@@ -1,0 +1,33 @@
+import type { CanvasMode } from '../components/flow/FlowCanvas';
+
+export const DEFAULT_CANVAS_MODE: CanvasMode = 'modeling';
+
+const CANVAS_MODE_STORAGE_PREFIX = 'vitruv.canvasMode';
+
+const isFiniteProjectId = (projectId?: number | null): projectId is number =>
+  typeof projectId === 'number' && Number.isFinite(projectId);
+
+export const canvasModeStorageKey = (projectId: number): string =>
+  `${CANVAS_MODE_STORAGE_PREFIX}.${projectId}`;
+
+export const isCanvasMode = (value: unknown): value is CanvasMode =>
+  value === 'modeling' || value === 'constraints' || value === 'views';
+
+export const readStoredCanvasMode = (projectId?: number | null): CanvasMode => {
+  if (!isFiniteProjectId(projectId)) return DEFAULT_CANVAS_MODE;
+  try {
+    const storedValue = localStorage.getItem(canvasModeStorageKey(projectId));
+    return isCanvasMode(storedValue) ? storedValue : DEFAULT_CANVAS_MODE;
+  } catch {
+    return DEFAULT_CANVAS_MODE;
+  }
+};
+
+export const writeStoredCanvasMode = (projectId: number | undefined | null, mode: CanvasMode): void => {
+  if (!isFiniteProjectId(projectId)) return;
+  try {
+    localStorage.setItem(canvasModeStorageKey(projectId), mode);
+  } catch {
+    return;
+  }
+};


### PR DESCRIPTION
This PR groups several small frontend UX improvements and route-handling fixes.

**Changes**
- Adds show/hide password toggles to the Change Password modal, matching Sign In and Sign Up behavior.
- Keeps New Password and Confirm Password visibility state independent.
- Prevents the Upload Model dialog from closing when the OS file picker is canceled.
- Preserves the selected canvas workspace after refresh: Modeling, Constraints, or Views.
- Adds proper canvas error states for invalid or inaccessible VSUM routes.
- Shows access-denied feedback for `403` responses.
- Shows not-found feedback for `404` responses.
- Prevents an empty canvas from rendering when VSUM details fail to load.
- Preserves API HTTP status on failed authenticated requests so frontend error handling can distinguish `403` and `404`.

**Testing**
- `ChangePasswordModal.test.tsx`
- `CreateModelModal.test.tsx`
- `canvasModeStorage.test.ts`
- `FlowCanvas.test.tsx`
- `CanvasPage.test.tsx`
- `api.test.ts`
- `npm run build`