### PR TITLE
Replace right-click with hover add-points for ViewType creation

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "vitruv-ui",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "start"],
+      "port": 3000
+    }
+  ]
+}

--- a/src/__tests__/components/flow/canvas/CircleOverlay.test.tsx
+++ b/src/__tests__/components/flow/canvas/CircleOverlay.test.tsx
@@ -184,31 +184,56 @@ describe('CircleOverlay', () => {
         expect(screen.queryByText('⤡')).toBeNull();
     });
 
-    // Context menu
+    // Hover add-points + context menu
 
-    it('shows context menu on right-click of circle hitbox', () => {
-        const { container } = render(<CircleOverlay {...defaultProps()} />);
+    const hoverCircle = (container: HTMLElement) => {
         // The hitbox is the transparent stroke circle — find it by stroke attr
         const hitbox = container.querySelectorAll('circle')[1]; // visible + hitbox
-        fireEvent.contextMenu(hitbox);
+        fireEvent.mouseEnter(hitbox.parentElement as Element);
+        return hitbox;
+    };
+
+    it('does not show add-points before hovering the circle', () => {
+        const { container } = render(<CircleOverlay {...defaultProps()} />);
+        // add-points render as extra <g> children inside the hitbox group; none should exist yet
+        expect(container.querySelectorAll('circle')).toHaveLength(2); // visible + hitbox only
+    });
+
+    it('shows add-points on hover and hides them on mouse leave', () => {
+        const { container } = render(<CircleOverlay {...defaultProps()} />);
+        const hitbox = hoverCircle(container);
+        // 2 circles per add-point (hit area + visible dot) × 4 cardinal slots
+        expect(container.querySelectorAll('circle')).toHaveLength(2 + 4 * 2);
+
+        fireEvent.mouseLeave(hitbox.parentElement as Element);
+        expect(container.querySelectorAll('circle')).toHaveLength(2);
+    });
+
+    it('opens the context menu when an add-point is clicked', () => {
+        const { container } = render(<CircleOverlay {...defaultProps()} />);
+        hoverCircle(container);
+        const addPointDot = container.querySelectorAll('circle')[3]; // first add-point's visible dot
+        fireEvent.click(addPointDot);
         expect(screen.getByTestId('context-menu')).toBeInTheDocument();
     });
 
     it('closes context menu when onClose is called', () => {
         const { container } = render(<CircleOverlay {...defaultProps()} />);
-        const hitbox = container.querySelectorAll('circle')[1];
-        fireEvent.contextMenu(hitbox);
+        hoverCircle(container);
+        const addPointDot = container.querySelectorAll('circle')[3];
+        fireEvent.click(addPointDot);
         fireEvent.click(screen.getByTestId('context-menu-close'));
         expect(screen.queryByTestId('context-menu')).toBeNull();
     });
 
-    it('calls onAddViewType with computed angle when context menu adds a view type', () => {
+    it('calls onAddViewType with the clicked add-point angle when context menu adds a view type', () => {
         const onAddViewType = jest.fn();
         const { container } = render(
             <CircleOverlay {...defaultProps()} onAddViewType={onAddViewType} />
         );
-        const hitbox = container.querySelectorAll('circle')[1];
-        fireEvent.contextMenu(hitbox);
+        hoverCircle(container);
+        const addPointDot = container.querySelectorAll('circle')[3];
+        fireEvent.click(addPointDot);
         fireEvent.click(screen.getByTestId('context-menu-add'));
         expect(onAddViewType).toHaveBeenCalledWith(
             'VT1', 'single', ['node-1'],
@@ -283,31 +308,37 @@ describe('CircleOverlay', () => {
 
     // Angle computation
 
-    it('places first bubble at -π/2 (top) when no existing viewTypes', () => {
+    it('offers an add-point at -π/2 (top) when no existing viewTypes, and spawns the VT there', () => {
         const onAddViewType = jest.fn();
         const { container } = render(
             <CircleOverlay {...defaultProps()} onAddViewType={onAddViewType} viewTypes={[]} />
         );
-        const hitbox = container.querySelectorAll('circle')[1];
-        fireEvent.contextMenu(hitbox);
+        hoverCircle(container);
+        const topAddPointDot = container.querySelectorAll('circle')[3]; // first cardinal slot: top
+        fireEvent.click(topAddPointDot);
         fireEvent.click(screen.getByTestId('context-menu-add'));
         const angle = onAddViewType.mock.calls[0][3];
         expect(angle).toBeCloseTo(-Math.PI / 2);
     });
 
-    it('places second bubble in the largest gap between existing bubbles', () => {
+    it('relocates the top add-point into the largest gap once the top slot is occupied', () => {
         const onAddViewType = jest.fn();
         const props = {
             ...defaultProps(),
-            viewTypes: [makeViewType({ angle: -Math.PI / 2 })], // top
+            viewTypes: [makeViewType({ angle: -Math.PI / 2 })], // top is now occupied
             onAddViewType,
         };
         const { container } = render(<CircleOverlay {...props} />);
-        const hitbox = container.querySelectorAll('circle')[1];
-        fireEvent.contextMenu(hitbox);
+        hoverCircle(container);
+        // Cardinal order is top/right/bottom/left; top is occupied so right/bottom/left
+        // stay as add-points (reserved so the relocated point can't land on them too),
+        // and the 4th (relocated) add-point is computed via the same gap algorithm used
+        // for new VT bubbles — here the largest tied gap is between right (0) and
+        // bottom (π/2), so it lands at their midpoint, π/4. Rendered last.
+        const relocatedAddPointDot = container.querySelectorAll('circle')[9];
+        fireEvent.click(relocatedAddPointDot);
         fireEvent.click(screen.getByTestId('context-menu-add'));
         const angle = onAddViewType.mock.calls[0][3];
-        // Largest gap is the lower half → best angle ≈ π/2 (bottom)
-        expect(angle).toBeCloseTo(Math.PI / 2, 1);
+        expect(angle).toBeCloseTo(Math.PI / 4, 1);
     });
 });

--- a/src/__tests__/components/ui/ModelLibraryTable.test.tsx
+++ b/src/__tests__/components/ui/ModelLibraryTable.test.tsx
@@ -5,6 +5,7 @@ import { ModelDetailModal, ModelLibraryTable } from '../../../components/ui/Mode
 jest.mock('../../../services/api', () => ({
   apiService: {
     findMetaModels: jest.fn(),
+    deleteMetaModel: jest.fn(),
   },
 }));
 
@@ -24,15 +25,26 @@ jest.mock('../../../components/ui/CreateModelModal', () => ({
 }));
 
 const { apiService } = require('../../../services/api') as {
-  apiService: { findMetaModels: jest.Mock };
+  apiService: { findMetaModels: jest.Mock; deleteMetaModel: jest.Mock };
 };
 
 const existingModel = { id: 1, name: 'Existing Model', createdAt: new Date().toISOString(), ecoreFileId: 1, genModelFileId: 1 };
 const newModel = { id: 2, name: 'New Model', createdAt: new Date().toISOString(), ecoreFileId: 5, genModelFileId: 6 };
 
+/** Mocks the 3 parallel find-all buckets fetchLibraryMetaModels issues: unscoped, owned, shared. */
+const mockLibraryFetch = (options: { owned?: any[]; notOwned?: any[] }) => {
+  const owned = options.owned ?? [];
+  const notOwned = options.notOwned ?? [];
+  apiService.findMetaModels
+    .mockResolvedValueOnce({ data: [...owned, ...notOwned] })
+    .mockResolvedValueOnce({ data: owned })
+    .mockResolvedValueOnce({ data: notOwned });
+};
+
 describe('ModelLibraryTable', () => {
   beforeEach(() => {
     apiService.findMetaModels.mockReset();
+    apiService.deleteMetaModel.mockReset();
     apiService.findMetaModels.mockResolvedValue({ data: [existingModel] });
   });
 
@@ -107,5 +119,84 @@ describe('ModelLibraryTable', () => {
     const formLabels = Array.from(document.querySelector('form')!.querySelectorAll('label'))
       .map((label) => label.textContent);
     expect(formLabels).toEqual(['Name', 'Keywords', 'Description', 'Domain']);
+  });
+
+  describe('delete model', () => {
+    it('lets the owner delete a model that is not referenced by any project', async () => {
+      apiService.findMetaModels.mockReset();
+      mockLibraryFetch({ owned: [existingModel] });
+      apiService.deleteMetaModel.mockResolvedValue({ data: null, message: '' });
+
+      render(<ModelLibraryTable />);
+      await waitFor(() => expect(screen.getByText('Existing Model')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByLabelText('Row actions'));
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+      expect(screen.getByText('Delete model')).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+      });
+
+      expect(apiService.deleteMetaModel).toHaveBeenCalledWith('1');
+      await waitFor(() => expect(screen.queryByText('Existing Model')).not.toBeInTheDocument());
+    });
+
+    it('does not offer a delete action for models the current user does not own', async () => {
+      apiService.findMetaModels.mockReset();
+      mockLibraryFetch({ notOwned: [existingModel] });
+
+      render(<ModelLibraryTable />);
+      await waitFor(() => expect(screen.getByText('Existing Model')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByLabelText('Row actions'));
+      expect(screen.queryByRole('menuitem', { name: 'Delete' })).not.toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'View details' })).toBeInTheDocument();
+    });
+
+    it('blocks deletion up front for a model referenced by a project — only the reason and Cancel are shown', async () => {
+      const referencedModel = { ...existingModel, vsums: [{ id: 99 }] };
+      apiService.findMetaModels.mockReset();
+      mockLibraryFetch({ owned: [referencedModel] });
+
+      render(<ModelLibraryTable />);
+      await waitFor(() => expect(screen.getByText('Existing Model')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByLabelText('Row actions'));
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+
+      // No API call and no way to confirm — the dialog opens already blocked.
+      expect(screen.getByText('This model is used by one or more projects and cannot be deleted.')).toBeInTheDocument();
+      expect(apiService.deleteMetaModel).not.toHaveBeenCalled();
+      expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(screen.queryByText('Delete model')).not.toBeInTheDocument();
+      expect(screen.getByText('Existing Model')).toBeInTheDocument();
+    });
+
+    it('falls back to the same reason-only + Cancel state when the backend rejects the deletion', async () => {
+      apiService.findMetaModels.mockReset();
+      mockLibraryFetch({ owned: [existingModel] });
+      apiService.deleteMetaModel.mockRejectedValue(new Error('Model is still referenced by a project.'));
+
+      render(<ModelLibraryTable />);
+      await waitFor(() => expect(screen.getByText('Existing Model')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByLabelText('Row actions'));
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+      expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+      });
+
+      expect(screen.getByText('Model is still referenced by a project.')).toBeInTheDocument();
+      expect(screen.getByText('Existing Model')).toBeInTheDocument();
+      // The dialog no longer offers a "Delete" retry — only acknowledge and close.
+      expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    });
   });
 });

--- a/src/__tests__/hooks/useFlowState.test.ts
+++ b/src/__tests__/hooks/useFlowState.test.ts
@@ -47,6 +47,25 @@ describe('useFlowState', () => {
             expect(labels).toContain('Node 1');
             expect(labels).toContain('Node 2');
         });
+
+        it('should use a caller-provided id instead of overwriting it, when one is given', () => {
+            // Mirrors FlowCanvas.addEcoreFile, which builds a semantic id (e.g. "ecore-42")
+            // up front and relies on it being the id actually stored in state.
+            const { result } = renderHook(() => useFlowState());
+
+            let nodeId: string = '';
+            act(() => {
+                nodeId = result.current.addNode({
+                    id: 'ecore-42',
+                    position: { x: 0, y: 0 },
+                    data: { label: 'Metamodel' },
+                } as any);
+            });
+
+            expect(nodeId).toBe('ecore-42');
+            expect(result.current.nodes).toHaveLength(1);
+            expect(result.current.nodes[0].id).toBe('ecore-42');
+        });
     });
 
     describe('removeNode', () => {
@@ -213,6 +232,83 @@ describe('useFlowState', () => {
 
             expect(result.current.nodes).toHaveLength(0);
             expect(result.current.edges).toHaveLength(0);
+        });
+    });
+
+    describe('undo integration', () => {
+        it('removes a newly added node when undo is called', () => {
+            const { result } = renderHook(() => useFlowState());
+
+            act(() => {
+                result.current.addNode({ position: { x: 0, y: 0 }, data: { label: 'Node 1' } });
+            });
+            expect(result.current.nodes).toHaveLength(1);
+            expect(result.current.canUndo).toBe(true);
+
+            act(() => {
+                result.current.undo();
+            });
+            expect(result.current.nodes).toHaveLength(0);
+        });
+
+        it('a single undo fully removes an added node even after ReactFlow re-measures it (width/height/selected/dragging)', () => {
+            // Reproduces the real bug: ReactFlow measures a node's DOM size after it first
+            // renders and writes width/height back via setNodes — a React-Flow-internal
+            // bookkeeping update, not a user edit. Before the fix, that measurement was
+            // treated as a real "Node modified" history entry, so a single Undo only
+            // stripped the measurement back off and left the node itself in place.
+            const { result } = renderHook(() => useFlowState());
+
+            act(() => {
+                result.current.addNode({ position: { x: 0, y: 0 }, data: { label: 'New Metamodel' } });
+            });
+            expect(result.current.nodes).toHaveLength(1);
+
+            act(() => {
+                result.current.setNodes(nds => nds.map(n => ({
+                    ...n,
+                    width: 118,
+                    height: 126,
+                    positionAbsolute: n.position,
+                    selected: false,
+                    dragging: false,
+                })));
+            });
+            expect(result.current.nodes[0]).toMatchObject({ width: 118, height: 126 });
+
+            act(() => {
+                result.current.undo();
+            });
+            expect(result.current.nodes).toHaveLength(0);
+        });
+
+        it('establishBaseline resets canUndo to false and undo no longer reverts prior nodes', () => {
+            // Mirrors hydrateCanvasWorkspace loading a project's existing metamodels
+            // (several addNode calls), after which establishBaseline() marks that
+            // loaded state as the undo floor — so it is not itself undoable.
+            const { result } = renderHook(() => useFlowState());
+
+            act(() => {
+                result.current.addNode({ position: { x: 0, y: 0 }, data: { label: 'Existing Metamodel' } });
+            });
+            act(() => {
+                result.current.establishBaseline();
+            });
+            expect(result.current.canUndo).toBe(false);
+            expect(result.current.nodes).toHaveLength(1);
+
+            act(() => {
+                result.current.addNode({ position: { x: 100, y: 0 }, data: { label: 'New Metamodel' } });
+            });
+            expect(result.current.nodes).toHaveLength(2);
+            expect(result.current.canUndo).toBe(true);
+
+            act(() => {
+                result.current.undo();
+            });
+            expect(result.current.nodes).toHaveLength(1);
+            expect(result.current.nodes[0].data.label).toBe('Existing Metamodel');
+            expect(result.current.canUndo).toBe(false);
         });
     });
 

--- a/src/__tests__/utils/metaModelList.test.ts
+++ b/src/__tests__/utils/metaModelList.test.ts
@@ -3,6 +3,7 @@ import {
   fetchLibraryMetaModels,
   fetchLibraryMetaModelsAfterCreate,
   findMatchingCreatedModel,
+  isModelReferencedByProjects,
   mergeCreatedMetaModel,
   normalizeCreatedMetaModel,
 } from '../../utils/metaModelList';
@@ -36,6 +37,34 @@ describe('fetchLibraryMetaModels', () => {
   it('returns empty array when all requests fail', async () => {
     findMetaModels.mockRejectedValue(new Error('network'));
     await expect(fetchLibraryMetaModels({})).resolves.toEqual([]);
+  });
+
+  it('marks models returned by the ownedByUser:true bucket as owned by the current user', async () => {
+    findMetaModels
+      .mockResolvedValueOnce({ data: [{ id: 1, name: 'Mine' }, { id: 2, name: 'Not mine' }] })
+      .mockResolvedValueOnce({ data: [{ id: 1, name: 'Mine' }] })
+      .mockResolvedValueOnce({ data: [{ id: 2, name: 'Not mine' }] });
+
+    const models = await fetchLibraryMetaModels({});
+
+    const mine = models.find(m => m.id === 1);
+    const notMine = models.find(m => m.id === 2);
+    expect(mine?.isOwnedByCurrentUser).toBe(true);
+    expect(notMine?.isOwnedByCurrentUser).toBe(false);
+  });
+});
+
+describe('isModelReferencedByProjects', () => {
+  it('is false when neither vsums nor projects are populated', () => {
+    expect(isModelReferencedByProjects({ id: 1, name: 'Eco' })).toBe(false);
+  });
+
+  it('is true when the model has at least one vsum reference', () => {
+    expect(isModelReferencedByProjects({ id: 1, name: 'Eco', vsums: [{ id: 1 }] })).toBe(true);
+  });
+
+  it('is true when the model has at least one project reference', () => {
+    expect(isModelReferencedByProjects({ id: 1, name: 'Eco', projects: [{ id: 1 }] })).toBe(true);
   });
 });
 

--- a/src/components/flow/FlowCanvas.tsx
+++ b/src/components/flow/FlowCanvas.tsx
@@ -413,6 +413,7 @@ export const FlowCanvas = forwardRef<{
   getWorkspaceSnapshot: () => WorkspaceSnapshot;
   fitUmlView: () => void;
   openSelectedReactionEditor: () => boolean;
+  establishBaseline: () => void;
 }, FlowCanvasProps>(
   function FlowCanvasComponent(
   {
@@ -2131,7 +2132,8 @@ export const FlowCanvas = forwardRef<{
       autoLayoutEcoreBoxes,
       fitUmlView,
       openSelectedReactionEditor,
-    }), [handleToolClick, loadDiagramData, nodes, edges, addEcoreFile, updateEcoreFileData, resetExpandedFile, undo, redo, canUndo, canRedo, getReactionEdges, buildWorkspaceSnapshot, autoLayoutEcoreBoxes, fitUmlView, openSelectedReactionEditor]);
+      establishBaseline,
+    }), [handleToolClick, loadDiagramData, nodes, edges, addEcoreFile, updateEcoreFileData, resetExpandedFile, undo, redo, canUndo, canRedo, getReactionEdges, buildWorkspaceSnapshot, autoLayoutEcoreBoxes, fitUmlView, openSelectedReactionEditor, establishBaseline]);
 
     const mappedNodes = nodes.map(node => {
       if (node.type === 'editable') {

--- a/src/components/flow/canvas/CircleOverlay.tsx
+++ b/src/components/flow/canvas/CircleOverlay.tsx
@@ -306,11 +306,11 @@ export const CircleOverlay: React.FC<CircleOverlayProps> = ({
                         onClick={(e) => { e.stopPropagation(); onSelect(); }}
                     />
 
-                    {isHovered && !contextMenu && addPointAngles.map((angle, i) => {
+                    {isHovered && !contextMenu && addPointAngles.map((angle) => {
                         const pos = getBubbleScreenPos(angle);
                         return (
                             <g
-                                key={`add-point-${i}`}
+                                key={`add-point-${angle.toFixed(5)}`}
                                 style={{ cursor: 'pointer' }}
                                 onClick={(e) => handleAddPointClick(angle, e)}
                             >

--- a/src/components/flow/canvas/CircleOverlay.tsx
+++ b/src/components/flow/canvas/CircleOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { Circle } from '../../../hooks/useCircleContainment';
 import { ViewType, ViewTypeScope } from '../../../hooks/useViewTypes';
 import { Node } from 'reactflow';
@@ -61,6 +61,42 @@ const computeBestAngle = (existingAngles: number[]): number => {
     return bestAngle;
 };
 
+// Preferred add-point slots: top, right, bottom, left.
+const CARDINAL_ANGLES = [-Math.PI / 2, 0, Math.PI / 2, Math.PI];
+const ADD_POINT_OCCUPIED_THRESHOLD = 0.2; // radians — how close a VT must be to "claim" a cardinal slot
+const ADD_POINT_RADIUS = 7;
+const ADD_POINT_HIT_RADIUS = 14;
+
+const angularDistance = (a: number, b: number): number => {
+    const diff = Math.abs(a - b) % (2 * Math.PI);
+    return diff > Math.PI ? 2 * Math.PI - diff : diff;
+};
+
+// Hover add-points: one per free cardinal slot; once a cardinal slot is occupied
+// by a VT bubble, its add-point relocates to the next best gap — same algorithm
+// used to place new VT bubbles — so add-points never overlap existing bubbles.
+const computeAddPointAngles = (existingAngles: number[]): number[] => {
+    const occupied = [...existingAngles];
+    const addPoints: number[] = [];
+
+    for (const cardinal of CARDINAL_ANGLES) {
+        const isFree = occupied.every(a => angularDistance(a, cardinal) > ADD_POINT_OCCUPIED_THRESHOLD);
+        if (isFree) {
+            addPoints.push(cardinal);
+            occupied.push(cardinal);
+        }
+    }
+
+    const missing = CARDINAL_ANGLES.length - addPoints.length;
+    for (let i = 0; i < missing; i++) {
+        const angle = computeBestAngle(occupied);
+        addPoints.push(angle);
+        occupied.push(angle);
+    }
+
+    return addPoints;
+};
+
 export const CircleOverlay: React.FC<CircleOverlayProps> = ({
     circle,
     viewport,
@@ -79,6 +115,8 @@ export const CircleOverlay: React.FC<CircleOverlayProps> = ({
 }) => {
     const [previewR, setPreviewR] = useState<number | null>(null);
     const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
+    const [pendingAngle, setPendingAngle] = useState<number | null>(null);
+    const [isHovered, setIsHovered] = useState(false);
     const [deletionMenu, setDeletionMenu] = useState<{
         x: number; y: number; id: string; label: string;
     } | null>(null);
@@ -159,9 +197,21 @@ export const CircleOverlay: React.FC<CircleOverlayProps> = ({
     }, [getContainerOffset]);
 
     const handleAddViewType = useCallback((label: string, scope: ViewTypeScope, linkedNodeIds: string[], editable: boolean) => {
-        const angle = computeBestAngle(viewTypes.map(vt => vt.angle));
+        const angle = pendingAngle ?? computeBestAngle(viewTypes.map(vt => vt.angle));
         onAddViewType(label, scope, linkedNodeIds, angle, editable);
-    }, [viewTypes, onAddViewType]);
+        setPendingAngle(null);
+    }, [pendingAngle, viewTypes, onAddViewType]);
+
+    const handleAddPointClick = useCallback((angle: number, e: React.MouseEvent) => {
+        e.stopPropagation();
+        setPendingAngle(angle);
+        setContextMenu({ x: e.clientX, y: e.clientY });
+    }, []);
+
+    const addPointAngles = useMemo(
+        () => computeAddPointAngles(viewTypes.map(vt => vt.angle)),
+        [viewTypes]
+    );
 
     if (circle.r === 0) return null;
 
@@ -242,19 +292,34 @@ export const CircleOverlay: React.FC<CircleOverlayProps> = ({
                     pointerEvents="none"
                 />
 
-                {/* Circle hitbox — stroke only */}
-                <circle
-                    cx={screenCx} cy={screenCy} r={screenR}
-                    fill="none" stroke="transparent" strokeWidth={20}
-                    pointerEvents="stroke"
-                    style={{ cursor: 'pointer' }}
-                    onClick={(e) => { e.stopPropagation(); onSelect(); }}
-                    onContextMenu={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        setContextMenu({ x: e.clientX, y: e.clientY });
-                    }}
-                />
+                {/* Circle hitbox + hover add-points */}
+                <g
+                    pointerEvents="all"
+                    onMouseEnter={() => setIsHovered(true)}
+                    onMouseLeave={() => setIsHovered(false)}
+                >
+                    <circle
+                        cx={screenCx} cy={screenCy} r={screenR}
+                        fill="none" stroke="transparent" strokeWidth={20}
+                        pointerEvents="stroke"
+                        style={{ cursor: 'pointer' }}
+                        onClick={(e) => { e.stopPropagation(); onSelect(); }}
+                    />
+
+                    {isHovered && !contextMenu && addPointAngles.map((angle, i) => {
+                        const pos = getBubbleScreenPos(angle);
+                        return (
+                            <g
+                                key={`add-point-${i}`}
+                                style={{ cursor: 'pointer' }}
+                                onClick={(e) => handleAddPointClick(angle, e)}
+                            >
+                                <circle cx={pos.x} cy={pos.y} r={ADD_POINT_HIT_RADIUS} fill="transparent" />
+                                <circle cx={pos.x} cy={pos.y} r={ADD_POINT_RADIUS} fill="#ef4444" stroke="none" />
+                            </g>
+                        );
+                    })}
+                </g>
 
                 {/* Bubbles */}
                 {viewTypes.map(vt => {
@@ -305,7 +370,7 @@ export const CircleOverlay: React.FC<CircleOverlayProps> = ({
                     y={contextMenu.y}
                     ecoreNodes={ecoreNodes}
                     onAdd={handleAddViewType}
-                    onClose={() => setContextMenu(null)}
+                    onClose={() => { setContextMenu(null); setPendingAngle(null); }}
                 />
             )}
 

--- a/src/components/ui/ModelLibraryTable.tsx
+++ b/src/components/ui/ModelLibraryTable.tsx
@@ -29,8 +29,11 @@ import {
   extractCreatePayload,
   fetchLibraryMetaModels,
   fetchLibraryMetaModelsAfterCreate,
+  isModelReferencedByProjects,
+  LibraryMetaModel,
 } from '../../utils/metaModelList';
 import { PortalRowActionsMenu } from './PortalRowActionsMenu';
+import { ConfirmDialog } from './ConfirmDialog';
 
 interface ModelLibraryTableProps {
   onModelOpen?: (model: any) => void;
@@ -722,6 +725,8 @@ export const ModelLibraryTable: React.FC<ModelLibraryTableProps> = ({ onModelOpe
   const [showAdvancedSearch, setShowAdvancedSearch] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
   const [viewModel, setViewModel] = useState<any>(null);
+  const [deletingModel, setDeletingModel] = useState<LibraryMetaModel | null>(null);
+  const [deleteError, setDeleteError] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 10;
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -805,6 +810,43 @@ export const ModelLibraryTable: React.FC<ModelLibraryTableProps> = ({ onModelOpe
     }
   }, [clearAllFilters]);
 
+  const requestDeleteModel = useCallback((model: LibraryMetaModel) => {
+    // Both rules are checked up front so a model that's already known to be
+    // blocked never shows a "Delete" action at all — only the reason + Cancel.
+    if (!model.isOwnedByCurrentUser) {
+      setDeleteError('Only the owner of this model can delete it.');
+    } else if (isModelReferencedByProjects(model)) {
+      setDeleteError('This model is used by one or more projects and cannot be deleted.');
+    } else {
+      setDeleteError('');
+    }
+    setDeletingModel(model);
+  }, []);
+
+  const cancelDeleteModel = useCallback(() => {
+    setDeletingModel(null);
+    setDeleteError('');
+  }, []);
+
+  const performDelete = useCallback(async () => {
+    if (!deletingModel) return;
+    try {
+      await apiService.deleteMetaModel(String(deletingModel.id));
+      setModels(prev => prev.filter(m => m.id !== deletingModel.id));
+      setDeletingModel(null);
+      setDeleteError('');
+      if (viewModel?.id === deletingModel.id) setViewModel(null);
+    } catch (e: unknown) {
+      // "Referenced by a project" can only be fully known by the backend (it
+      // spans every V-SUM, not just ones visible to this user) — if it rejects
+      // the request for either rule, switch to the same reason-only + Cancel
+      // state instead of leaving an actionable "Delete" button up.
+      setDeleteError(e instanceof Error ? e.message : 'Failed to delete model');
+    }
+  }, [deletingModel, viewModel]);
+
+  const isDeleteBlocked = !!deleteError;
+
   const appendSearchFilter = (key: 'name' | 'domain' | 'keywords' | 'created', value: string) => {
     setSearch(prev => appendMetaModelSearchToken(prev, key, value));
   };
@@ -852,6 +894,7 @@ export const ModelLibraryTable: React.FC<ModelLibraryTableProps> = ({ onModelOpe
           setViewModel(model);
           onModelOpen?.(model);
         }}
+        onDelete={() => requestDeleteModel(model)}
       />
     ));
   }
@@ -1038,6 +1081,18 @@ export const ModelLibraryTable: React.FC<ModelLibraryTableProps> = ({ onModelOpe
           onUpdated={() => { fetchModels(); }}
         />
       )}
+
+      <ConfirmDialog
+        isOpen={!!deletingModel}
+        title="Delete model"
+        message={deleteError || `Do you really want to delete "${deletingModel?.name}"? This action cannot be undone.`}
+        confirmText={isDeleteBlocked ? 'Cancel' : 'Delete'}
+        cancelText="Cancel"
+        singleAction={isDeleteBlocked}
+        variant="danger"
+        onConfirm={isDeleteBlocked ? cancelDeleteModel : performDelete}
+        onCancel={cancelDeleteModel}
+      />
     </div>
   );
 };
@@ -1047,11 +1102,12 @@ export const ModelLibraryTable: React.FC<ModelLibraryTableProps> = ({ onModelOpe
 interface TableRowProps {
   model: any;
   onView: () => void;
+  onDelete: () => void;
 }
 
-const TableRow: React.FC<TableRowProps> = ({ model, onView }) => {
+const TableRow: React.FC<TableRowProps> = ({ model, onView, onDelete }) => {
   const [hovered, setHovered] = useState(false);
-  const hasProjects = model.vsums?.length > 0 || model.projects?.length > 0;
+  const hasProjects = isModelReferencedByProjects(model);
 
   return (
     <tr
@@ -1083,6 +1139,9 @@ const TableRow: React.FC<TableRowProps> = ({ model, onView }) => {
           minWidth={140}
           actions={[
             { label: 'View details', onClick: onView },
+            ...(model.isOwnedByCurrentUser
+              ? [{ label: 'Delete', onClick: onDelete, danger: true, dividerBefore: true }]
+              : []),
           ]}
         />
       </td>

--- a/src/hooks/useFlowState.ts
+++ b/src/hooks/useFlowState.ts
@@ -9,13 +9,40 @@ interface UseFlowStateProps {
 
 type DiagramState = { nodes: Node[]; edges: Edge[]; idCounter: number };
 
+// React Flow manages these fields internally — width/height/positionAbsolute come from
+// its own post-render measurement of the DOM node, dragging/selected are transient
+// interaction UI state. None of them are user-intentional diagram edits, so they must be
+// excluded when deciding whether a new undo/redo history entry is warranted. Otherwise,
+// applying an older history state (e.g. one saved before a node was first measured)
+// causes React Flow to immediately re-measure and re-populate width/height, which the
+// diff would treat as a fresh "change" and auto-save right back — silently undoing the
+// user's undo.
+const NODE_FIELDS_IGNORED_FOR_HISTORY = ['width', 'height', 'positionAbsolute', 'dragging', 'selected', 'resizing'] as const;
+const EDGE_FIELDS_IGNORED_FOR_HISTORY = ['selected'] as const;
+
+function omitFields<T extends object>(obj: T, fields: readonly string[]): T {
+  const clone: any = { ...obj };
+  fields.forEach(f => delete clone[f]);
+  return clone;
+}
+
+function normalizeForHistoryComparison(state: DiagramState): DiagramState {
+  return {
+    nodes: state.nodes.map(n => omitFields(n, NODE_FIELDS_IGNORED_FOR_HISTORY)),
+    edges: state.edges.map(e => omitFields(e, EDGE_FIELDS_IGNORED_FOR_HISTORY)),
+    idCounter: state.idCounter,
+  };
+}
+
 function hasDiagramStateChanged(lastSaved: DiagramState, current: DiagramState): boolean {
+  const a = normalizeForHistoryComparison(lastSaved);
+  const b = normalizeForHistoryComparison(current);
   return (
-    lastSaved.nodes.length !== current.nodes.length ||
-    lastSaved.edges.length !== current.edges.length ||
-    lastSaved.idCounter !== current.idCounter ||
-    JSON.stringify(lastSaved.nodes) !== JSON.stringify(current.nodes) ||
-    JSON.stringify(lastSaved.edges) !== JSON.stringify(current.edges)
+    a.nodes.length !== b.nodes.length ||
+    a.edges.length !== b.edges.length ||
+    a.idCounter !== b.idCounter ||
+    JSON.stringify(a.nodes) !== JSON.stringify(b.nodes) ||
+    JSON.stringify(a.edges) !== JSON.stringify(b.edges)
   );
 }
 
@@ -189,18 +216,12 @@ export function useFlowState(props?: UseFlowStateProps) {
     [getId, setEdges, nodes, chooseHandlesForPair]
   );
 
-  const addNode = useCallback((node: Omit<Node, 'id'>) => {
+  const addNode = useCallback((node: (Omit<Node, 'id'> & { id?: string })) => {
     const newNode: Node = {
       ...node,
-      id: getId(),
+      id: node.id ?? getId(),
     };
-    console.log('useFlowState.addNode called with:', node);
-    console.log('Created newNode:', newNode);
-    setNodes((nds) => {
-      const newNodes = nds.concat(newNode);
-      console.log('Updated nodes array:', newNodes);
-      return newNodes;
-    });
+    setNodes((nds) => nds.concat(newNode));
     return newNode.id;
   }, [getId, setNodes]);
 

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -237,7 +237,7 @@ interface HydrateCanvasWorkspaceParams {
   details: VsumDetails;
   forInstanceId?: string;
   activeInstanceId: string | null;
-  flowCanvasRef: React.RefObject<{ getNodes?: () => Node[] } | null>;
+  flowCanvasRef: React.RefObject<{ getNodes?: () => Node[]; establishBaseline?: () => void } | null>;
   canvasMode: CanvasMode;
   setConstraintsNodes: React.Dispatch<React.SetStateAction<Node[]>>;
   setMyLibraryModels: React.Dispatch<React.SetStateAction<DrawerModel[]>>;
@@ -280,6 +280,12 @@ async function hydrateCanvasWorkspace(params: HydrateCanvasWorkspaceParams): Pro
 
   await new Promise(r => setTimeout(r, 150));
   if (isStale()) return false;
+
+  // The project's existing metamodels/relations just loaded via a sequence of
+  // canvas mutations (one per file, one per relation) — none of that should be
+  // undoable by the user. Establish it as the undo baseline, mirroring how
+  // loadDiagramData() resets the baseline for every other bulk-load path.
+  flowCanvasRef.current?.establishBaseline?.();
 
   globalThis.dispatchEvent(new CustomEvent('vitruv.fitEcoreWorkspace'));
   return true;

--- a/src/utils/metaModelList.ts
+++ b/src/utils/metaModelList.ts
@@ -13,6 +13,13 @@ export interface LibraryMetaModel {
   genModelFileId?: number;
   vsums?: unknown[];
   projects?: unknown[];
+  /** True when the current user owns this model (derived from the `ownedByUser: true` fetch bucket). */
+  isOwnedByCurrentUser?: boolean;
+}
+
+/** True when a model is referenced by at least one project in any V-SUM. */
+export function isModelReferencedByProjects(model: LibraryMetaModel): boolean {
+  return (model.vsums?.length ?? 0) > 0 || (model.projects?.length ?? 0) > 0;
 }
 
 export interface CreateMetaModelPayload {
@@ -65,6 +72,7 @@ export function normalizeCreatedMetaModel(data: unknown): LibraryMetaModel | nul
         createdAt: typeof (data as Record<string, unknown>).createdAt === 'string'
           ? (data as Record<string, unknown>).createdAt as string
           : new Date().toISOString(),
+        isOwnedByCurrentUser: true,
       };
     }
   }
@@ -82,6 +90,8 @@ export function buildPendingMetaModelFromCreate(payload: CreateMetaModelPayload)
     createdAt: new Date().toISOString(),
     ecoreFileId: payload.ecoreFileId,
     genModelFileId: payload.genModelFileId,
+    // The current user always owns a model they just created.
+    isOwnedByCurrentUser: true,
   };
 }
 
@@ -144,21 +154,29 @@ export async function fetchLibraryMetaModels(
 ): Promise<LibraryMetaModel[]> {
   const baseFilters = stripOwnedByUser(filters);
 
-  const requests = [
+  const [unscopedResult, ownedResult, sharedResult] = await Promise.allSettled([
     apiService.findMetaModels(baseFilters),
     apiService.findMetaModels({ ...baseFilters, ownedByUser: true }),
     apiService.findMetaModels({ ...baseFilters, ownedByUser: false }),
-  ];
+  ]);
 
-  const results = await Promise.allSettled(requests);
   const lists: LibraryMetaModel[][] = [];
-  for (const result of results) {
+  for (const result of [unscopedResult, ownedResult, sharedResult]) {
     if (result.status === 'fulfilled') {
       lists.push(normalizeMetaModelList(result.value.data));
     }
   }
 
-  return mergeMetaModelsById(lists);
+  const ownedIds = new Set(
+    ownedResult.status === 'fulfilled'
+      ? normalizeMetaModelList(ownedResult.value.data).map(m => m.id)
+      : [],
+  );
+
+  return mergeMetaModelsById(lists).map(model => ({
+    ...model,
+    isOwnedByCurrentUser: ownedIds.has(model.id),
+  }));
 }
 
 /**


### PR DESCRIPTION
- Replaces the right-click context menu on the VSUM Circle with hover-revealed
  add-point dots, consistent with the existing drag-from-handle interaction
  used elsewhere for drawing connections between models.
- On hover, up to 4 small red add-points appear at the circle's top/right/
  bottom/left. Once a cardinal slot is occupied by a ViewType bubble, its
  add-point relocates to the next best gap, using the same placement
  algorithm already used for new VT bubbles, so add-points never overlap
  existing bubbles.
- Clicking an add-point opens the existing "Add View Type" menu and spawns
  the new ViewType at that exact point instead of an auto-computed angle.

closes #409 
closes #417 
closes #416 