### PR TITLE
Fix frozen UML class drag and Detailed Metrics modal under header

### DIFF
--- a/src/__tests__/components/canvas/UMLDiagram.render.test.tsx
+++ b/src/__tests__/components/canvas/UMLDiagram.render.test.tsx
@@ -9,7 +9,7 @@ jest.mock('../../../utils/umlDiagramGeometry', () => require('../../../testSuppo
 jest.mock('../../../utils/umlClassLayout', () => require('../../../testSupport/umlDiagram/mockFactories').umlClassLayoutMock());
 jest.mock('../../../utils/umlLayoutStorage', () => require('../../../testSupport/umlDiagram/mockFactories').umlLayoutStorageMock());
 
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { EMPTY_ECORE } from '../../../testSupport/umlDiagram/fixtures';
 import { renderDiagram } from '../../../testSupport/umlDiagram/renderUtils';
 
@@ -35,6 +35,21 @@ describe('UMLDiagram render', () => {
 
     expect(screen.getByText(/Drag from a purple dot/i)).toBeInTheDocument();
     expect(container.querySelector('[data-reaction-port]')).toBeTruthy();
+  });
+
+  it('allows dragging a class box from its name button', () => {
+    const { container } = renderDiagram();
+    const box = container.querySelector('[data-classbox]') as HTMLElement;
+    expect(box).toBeTruthy();
+    const wrapper = box.parentElement as HTMLElement;
+    const beforeLeft = wrapper.style.left;
+
+    const nameBtn = screen.getByRole('button', { name: /Class name: Person/i });
+    fireEvent.mouseDown(nameBtn, { clientX: 100, clientY: 100 });
+    fireEvent.mouseMove(window, { clientX: 160, clientY: 140 });
+    fireEvent.mouseUp(window);
+
+    expect(wrapper.style.left).not.toBe(beforeLeft);
   });
 });
 

--- a/src/__tests__/components/constraints/ConstraintsView.test.tsx
+++ b/src/__tests__/components/constraints/ConstraintsView.test.tsx
@@ -91,8 +91,8 @@ jest.mock('../../../components/ui/sharedStyles', () => ({
 }));
 
 jest.mock('../../../components/ui/modalUtils', () => ({
-  modalBackdropStyle: {},
-  modalDialogShellStyle: {},
+  ...jest.requireActual('../../../components/ui/modalUtils'),
+  useModalBodyLock: jest.fn(),
 }));
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -503,6 +503,7 @@ describe('ConstraintsView', () => {
       await waitFor(() => {
         expect(screen.getByText('Detailed Metrics')).toBeInTheDocument();
       });
+      expect(document.querySelector('dialog[open]')).toBeTruthy();
     });
   });
 

--- a/src/components/canvas/UMLDiagram.tsx
+++ b/src/components/canvas/UMLDiagram.tsx
@@ -898,17 +898,11 @@ interface UMLDiagramProps {
   vsumId?: string;
 }
 
-const REL_TYPE_CYCLE: UMLRelType[] = ['association', 'composition', 'inheritance'];
 const REL_TYPE_LABELS: Record<UMLRelType, string> = {
   association: 'Association',
   composition: 'Composition',
   inheritance: 'Inheritance',
 };
-
-function nextRelType(current: UMLRelType): UMLRelType {
-  const idx = REL_TYPE_CYCLE.indexOf(current);
-  return REL_TYPE_CYCLE[(idx + 1) % REL_TYPE_CYCLE.length];
-}
 
 function isKeyboardInputField(target: EventTarget | null): boolean {
   const tag = (target as HTMLElement | null)?.tagName;
@@ -1932,13 +1926,6 @@ export const UMLDiagram = forwardRef<UMLDiagramHandle, UMLDiagramProps>(({
     setSelectedRelId(prev => (prev === relId ? null : prev));
   }, [recordChange]);
 
-  const cycleRelationshipType = useCallback((relId: string) => {
-    recordChange();
-    setRelationships(prev => prev.map(r =>
-      r.id === relId ? { ...r, type: nextRelType(r.type) } : r,
-    ));
-  }, [recordChange]);
-
   const updateRelationship = useCallback((relId: string, patch: Partial<UMLRelationship>) => {
     recordChange();
     setRelationships(prev => prev.map(r => (r.id === relId ? { ...r, ...patch } : r)));
@@ -2002,12 +1989,9 @@ export const UMLDiagram = forwardRef<UMLDiagramHandle, UMLDiagramProps>(({
       setSelectedClassId(null);
       return;
     }
-    if (e.detail >= 2 && interactive && reactionsMode !== 'reactions') {
-      cycleRelationshipType(relId);
-    }
     setEditingReactionId(null);
     setSelectedRelId(relId);
-  }, [interactive, reactionsMode, reactionEdges, cycleRelationshipType, openReactionEditor]);
+  }, [reactionsMode, reactionEdges, openReactionEditor]);
 
   const isDirty = useCallback(() => {
     return umlSemanticSnapshot(getModel()) !== initialSnapshotRef.current;
@@ -3060,6 +3044,7 @@ function getClassBoxNameSectionInteractionProps(params: {
   selected: boolean;
   edit: EditState | null;
   classId: string;
+  didDragRef: ClassBoxDidDragRef;
   onSelect: () => void;
   onStartEditName: () => void;
 }): Pick<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onDoubleClick' | 'onClick' | 'onKeyDown'> {
@@ -3074,6 +3059,7 @@ function getClassBoxNameSectionInteractionProps(params: {
       params.selected,
       params.edit,
       params.classId,
+      params.didDragRef,
       params.onSelect,
       params.onStartEditName,
     ),
@@ -3109,7 +3095,8 @@ function startClassBoxDrag({
   onDragEnd: () => void;
 }): void {
   const target = e.target as HTMLElement;
-  if (target.closest('input, button, [data-no-drag], [data-reaction-port]')) return;
+  // Allow drag from a11y <button> surfaces (name / members). Keep true controls non-draggable.
+  if (target.closest('input, select, textarea, [data-no-drag], [data-reaction-port]')) return;
   e.stopPropagation();
   didDragRef.current = false;
   onDragStart();
@@ -3154,10 +3141,15 @@ function handleClassBoxNameSectionClick(
   selected: boolean,
   edit: EditState | null,
   classId: string,
+  didDragRef: ClassBoxDidDragRef,
   onSelect: () => void,
   onStartEditName: () => void,
 ): void {
   e.stopPropagation();
+  if (didDragRef.current) {
+    didDragRef.current = false;
+    return;
+  }
   if (!interactive) return;
   if (!selected) {
     onSelect();
@@ -3185,6 +3177,7 @@ interface ClassBoxNameSectionProps {
   selected: boolean;
   isEditingName: boolean;
   nameSectionH: number;
+  didDragRef: ClassBoxDidDragRef;
   onSelect: () => void;
   onStartEditName: () => void;
   onSaveName: (name: string) => void;
@@ -3193,7 +3186,7 @@ interface ClassBoxNameSectionProps {
 }
 
 const ClassBoxNameSection: React.FC<ClassBoxNameSectionProps> = ({
-  cls, edit, interactive, selected, isEditingName, nameSectionH,
+  cls, edit, interactive, selected, isEditingName, nameSectionH, didDragRef,
   onSelect, onStartEditName, onSaveName, onCancelEdit, onEditChange,
 }) => {
   const isAbstractOrIface = cls.isAbstract || cls.isInterface;
@@ -3209,6 +3202,7 @@ const ClassBoxNameSection: React.FC<ClassBoxNameSectionProps> = ({
     selected,
     edit,
     classId: cls.id,
+    didDragRef,
     onSelect,
     onStartEditName,
   });
@@ -3274,7 +3268,7 @@ const ClassBoxNameSection: React.FC<ClassBoxNameSectionProps> = ({
         margin: 0,
         width: '100%',
         boxSizing: 'border-box',
-        cursor: interactive ? 'pointer' : 'default',
+        cursor: interactive ? 'grab' : 'default',
         font: 'inherit',
         textAlign: 'center',
       }}
@@ -3395,6 +3389,7 @@ const ClassBox: React.FC<ClassBoxProps> = ({
         selected={selected}
         isEditingName={isEditingName}
         nameSectionH={nameSectionH}
+        didDragRef={didDragRef}
         onSelect={onSelect}
         onStartEditName={onStartEditName}
         onSaveName={onSaveName}
@@ -4480,7 +4475,7 @@ const RelationshipEditPanel: React.FC<{
       </div>
 
       <div style={{ padding: '8px 14px', borderTop: `1px solid ${UML.border}`, fontSize: 10, color: UML.textMuted, lineHeight: 1.45 }}>
-        Double-click a line to cycle type · Delete key removes selection · Close with ✕
+        Change type in this panel · Delete key removes selection · Close with ✕
       </div>
     </DiagramEditPanelShell>
   );

--- a/src/components/constraints/ConstraintsView.tsx
+++ b/src/components/constraints/ConstraintsView.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useRef, useMemo, useEffect, MouseEvent as ReactMouseEvent } from 'react';
+import ReactDOM from 'react-dom';
 import Editor, { OnMount } from '@monaco-editor/react';
 import { Node } from 'reactflow';
 import { cardColor } from '../flow/EcoreFileBox';
@@ -6,6 +7,7 @@ import { APP_FONT } from '../ui/sharedStyles';
 import { apiService } from '../../services/api';
 import { CodeEditorModal } from '../flow/CodeEditorModal';
 import { useOclLsp } from '../../hooks/useOclLsp';
+import { MODAL_Z_INDEX, getAppPortalRoot, useModalBodyLock } from '../ui/modalUtils';
 import {
   vitruvOCLLanguageId,
   vitruvOCLMonarch,
@@ -1313,16 +1315,17 @@ const MetricsPanel: React.FC<MetricsPanelProps> = ({ ruleSets, colorMap }) => {
 
 const DetailedMetricsModal: React.FC<{ ruleSets: RuleSet[]; colorMap: Record<string, string>; onClose: () => void }> = ({ ruleSets, colorMap, onClose }) => {
   const sev = SEVERITY_OPTIONS.reduce<Record<string, { color: string; bg: string }>>((m, o) => { m[o.value] = { color: o.color, bg: o.bg }; return m; }, {});
+  useModalBodyLock(true);
 
-  return (
+  return ReactDOM.createPortal(
     <dialog
       open
       style={{
         position: 'fixed', inset: 0, width: '100%', height: '100%',
         maxWidth: '100vw', maxHeight: '100vh',
         background: 'none', border: 'none', padding: 0, margin: 0,
-        zIndex: 2000, display: 'flex', alignItems: 'center', justifyContent: 'center',
-        overflow: 'hidden', boxSizing: 'border-box',
+        zIndex: MODAL_Z_INDEX, display: 'flex', alignItems: 'center', justifyContent: 'center',
+        overflow: 'hidden', boxSizing: 'border-box', pointerEvents: 'auto',
       }}
     >
       <button type="button" onClick={onClose} aria-label="Close" style={{ position: 'absolute', inset: 0, background: 'rgba(15,23,42,0.35)', border: 'none', cursor: 'default', padding: 0 }} />
@@ -1432,7 +1435,8 @@ const DetailedMetricsModal: React.FC<{ ruleSets: RuleSet[]; colorMap: Record<str
           })}
         </div>
       </div>
-    </dialog>
+    </dialog>,
+    getAppPortalRoot(),
   );
 };
 


### PR DESCRIPTION

- UML class boxes can be dragged again (drag was blocked because name/member areas are buttons)
- Detailed Metrics dialog now opens above the project toolbar and Share controls on all screen sizes
- Relationship type no longer changes on double-click; change it only in Edit relationship

