### PR TITLE
Refactor FlowCanvas into focused modules, hooks, and components

### DIFF
--- a/src/__tests__/components/flow/canvas/CanvasControls.test.tsx
+++ b/src/__tests__/components/flow/canvas/CanvasControls.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CanvasControls } from '../../../../components/flow/canvas/CanvasControls';
+
+describe('CanvasControls', () => {
+  const setup = (props: Partial<React.ComponentProps<typeof CanvasControls>> = {}) => {
+    const handlers = {
+      onZoomIn: jest.fn(),
+      onZoomOut: jest.fn(),
+      onFitView: jest.fn(),
+      onToggleInteractive: jest.fn(),
+    };
+    render(
+      <CanvasControls {...handlers} isInteractive readOnly={false} {...props} />,
+    );
+    return handlers;
+  };
+
+  it('renders the zoom and fit controls', () => {
+    setup();
+
+    expect(screen.getByTitle('Zoom in')).toBeInTheDocument();
+    expect(screen.getByTitle('Zoom out')).toBeInTheDocument();
+    expect(screen.getByTitle('Fit view')).toBeInTheDocument();
+  });
+
+  it('wires each control to its handler', () => {
+    const handlers = setup();
+
+    fireEvent.click(screen.getByTitle('Zoom in'));
+    fireEvent.click(screen.getByTitle('Zoom out'));
+    fireEvent.click(screen.getByTitle('Fit view'));
+
+    expect(handlers.onZoomIn).toHaveBeenCalledTimes(1);
+    expect(handlers.onZoomOut).toHaveBeenCalledTimes(1);
+    expect(handlers.onFitView).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers to lock interactions while unlocked', () => {
+    const handlers = setup({ isInteractive: true });
+
+    fireEvent.click(screen.getByTitle('Lock interactions'));
+
+    expect(handlers.onToggleInteractive).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers to unlock interactions while locked', () => {
+    setup({ isInteractive: false });
+
+    expect(screen.getByTitle('Unlock interactions')).toBeInTheDocument();
+  });
+
+  it('hides the lock toggle for read-only viewers but keeps zoom', () => {
+    setup({ readOnly: true });
+
+    expect(screen.queryByTitle('Lock interactions')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Unlock interactions')).not.toBeInTheDocument();
+    expect(screen.getByTitle('Zoom in')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/flow/canvas/CanvasModeToggle.test.tsx
+++ b/src/__tests__/components/flow/canvas/CanvasModeToggle.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CanvasModeToggle } from '../../../../components/flow/canvas/CanvasModeToggle';
+
+describe('CanvasModeToggle', () => {
+  const setup = (props: Partial<React.ComponentProps<typeof CanvasModeToggle>> = {}) => {
+    const onSelectMode = jest.fn();
+    render(
+      <CanvasModeToggle
+        activeCanvasMode="modeling"
+        onSelectMode={onSelectMode}
+        readOnly={false}
+        {...props}
+      />,
+    );
+    return { onSelectMode };
+  };
+
+  it('offers all three modes when editing is allowed', () => {
+    setup();
+
+    expect(screen.getByRole('button', { name: /modeling/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /constraints/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /views/i })).toBeInTheDocument();
+  });
+
+  it('hides Constraints for read-only viewers', () => {
+    setup({ readOnly: true });
+
+    expect(screen.queryByRole('button', { name: /constraints/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /modeling/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /views/i })).toBeInTheDocument();
+  });
+
+  it('reports the selected mode', () => {
+    const { onSelectMode } = setup();
+
+    fireEvent.click(screen.getByRole('button', { name: /views/i }));
+
+    expect(onSelectMode).toHaveBeenCalledWith('views');
+  });
+
+  it('reports a re-click of the already active mode', () => {
+    const { onSelectMode } = setup({ activeCanvasMode: 'views' });
+
+    fireEvent.click(screen.getByRole('button', { name: /views/i }));
+
+    expect(onSelectMode).toHaveBeenCalledWith('views');
+  });
+
+  it('renders the slot beneath the toggle', () => {
+    setup({ projectTabsBelowModeToggle: <div data-testid="project-tabs" /> });
+
+    expect(screen.getByTestId('project-tabs')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/flow/flowCanvasAutoLayout.test.ts
+++ b/src/__tests__/components/flow/flowCanvasAutoLayout.test.ts
@@ -1,0 +1,121 @@
+import { Edge, Node } from 'reactflow';
+import {
+  LAYOUT_CONFIG,
+  applyAutoLayoutPositions,
+  buildAdjacencyMap,
+  computeAutoLayoutPositions,
+  findConnectedComponents,
+  layoutComponent,
+} from '../../../components/flow/flowCanvasAutoLayout';
+
+const node = (id: string, x = 0, y = 0, type = 'ecoreFile'): Node =>
+  ({ id, position: { x, y }, data: {}, type } as Node);
+
+const reaction = (id: string, source: string, target: string): Edge =>
+  ({ id, source, target, type: 'reactions' } as Edge);
+
+describe('buildAdjacencyMap', () => {
+  it('links both directions for reaction edges', () => {
+    const nodes = [node('a'), node('b')];
+    const map = buildAdjacencyMap(nodes, [reaction('e', 'a', 'b')]);
+
+    expect(Array.from(map.get('a')!)).toEqual(['b']);
+    expect(Array.from(map.get('b')!)).toEqual(['a']);
+  });
+
+  it('ignores non-reaction edges', () => {
+    const nodes = [node('a'), node('b')];
+    const map = buildAdjacencyMap(nodes, [{ id: 'u', source: 'a', target: 'b', type: 'uml' } as Edge]);
+
+    expect(map.get('a')!.size).toBe(0);
+  });
+});
+
+describe('findConnectedComponents', () => {
+  it('separates isolated nodes from connected ones', () => {
+    const nodes = [node('a'), node('b'), node('lonely')];
+    const adjacency = buildAdjacencyMap(nodes, [reaction('e', 'a', 'b')]);
+
+    const { components, isolatedNodes } = findConnectedComponents(nodes, adjacency);
+
+    expect(isolatedNodes).toEqual(['lonely']);
+    expect(components).toHaveLength(1);
+    expect(components[0].sort()).toEqual(['a', 'b']);
+  });
+
+  it('finds several disjoint components', () => {
+    const nodes = [node('a'), node('b'), node('c'), node('d')];
+    const adjacency = buildAdjacencyMap(nodes, [
+      reaction('e1', 'a', 'b'),
+      reaction('e2', 'c', 'd'),
+    ]);
+
+    expect(findConnectedComponents(nodes, adjacency).components).toHaveLength(2);
+  });
+});
+
+describe('layoutComponent', () => {
+  it('places a single node exactly at the start position', () => {
+    const positions = layoutComponent(['solo'], 40, 90, new Map());
+
+    expect(positions.get('solo')).toEqual({ x: 40, y: 90 });
+  });
+
+  it('normalises a multi-node component to start at the given origin', () => {
+    const adjacency = new Map([['a', new Set(['b'])], ['b', new Set(['a'])]]);
+    const positions = layoutComponent(['a', 'b'], 100, 200, adjacency);
+
+    const xs = Array.from(positions.values()).map(p => p.x);
+    const ys = Array.from(positions.values()).map(p => p.y);
+
+    expect(Math.min(...xs)).toBeCloseTo(100);
+    expect(Math.min(...ys)).toBeCloseTo(200);
+  });
+
+  it('pushes connected nodes apart rather than stacking them', () => {
+    const adjacency = new Map([['a', new Set(['b'])], ['b', new Set(['a'])]]);
+    const positions = layoutComponent(['a', 'b'], 0, 0, adjacency);
+
+    const a = positions.get('a')!;
+    const b = positions.get('b')!;
+    expect(Math.hypot(b.x - a.x, b.y - a.y)).toBeGreaterThan(LAYOUT_CONFIG.BOX_WIDTH);
+  });
+});
+
+describe('computeAutoLayoutPositions', () => {
+  it('assigns a position to every ecore node', () => {
+    const nodes = [node('a'), node('b'), node('lonely')];
+    const positions = computeAutoLayoutPositions(nodes, [reaction('e', 'a', 'b')]);
+
+    expect(positions.size).toBe(3);
+    nodes.forEach(n => expect(positions.get(n.id)).toBeDefined());
+  });
+
+  it('lays isolated nodes out in a grid below the components', () => {
+    const nodes = [node('i1'), node('i2'), node('i3')];
+    const positions = computeAutoLayoutPositions(nodes, []);
+
+    // With no connected components the grid starts at the configured origin.
+    expect(positions.get('i1')).toEqual({ x: LAYOUT_CONFIG.START_X, y: LAYOUT_CONFIG.START_Y });
+    expect(positions.get('i2')!.x).toBeGreaterThan(positions.get('i1')!.x);
+  });
+});
+
+describe('applyAutoLayoutPositions', () => {
+  it('moves ecore nodes and leaves other node types untouched', () => {
+    const editable = node('uml', 7, 7, 'editable');
+    const nodes = [node('a', 0, 0), editable];
+    const positions = new Map([['a', { x: 500, y: 600 }], ['uml', { x: 1, y: 1 }]]);
+
+    const [movedEcore, untouched] = applyAutoLayoutPositions(nodes, positions);
+
+    expect(movedEcore.position).toEqual({ x: 500, y: 600 });
+    expect(untouched).toBe(editable);
+  });
+
+  it('keeps an ecore node in place when it has no computed position', () => {
+    const original = node('a', 12, 34);
+
+    expect(applyAutoLayoutPositions([original], new Map())[0]).toBe(original);
+  });
+});

--- a/src/__tests__/components/flow/flowCanvasEdgeDistribution.test.ts
+++ b/src/__tests__/components/flow/flowCanvasEdgeDistribution.test.ts
@@ -1,0 +1,74 @@
+import { Edge, Node } from 'reactflow';
+import {
+  buildEdgeDistributionMap,
+  collectNodeSideEdges,
+} from '../../../components/flow/flowCanvasEdgeDistribution';
+
+const ecore = (id: string): Node => ({ id, position: { x: 0, y: 0 }, data: {}, type: 'ecoreFile' } as Node);
+
+const reaction = (id: string, source: string, target: string): Edge =>
+  ({ id, source, target, type: 'reactions', sourceHandle: 'bottom', targetHandle: 'top' } as Edge);
+
+describe('collectNodeSideEdges', () => {
+  it('groups edges by the handle they attach to', () => {
+    const edges = [reaction('e1', 'a', 'b')];
+    const sideMap = collectNodeSideEdges(ecore('a'), edges);
+
+    expect(sideMap.get('bottom')).toEqual(['e1']);
+    expect(sideMap.get('top')).toEqual([]);
+  });
+
+  it('records the edge on the target side too', () => {
+    const sideMap = collectNodeSideEdges(ecore('b'), [reaction('e1', 'a', 'b')]);
+
+    expect(sideMap.get('top')).toEqual(['e1']);
+  });
+
+  it('ignores non-reaction edges', () => {
+    const uml = { id: 'u', source: 'a', target: 'b', type: 'uml', sourceHandle: 'bottom' } as Edge;
+    const sideMap = collectNodeSideEdges(ecore('a'), [uml]);
+
+    expect(sideMap.get('bottom')).toEqual([]);
+  });
+
+  it('does not list a self-loop twice on one side', () => {
+    const loop = { id: 'l', source: 'a', target: 'a', type: 'reactions', sourceHandle: 'bottom', targetHandle: 'bottom' } as Edge;
+    const sideMap = collectNodeSideEdges(ecore('a'), [loop]);
+
+    expect(sideMap.get('bottom')).toEqual(['l']);
+  });
+});
+
+describe('buildEdgeDistributionMap', () => {
+  const nodes = [ecore('a'), ecore('b'), ecore('c')];
+
+  it('assigns each edge on a handle an index out of the total', () => {
+    const edges = [reaction('e1', 'a', 'b'), reaction('e2', 'a', 'c')];
+    const bottom = buildEdgeDistributionMap(nodes, edges).get('a')!.get('bottom')!;
+
+    expect(bottom).toEqual([
+      { edgeId: 'e1', index: 0, total: 2 },
+      { edgeId: 'e2', index: 1, total: 2 },
+    ]);
+  });
+
+  it('orders slots by the far-end node id, not by array order', () => {
+    const edges = [reaction('toC', 'a', 'c'), reaction('toB', 'a', 'b')];
+    const bottom = buildEdgeDistributionMap(nodes, edges).get('a')!.get('bottom')!;
+
+    expect(bottom.map(slot => slot.edgeId)).toEqual(['toB', 'toC']);
+  });
+
+  it('skips nodes that are not ecore files', () => {
+    const withEditable = [...nodes, { id: 'uml', position: { x: 0, y: 0 }, data: {}, type: 'editable' } as Node];
+
+    expect(buildEdgeDistributionMap(withEditable, []).has('uml')).toBe(false);
+  });
+
+  it('gives every ecore node an entry even with no edges', () => {
+    const map = buildEdgeDistributionMap(nodes, []);
+
+    expect(map.size).toBe(3);
+    expect(map.get('a')!.get('bottom')).toEqual([]);
+  });
+});

--- a/src/__tests__/components/flow/flowCanvasEdgeFactory.test.ts
+++ b/src/__tests__/components/flow/flowCanvasEdgeFactory.test.ts
@@ -1,0 +1,85 @@
+import { Node } from 'reactflow';
+import {
+  buildReactionEdge,
+  metaModelIdsFromNodes,
+} from '../../../components/flow/flowCanvasEdgeFactory';
+
+const node = (id: string, x: number, y: number, data: Record<string, unknown> = {}): Node =>
+  ({ id, position: { x, y }, data, type: 'ecoreFile' } as Node);
+
+describe('metaModelIdsFromNodes', () => {
+  it('prefers the named id and falls back to the other flavour', () => {
+    const source = node('a', 0, 0, { metaModelId: 1 });
+    const target = node('b', 0, 0, { metaModelSourceId: 2 });
+
+    expect(metaModelIdsFromNodes(source, target)).toEqual({
+      sourceMetaModelId: 1,
+      targetMetaModelId: 2,
+      sourceMetaModelSourceId: 1,
+      targetMetaModelSourceId: 2,
+    });
+  });
+
+  it('keeps both ids distinct when a node carries each', () => {
+    const source = node('a', 0, 0, { metaModelId: 10, metaModelSourceId: 20 });
+    const target = node('b', 0, 0, { metaModelId: 30, metaModelSourceId: 40 });
+    const ids = metaModelIdsFromNodes(source, target);
+
+    expect(ids.sourceMetaModelId).toBe(10);
+    expect(ids.sourceMetaModelSourceId).toBe(20);
+    expect(ids.targetMetaModelId).toBe(30);
+    expect(ids.targetMetaModelSourceId).toBe(40);
+  });
+
+  it('yields undefined for nodes without numeric ids', () => {
+    const ids = metaModelIdsFromNodes(node('a', 0, 0), node('b', 0, 0));
+
+    expect(ids.sourceMetaModelId).toBeUndefined();
+    expect(ids.targetMetaModelSourceId).toBeUndefined();
+  });
+});
+
+describe('buildReactionEdge', () => {
+  const source = node('a', 0, 0, { metaModelId: 1 });
+  const target = node('b', 0, 500, { metaModelId: 2 });
+
+  it('derives facing handles from the node positions', () => {
+    const edge = buildReactionEdge({ id: 'e', sourceNode: source, targetNode: target, color: '#fff' });
+
+    expect(edge.sourceHandle).toBe('bottom');
+    expect(edge.targetHandle).toBe('top');
+  });
+
+  it('produces a styled reaction edge between the two nodes', () => {
+    const edge = buildReactionEdge({ id: 'e', sourceNode: source, targetNode: target, color: '#abc' });
+
+    expect(edge).toMatchObject({
+      id: 'e',
+      source: 'a',
+      target: 'b',
+      type: 'reactions',
+      style: { stroke: '#abc', strokeWidth: 2 },
+    });
+  });
+
+  it('includes the derived metamodel ids in the edge data', () => {
+    const edge = buildReactionEdge({ id: 'e', sourceNode: source, targetNode: target, color: '#fff' });
+
+    expect(edge.data.sourceMetaModelId).toBe(1);
+    expect(edge.data.targetMetaModelId).toBe(2);
+  });
+
+  it('merges extra data over the derived ids', () => {
+    const edge = buildReactionEdge({
+      id: 'e',
+      sourceNode: source,
+      targetNode: target,
+      color: '#fff',
+      data: { reactionFileId: 99, backendRelationId: 7 },
+    });
+
+    expect(edge.data.reactionFileId).toBe(99);
+    expect(edge.data.backendRelationId).toBe(7);
+    expect(edge.data.sourceMetaModelId).toBe(1);
+  });
+});

--- a/src/__tests__/components/flow/flowCanvasEdgeHygiene.test.ts
+++ b/src/__tests__/components/flow/flowCanvasEdgeHygiene.test.ts
@@ -1,0 +1,86 @@
+import { Edge, Node } from 'reactflow';
+import {
+  dedupeEdgeIds,
+  removeOrphanEdges,
+  uniquifyLoadedEdgeIds,
+  uniquifyLoadedNodeIds,
+  withUniqueEdgeIds,
+} from '../../../components/flow/flowCanvasEdgeHygiene';
+
+const edge = (id: string, source = 'a', target = 'b'): Edge =>
+  ({ id, source, target } as Edge);
+
+const node = (id: string): Node => ({ id, position: { x: 0, y: 0 }, data: {} } as Node);
+
+describe('removeOrphanEdges', () => {
+  it('drops edges whose endpoints no longer exist', () => {
+    const nodes = [node('a'), node('b')];
+    const edges = [edge('keep', 'a', 'b'), edge('gone', 'a', 'deleted')];
+
+    expect(removeOrphanEdges(nodes, edges).map(e => e.id)).toEqual(['keep']);
+  });
+
+  it('keeps every edge when all endpoints are present', () => {
+    const nodes = [node('a'), node('b')];
+    const edges = [edge('one'), edge('two')];
+
+    expect(removeOrphanEdges(nodes, edges)).toHaveLength(2);
+  });
+});
+
+describe('dedupeEdgeIds', () => {
+  it('returns null when all ids are already unique', () => {
+    expect(dedupeEdgeIds([edge('a'), edge('b')])).toBeNull();
+  });
+
+  it('renames repeated ids, keeping the first occurrence', () => {
+    const result = dedupeEdgeIds([edge('dup'), edge('dup'), edge('dup')]);
+
+    expect(result?.map(e => e.id)).toEqual(['dup', 'dup__1', 'dup__2']);
+  });
+
+  it('leaves untouched edges referentially identical', () => {
+    const first = edge('dup');
+    const result = dedupeEdgeIds([first, edge('dup')]);
+
+    expect(result?.[0]).toBe(first);
+  });
+});
+
+describe('withUniqueEdgeIds', () => {
+  it('suffixes duplicates with the dup marker', () => {
+    const result = withUniqueEdgeIds([edge('x'), edge('x')]);
+
+    expect(result.map(e => e.id)).toEqual(['x', 'x-dup-1']);
+  });
+
+  it('synthesises an id for edges that arrived without one', () => {
+    const result = withUniqueEdgeIds([{ source: 'a', target: 'b' } as Edge]);
+
+    expect(result[0].id).toBe('edge-0');
+  });
+});
+
+describe('uniquifyLoadedEdgeIds', () => {
+  it('probes upward until it finds a free id', () => {
+    const result = uniquifyLoadedEdgeIds([
+      { id: 'e' }, { id: 'e' }, { id: 'e-1' }, { id: 'e' },
+    ]);
+
+    expect(result.map(e => e.id)).toEqual(['e', 'e-1', 'e-1-1', 'e-2']);
+  });
+
+  it('falls back to an index-based id when none is supplied', () => {
+    expect(uniquifyLoadedEdgeIds([{ source: 'a' }])[0].id).toBe('loaded-edge-0');
+  });
+});
+
+describe('uniquifyLoadedNodeIds', () => {
+  it('keeps existing ids', () => {
+    expect(uniquifyLoadedNodeIds([{ id: 'kept' }])[0].id).toBe('kept');
+  });
+
+  it('generates an id when one is missing', () => {
+    expect(uniquifyLoadedNodeIds([{ type: 'editable' }])[0].id).toMatch(/^loaded-node-0-\d+$/);
+  });
+});

--- a/src/__tests__/components/flow/flowCanvasEdgeReorder.test.ts
+++ b/src/__tests__/components/flow/flowCanvasEdgeReorder.test.ts
@@ -1,0 +1,109 @@
+import { Edge, Node } from 'reactflow';
+import {
+  applyEdgeReorderData,
+  calculateDefaultControlPoint,
+  computeParallelEdgeReorder,
+} from '../../../components/flow/flowCanvasEdgeReorder';
+import { NODE_DIMENSIONS } from '../../../components/flow/flowCanvasConstants';
+
+const node = (id: string, x = 0, y = 0): Node =>
+  ({ id, position: { x, y }, data: {}, type: 'ecoreFile' } as Node);
+
+const reaction = (id: string, target: string, controlPointX: number): Edge =>
+  ({
+    id,
+    source: 'a',
+    target,
+    type: 'reactions',
+    sourceHandle: 'bottom',
+    targetHandle: 'top',
+    data: { customControlPoint: { x: controlPointX, y: 50 } },
+  } as Edge);
+
+describe('calculateDefaultControlPoint', () => {
+  it('returns the midpoint between the two boxes', () => {
+    const nodes = [node('a', 0, 0), node('b', 200, 400)];
+    const edge = { id: 'e', source: 'a', target: 'b' } as Edge;
+
+    expect(calculateDefaultControlPoint(edge, nodes)).toEqual({
+      x: (0 + 200 + NODE_DIMENSIONS.width) / 2,
+      y: (0 + 400 + NODE_DIMENSIONS.height) / 2,
+    });
+  });
+
+  it('falls back to the origin when an endpoint is missing', () => {
+    const edge = { id: 'e', source: 'a', target: 'ghost' } as Edge;
+
+    expect(calculateDefaultControlPoint(edge, [node('a')])).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe('applyEdgeReorderData', () => {
+  it('writes slot index and count onto participating edges only', () => {
+    const e1 = reaction('e1', 'b', 0);
+    const e2 = reaction('e2', 'c', 0);
+    const unrelated = { id: 'other', source: 'z', target: 'y' } as Edge;
+
+    const result = applyEdgeReorderData([e1, e2, unrelated], [e2, e1], []);
+
+    expect(result[0].data.sourceParallelIndex).toBe(1);
+    expect(result[1].data.sourceParallelIndex).toBe(0);
+    expect(result[0].data.sourceParallelCount).toBe(2);
+    expect(result[2]).toBe(unrelated);
+  });
+});
+
+describe('computeParallelEdgeReorder', () => {
+  const nodes = [node('a', 0, 0), node('b', 0, 500), node('c', 400, 500)];
+
+  it('leaves the list untouched for a non-reaction edge', () => {
+    const edges = [{ id: 'u', source: 'a', target: 'b', type: 'uml' } as Edge];
+
+    expect(computeParallelEdgeReorder(edges, { edgeId: 'u', controlPoint: { x: 0, y: 0 }, nodes }))
+      .toBe(edges);
+  });
+
+  it('leaves the list untouched when the edge id is unknown', () => {
+    const edges = [reaction('e1', 'b', 100)];
+
+    expect(computeParallelEdgeReorder(edges, { edgeId: 'missing', controlPoint: { x: 0, y: 0 }, nodes }))
+      .toBe(edges);
+  });
+
+  it('leaves the list untouched when an endpoint node is missing', () => {
+    const edges = [reaction('e1', 'ghost', 100)];
+
+    expect(computeParallelEdgeReorder(edges, { edgeId: 'e1', controlPoint: { x: 0, y: 0 }, nodes }))
+      .toBe(edges);
+  });
+
+  it('re-slots edges sharing a handle by the dragged control point', () => {
+    const edges = [reaction('e1', 'b', 100), reaction('e2', 'c', 300)];
+
+    // Drag e2 to the left of e1 — on a bottom handle the x axis decides order.
+    const result = computeParallelEdgeReorder(edges, {
+      edgeId: 'e2',
+      controlPoint: { x: 0, y: 50 },
+      nodes,
+    });
+
+    const byId = new Map(result.map(e => [e.id, e]));
+    expect(byId.get('e2')!.data.sourceParallelIndex).toBe(0);
+    expect(byId.get('e1')!.data.sourceParallelIndex).toBe(1);
+    expect(byId.get('e1')!.data.sourceParallelCount).toBe(2);
+  });
+
+  it('counts a lone edge on the target handle as a single slot', () => {
+    const edges = [reaction('e1', 'b', 100), reaction('e2', 'c', 300)];
+
+    const result = computeParallelEdgeReorder(edges, {
+      edgeId: 'e2',
+      controlPoint: { x: 0, y: 50 },
+      nodes,
+    });
+
+    const e2 = result.find(e => e.id === 'e2')!;
+    expect(e2.data.targetParallelIndex).toBe(0);
+    expect(e2.data.targetParallelCount).toBe(1);
+  });
+});

--- a/src/__tests__/components/flow/flowCanvasHandleUtils.test.ts
+++ b/src/__tests__/components/flow/flowCanvasHandleUtils.test.ts
@@ -1,0 +1,135 @@
+import { Edge, Node } from 'reactflow';
+import {
+  calculateOptimalHandles,
+  calculateReactionHandles,
+  cleanHandleId,
+  optimizeEdgeHandles,
+  updateEdgeHandles,
+} from '../../../components/flow/flowCanvasHandleUtils';
+
+const node = (id: string, x: number, y: number): Node =>
+  ({ id, position: { x, y }, data: {}, type: 'ecoreFile' } as Node);
+
+describe('cleanHandleId', () => {
+  it('strips the source and target suffixes', () => {
+    expect(cleanHandleId('bottom-source')).toBe('bottom');
+    expect(cleanHandleId('top-target')).toBe('top');
+  });
+
+  it('leaves an already-clean handle untouched', () => {
+    expect(cleanHandleId('left')).toBe('left');
+  });
+});
+
+describe('calculateOptimalHandles', () => {
+  const source = node('a', 0, 0);
+
+  it('connects bottom-to-top when the target is below', () => {
+    expect(calculateOptimalHandles(source, node('b', 0, 500))).toEqual({
+      sourceHandle: 'bottom-source',
+      targetHandle: 'top-target',
+    });
+  });
+
+  it('connects top-to-bottom when the target is above', () => {
+    expect(calculateOptimalHandles(source, node('b', 0, -500))).toEqual({
+      sourceHandle: 'top-source',
+      targetHandle: 'bottom-target',
+    });
+  });
+
+  it('connects right-to-left when the target is to the right', () => {
+    expect(calculateOptimalHandles(source, node('b', 500, 0))).toEqual({
+      sourceHandle: 'right-source',
+      targetHandle: 'left-target',
+    });
+  });
+
+  it('connects left-to-right when the target is to the left', () => {
+    expect(calculateOptimalHandles(source, node('b', -500, 0))).toEqual({
+      sourceHandle: 'left-source',
+      targetHandle: 'right-target',
+    });
+  });
+
+  it('prefers the horizontal axis when both offsets are equal', () => {
+    expect(calculateOptimalHandles(source, node('b', 100, 100)).sourceHandle).toBe('right-source');
+  });
+});
+
+describe('calculateReactionHandles', () => {
+  it('returns handles without the suffixes', () => {
+    expect(calculateReactionHandles(node('a', 0, 0), node('b', 0, 300))).toEqual({
+      sourceHandle: 'bottom',
+      targetHandle: 'top',
+    });
+  });
+});
+
+describe('updateEdgeHandles', () => {
+  const nodes = [node('a', 0, 0), node('b', 0, 500)];
+
+  it('ignores edges that are neither reaction nor UML', () => {
+    const edge = { id: 'e', source: 'a', target: 'b', type: 'default' } as Edge;
+    expect(updateEdgeHandles(edge, nodes)).toBe(edge);
+  });
+
+  it('returns the same edge when an endpoint is missing', () => {
+    const edge = { id: 'e', source: 'a', target: 'missing', type: 'reactions' } as Edge;
+    expect(updateEdgeHandles(edge, nodes)).toBe(edge);
+  });
+
+  it('returns the same edge when the handles are already correct', () => {
+    const edge = {
+      id: 'e', source: 'a', target: 'b', type: 'reactions',
+      sourceHandle: 'bottom', targetHandle: 'top',
+    } as Edge;
+    expect(updateEdgeHandles(edge, nodes)).toBe(edge);
+  });
+
+  it('re-points a stale reaction edge and clears its control point', () => {
+    const edge = {
+      id: 'e', source: 'a', target: 'b', type: 'reactions',
+      sourceHandle: 'left', targetHandle: 'right',
+      data: { customControlPoint: { x: 5, y: 5 }, code: 'keep me' },
+    } as Edge;
+
+    const result = updateEdgeHandles(edge, nodes);
+
+    expect(result.sourceHandle).toBe('bottom');
+    expect(result.targetHandle).toBe('top');
+    expect(result.data.customControlPoint).toBeUndefined();
+    expect(result.data.code).toBe('keep me');
+  });
+
+  it('keeps the suffixed handle form for UML edges', () => {
+    const edge = {
+      id: 'e', source: 'a', target: 'b', type: 'uml',
+      sourceHandle: 'left-source', targetHandle: 'right-target',
+    } as Edge;
+
+    const result = updateEdgeHandles(edge, nodes);
+
+    expect(result.sourceHandle).toBe('bottom-source');
+    expect(result.targetHandle).toBe('top-target');
+  });
+});
+
+describe('optimizeEdgeHandles', () => {
+  it('rewrites reaction edges and leaves other types alone', () => {
+    const nodes = [node('a', 0, 0), node('b', 600, 0)];
+    const reaction = {
+      id: 'r', source: 'a', target: 'b', type: 'reactions',
+      sourceHandle: 'top', targetHandle: 'bottom',
+      data: { customControlPoint: { x: 1, y: 1 } },
+    } as Edge;
+    const uml = { id: 'u', source: 'a', target: 'b', type: 'uml', sourceHandle: 'top-source' } as Edge;
+
+    const [updatedReaction, updatedUml] = optimizeEdgeHandles(nodes, [reaction, uml]);
+
+    expect(updatedReaction.sourceHandle).toBe('right');
+    expect(updatedReaction.targetHandle).toBe('left');
+    expect(updatedReaction.data.customControlPoint).toBeUndefined();
+    expect(updatedUml).toBe(uml);
+  });
+});

--- a/src/__tests__/components/flow/flowCanvasNodeLookup.test.ts
+++ b/src/__tests__/components/flow/flowCanvasNodeLookup.test.ts
@@ -1,0 +1,117 @@
+import { Node } from 'reactflow';
+import {
+  ECORE_DROP_SNAP_DISTANCE,
+  findEcoreTargetAtPosition,
+  findNodeByMetaModelId,
+  getBackendMetaModelId,
+  getMetaModelSourceId,
+  isPositionInsideNode,
+} from '../../../components/flow/flowCanvasNodeLookup';
+import { ECORE_FILE_BOX_SIZE } from '../../../components/flow/flowCanvasConstants';
+
+const ecore = (id: string, x = 0, y = 0, data: Record<string, unknown> = {}): Node =>
+  ({ id, position: { x, y }, data, type: 'ecoreFile' } as Node);
+
+describe('getMetaModelSourceId / getBackendMetaModelId', () => {
+  const nodes = [
+    ecore('both', 0, 0, { metaModelId: 10, metaModelSourceId: 20 }),
+    ecore('backendOnly', 0, 0, { metaModelId: 30 }),
+    ecore('sourceOnly', 0, 0, { metaModelSourceId: 40 }),
+    ecore('neither'),
+  ];
+
+  it('prefers its own id flavour when both are present', () => {
+    expect(getMetaModelSourceId(nodes, 'both')).toBe(20);
+    expect(getBackendMetaModelId(nodes, 'both')).toBe(10);
+  });
+
+  it('falls back to the other flavour when only one is present', () => {
+    expect(getMetaModelSourceId(nodes, 'backendOnly')).toBe(30);
+    expect(getBackendMetaModelId(nodes, 'sourceOnly')).toBe(40);
+  });
+
+  it('returns undefined for a node without ids, an unknown id, or no id at all', () => {
+    expect(getMetaModelSourceId(nodes, 'neither')).toBeUndefined();
+    expect(getMetaModelSourceId(nodes, 'ghost')).toBeUndefined();
+    expect(getMetaModelSourceId(nodes, null)).toBeUndefined();
+  });
+
+  it('ignores non-numeric ids', () => {
+    const odd = [ecore('odd', 0, 0, { metaModelId: 'not-a-number' })];
+
+    expect(getBackendMetaModelId(odd, 'odd')).toBeUndefined();
+  });
+});
+
+describe('findNodeByMetaModelId', () => {
+  const nodes = [
+    ecore('a', 0, 0, { metaModelId: 1 }),
+    ecore('b', 0, 0, { metaModelSourceId: 2 }),
+    { id: 'editable', position: { x: 0, y: 0 }, data: { metaModelId: 3 }, type: 'editable' } as Node,
+  ];
+
+  it('matches on either id flavour', () => {
+    expect(findNodeByMetaModelId(nodes, 1)!.id).toBe('a');
+    expect(findNodeByMetaModelId(nodes, 2)!.id).toBe('b');
+  });
+
+  it('only considers ecoreFile nodes', () => {
+    expect(findNodeByMetaModelId(nodes, 3)).toBeUndefined();
+  });
+});
+
+describe('isPositionInsideNode', () => {
+  const box = ecore('a', 100, 100);
+
+  it('accepts a point within the footprint, including the edges', () => {
+    expect(isPositionInsideNode({ x: 110, y: 110 }, box)).toBe(true);
+    expect(isPositionInsideNode({ x: 100, y: 100 }, box)).toBe(true);
+    expect(isPositionInsideNode(
+      { x: 100 + ECORE_FILE_BOX_SIZE.width, y: 100 + ECORE_FILE_BOX_SIZE.height },
+      box,
+    )).toBe(true);
+  });
+
+  it('rejects a point outside the footprint', () => {
+    expect(isPositionInsideNode({ x: 99, y: 110 }, box)).toBe(false);
+    expect(isPositionInsideNode({ x: 10_000, y: 110 }, box)).toBe(false);
+  });
+});
+
+describe('findEcoreTargetAtPosition', () => {
+  const nodes = [ecore('source', 0, 0), ecore('target', 1000, 1000)];
+
+  it('never returns the source node itself', () => {
+    expect(findEcoreTargetAtPosition(nodes, { x: 10, y: 10 }, 'source')).toBeNull();
+  });
+
+  it('returns the box the point lands inside', () => {
+    expect(findEcoreTargetAtPosition(nodes, { x: 1010, y: 1010 }, 'source')!.id).toBe('target');
+  });
+
+  it('snaps to a box just outside it, measuring from the box centre', () => {
+    // Level with the centre and 5px clear of the left edge, so the point is
+    // outside the footprint but well inside the snap radius of the centre.
+    const nearby = { x: 1000 - 5, y: 1000 + ECORE_FILE_BOX_SIZE.height / 2 };
+    const distanceToCentre = ECORE_FILE_BOX_SIZE.width / 2 + 5;
+
+    expect(isPositionInsideNode(nearby, nodes[1])).toBe(false);
+    expect(distanceToCentre).toBeLessThan(ECORE_DROP_SNAP_DISTANCE);
+    expect(findEcoreTargetAtPosition(nodes, nearby, 'source')!.id).toBe('target');
+  });
+
+  it('returns null when nothing is within snapping distance', () => {
+    expect(findEcoreTargetAtPosition(nodes, { x: 500, y: 500 }, 'source')).toBeNull();
+  });
+
+  it('picks the closest candidate when two are within range', () => {
+    // Centres at x=259 and x=409; the probe at x=330 is outside both boxes and
+    // within the snap radius of each, but 71px from the first and 79px from the second.
+    const crowded = [ecore('source', 0, 0), ecore('nearer', 200, 0), ecore('farther', 350, 0)];
+    const probe = { x: 330, y: ECORE_FILE_BOX_SIZE.height / 2 };
+
+    expect(isPositionInsideNode(probe, crowded[1])).toBe(false);
+    expect(isPositionInsideNode(probe, crowded[2])).toBe(false);
+    expect(findEcoreTargetAtPosition(crowded, probe, 'source')!.id).toBe('nearer');
+  });
+});

--- a/src/__tests__/components/flow/flowCanvasReactionCode.test.ts
+++ b/src/__tests__/components/flow/flowCanvasReactionCode.test.ts
@@ -1,0 +1,55 @@
+import { Node } from 'reactflow';
+import { buildInitialReactionCode } from '../../../components/flow/flowCanvasReactionCode';
+import { getToolLabel } from '../../../components/flow/flowCanvasToolLabels';
+
+const ecore = (id: string, data: Record<string, unknown>): Node =>
+  ({ id, position: { x: 0, y: 0 }, data, type: 'ecoreFile' } as Node);
+
+describe('buildInitialReactionCode', () => {
+  it('uses the EPackage name declared in the ecore content', () => {
+    const nodes = [
+      ecore('a', { fileContent: '<ecore:EPackage xmi:version="2.0" name="Families"', nsUri: 'http://families' }),
+      ecore('b', { fileContent: '<ecore:EPackage xmi:version="2.0" name="Persons"', nsUri: 'http://persons' }),
+    ];
+
+    const code = buildInitialReactionCode(nodes, 'a', 'b');
+
+    expect(code).toContain('import "http://families" as Families');
+    expect(code).toContain('import "http://persons" as Persons');
+    expect(code).toContain('reactions: FamiliesToPersons');
+    expect(code).toContain('in reaction to changes in Families');
+    expect(code).toContain('execute actions in Persons');
+  });
+
+  it('falls back to the file name without its extension', () => {
+    const nodes = [
+      ecore('a', { fileName: 'Families.ecore' }),
+      ecore('b', { fileName: 'Persons.ecore' }),
+    ];
+
+    expect(buildInitialReactionCode(nodes, 'a', 'b')).toContain('reactions: FamiliesToPersons');
+  });
+
+  it('synthesises a namespace URI when the node has none', () => {
+    const nodes = [ecore('a', { fileName: 'Families.ecore' }), ecore('b', { fileName: 'Persons.ecore' })];
+
+    expect(buildInitialReactionCode(nodes, 'a', 'b')).toContain('import "http://vitruv.tools/Families"');
+  });
+
+  it('falls back to a placeholder name for unknown nodes', () => {
+    expect(buildInitialReactionCode([], 'ghost', 'phantom')).toContain('reactions: sourceTosource');
+  });
+});
+
+describe('getToolLabel', () => {
+  it('maps a known tool to its display label', () => {
+    expect(getToolLabel('element', 'abstract-class')).toBe('AbstractClass');
+    expect(getToolLabel('member', 'attribute')).toBe('+ attribute: Type');
+    expect(getToolLabel('multiplicity', 'range')).toBe('1..*');
+  });
+
+  it('falls back to the raw name for an unknown tool or category', () => {
+    expect(getToolLabel('element', 'unknown-tool')).toBe('unknown-tool');
+    expect(getToolLabel('unknown-category', 'thing')).toBe('thing');
+  });
+});

--- a/src/__tests__/components/flow/flowCanvasSnapshot.test.ts
+++ b/src/__tests__/components/flow/flowCanvasSnapshot.test.ts
@@ -1,0 +1,61 @@
+import { Edge, Node } from 'reactflow';
+import { buildWorkspaceSnapshot } from '../../../components/flow/flowCanvasSnapshot';
+
+const ecore = (id: string, data: Record<string, unknown>): Node =>
+  ({ id, position: { x: 0, y: 0 }, data, type: 'ecoreFile' } as Node);
+
+const reaction = (id: string, source: string, target: string, data: Record<string, unknown> = {}): Edge =>
+  ({ id, source, target, type: 'reactions', data } as Edge);
+
+describe('buildWorkspaceSnapshot', () => {
+  const nodes = [
+    ecore('a', { metaModelSourceId: 1 }),
+    ecore('b', { metaModelSourceId: 2 }),
+  ];
+
+  it('collects the metamodel ids of the ecore nodes', () => {
+    expect(buildWorkspaceSnapshot(nodes, []).metaModelIds).toEqual([1, 2]);
+  });
+
+  it('excludes non-ecore nodes', () => {
+    const withEditable = [
+      ...nodes,
+      { id: 'uml', position: { x: 0, y: 0 }, data: { metaModelSourceId: 99 }, type: 'editable' } as Node,
+    ];
+
+    expect(buildWorkspaceSnapshot(withEditable, []).metaModelIds).toEqual([1, 2]);
+  });
+
+  it('de-duplicates repeated metamodel ids', () => {
+    const duplicated = [...nodes, ecore('c', { metaModelSourceId: 1 })];
+
+    expect(buildWorkspaceSnapshot(duplicated, []).metaModelIds).toEqual([1, 2]);
+  });
+
+  it('maps reaction edges to relation requests', () => {
+    const edges = [reaction('e', 'a', 'b', { reactionFileId: 7 })];
+
+    expect(buildWorkspaceSnapshot(nodes, edges).metaModelRelationRequests).toEqual([
+      { sourceId: 1, targetId: 2, reactionFileId: 7 },
+    ]);
+  });
+
+  it('defaults a missing reaction file id to zero', () => {
+    const edges = [reaction('e', 'a', 'b')];
+
+    expect(buildWorkspaceSnapshot(nodes, edges).metaModelRelationRequests[0].reactionFileId).toBe(0);
+  });
+
+  it('ignores non-reaction edges', () => {
+    const edges = [{ id: 'u', source: 'a', target: 'b', type: 'uml' } as Edge];
+
+    expect(buildWorkspaceSnapshot(nodes, edges).metaModelRelationRequests).toEqual([]);
+  });
+
+  it('drops relations whose endpoints have no resolvable metamodel id', () => {
+    const withUnmapped = [...nodes, ecore('c', {})];
+    const edges = [reaction('e', 'a', 'c')];
+
+    expect(buildWorkspaceSnapshot(withUnmapped, edges).metaModelRelationRequests).toEqual([]);
+  });
+});

--- a/src/__tests__/components/flow/flowCanvasUmlMerge.test.ts
+++ b/src/__tests__/components/flow/flowCanvasUmlMerge.test.ts
@@ -1,0 +1,104 @@
+import { Edge, Node } from 'reactflow';
+import {
+  calculateAverageSourcePosition,
+  calculateMergePoint,
+  computeUmlMergeData,
+} from '../../../components/flow/flowCanvasUmlMerge';
+import { NODE_DIMENSIONS } from '../../../components/flow/flowCanvasConstants';
+
+const node = (id: string, x = 0, y = 0): Node =>
+  ({ id, position: { x, y }, data: {}, type: 'editable' } as Node);
+
+const inheritance = (id: string, source: string, target: string): Edge =>
+  ({ id, source, target, type: 'uml', data: { relationshipType: 'inheritance' } } as Edge);
+
+describe('calculateAverageSourcePosition', () => {
+  it('averages the centres of the source boxes', () => {
+    const nodes = [node('a', 0, 0), node('b', 200, 400)];
+    const edges = [inheritance('e1', 'a', 'z'), inheritance('e2', 'b', 'z')];
+
+    expect(calculateAverageSourcePosition(edges, nodes)).toEqual({
+      x: 100 + NODE_DIMENSIONS.width / 2,
+      y: 200 + NODE_DIMENSIONS.height / 2,
+    });
+  });
+
+  it('falls back to the origin when no source node resolves', () => {
+    expect(calculateAverageSourcePosition([inheritance('e', 'ghost', 'z')], [])).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe('calculateMergePoint', () => {
+  it('aligns horizontally with the target centre', () => {
+    const target = node('t', 300, 900);
+    const point = calculateMergePoint({ x: 0, y: 100 }, target);
+
+    expect(point.x).toBe(300 + NODE_DIMENSIONS.width / 2);
+  });
+
+  it('sits 40% of the way from the sources toward the target', () => {
+    const target = node('t', 0, 1000);
+    const targetCenterY = 1000 + NODE_DIMENSIONS.height / 2;
+    const point = calculateMergePoint({ x: 0, y: 0 }, target);
+
+    expect(point.y).toBeCloseTo(targetCenterY * 0.4);
+  });
+});
+
+describe('computeUmlMergeData', () => {
+  const nodes = [node('sub1', 0, 0), node('sub2', 400, 0), node('sub3', 800, 0), node('super', 400, 600)];
+
+  it('returns empty maps when there are no inheritance edges', () => {
+    const result = computeUmlMergeData([{ id: 'e', source: 'a', target: 'b', type: 'uml' } as Edge], nodes);
+
+    expect(result.mergePointsMap.size).toBe(0);
+  });
+
+  it('does not merge a lone subclass', () => {
+    const result = computeUmlMergeData([inheritance('e1', 'sub1', 'super')], nodes);
+
+    expect(result.mergePointsMap.size).toBe(0);
+  });
+
+  it('merges two or more subclasses sharing a superclass', () => {
+    const edges = [inheritance('e1', 'sub1', 'super'), inheritance('e2', 'sub2', 'super')];
+    const result = computeUmlMergeData(edges, nodes);
+
+    expect(result.mergePointsMap.size).toBe(2);
+    expect(result.mergePointsMap.get('e1')!.mergeGroupId).toBe('merge-super');
+    expect(result.mergeGroupSourceNodesMap.get('merge-super')).toEqual(['sub1', 'sub2']);
+  });
+
+  it('nominates the first edge of the group deterministically by source id', () => {
+    const edges = [inheritance('later', 'sub2', 'super'), inheritance('earlier', 'sub1', 'super')];
+    const result = computeUmlMergeData(edges, nodes);
+
+    expect(result.firstInGroupMap.get('merge-super')).toBe('earlier');
+  });
+
+  it('excludes a subclass that reaches the superclass more than once', () => {
+    const edges = [
+      inheritance('e1', 'sub1', 'super'),
+      inheritance('e2', 'sub1', 'super'),
+      inheritance('e3', 'sub2', 'super'),
+    ];
+    const result = computeUmlMergeData(edges, nodes);
+
+    // Only sub2 remains eligible, which is fewer than the two needed to merge.
+    expect(result.mergePointsMap.size).toBe(0);
+  });
+
+  it('skips groups whose superclass node is missing', () => {
+    const edges = [inheritance('e1', 'sub1', 'ghost'), inheritance('e2', 'sub2', 'ghost')];
+
+    expect(computeUmlMergeData(edges, nodes).mergePointsMap.size).toBe(0);
+  });
+
+  it('ignores non-inheritance relationships', () => {
+    const association = (id: string, source: string) =>
+      ({ id, source, target: 'super', type: 'uml', data: { relationshipType: 'association' } } as Edge);
+    const edges = [association('a1', 'sub1'), association('a2', 'sub2')];
+
+    expect(computeUmlMergeData(edges, nodes).mergePointsMap.size).toBe(0);
+  });
+});

--- a/src/__tests__/components/flow/useEdgeColorMap.test.ts
+++ b/src/__tests__/components/flow/useEdgeColorMap.test.ts
@@ -1,0 +1,105 @@
+import { renderHook } from '@testing-library/react';
+import {
+  getEdgeColorStorageKey,
+  pairKey,
+  resolveNextColorIndex,
+  useEdgeColorMap,
+} from '../../../components/flow/useEdgeColorMap';
+import { EDGE_COLOR_LIST } from '../../../components/flow/flowCanvasConstants';
+
+describe('pairKey', () => {
+  it('is independent of argument order', () => {
+    expect(pairKey('b', 'a')).toBe(pairKey('a', 'b'));
+  });
+
+  it('separates the two ids', () => {
+    expect(pairKey('a', 'b')).toBe('a::b');
+  });
+});
+
+describe('getEdgeColorStorageKey', () => {
+  it('scopes the key to user and project when both are known', () => {
+    expect(getEdgeColorStorageKey('u1', 'v2')).toBe('flow_edge_color_map_v1_user_u1_vsum_v2');
+  });
+
+  it('falls back to a shared key when either is missing', () => {
+    expect(getEdgeColorStorageKey(undefined, 'v2')).toBe('flow_edge_color_map_v1');
+    expect(getEdgeColorStorageKey('u1', undefined)).toBe('flow_edge_color_map_v1');
+  });
+});
+
+describe('resolveNextColorIndex', () => {
+  it('starts at zero when nothing is in use', () => {
+    expect(resolveNextColorIndex([])).toBe(0);
+  });
+
+  it('resumes after the highest-numbered colour in use', () => {
+    expect(resolveNextColorIndex([EDGE_COLOR_LIST[2]])).toBe(3);
+  });
+
+  it('wraps back to the start once the palette is exhausted', () => {
+    expect(resolveNextColorIndex([EDGE_COLOR_LIST[EDGE_COLOR_LIST.length - 1]])).toBe(0);
+  });
+
+  it('ignores colours outside the palette', () => {
+    expect(resolveNextColorIndex(['#not-a-palette-colour'])).toBe(0);
+  });
+});
+
+describe('useEdgeColorMap', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('returns a stable colour for a pair regardless of order', () => {
+    const { result } = renderHook(() => useEdgeColorMap('u', 'v'));
+
+    const first = result.current.getColorForPair('a', 'b');
+    expect(result.current.getColorForPair('b', 'a')).toBe(first);
+  });
+
+  it('hands out a different colour to a different pair', () => {
+    const { result } = renderHook(() => useEdgeColorMap('u', 'v'));
+
+    expect(result.current.getColorForPair('a', 'b'))
+      .not.toBe(result.current.getColorForPair('a', 'c'));
+  });
+
+  it('persists assignments under the scoped storage key', () => {
+    const { result } = renderHook(() => useEdgeColorMap('u', 'v'));
+    const color = result.current.getColorForPair('a', 'b');
+
+    const stored = JSON.parse(localStorage.getItem(getEdgeColorStorageKey('u', 'v'))!);
+    expect(stored['a::b']).toBe(color);
+  });
+
+  it('restores colours assigned in an earlier session', () => {
+    localStorage.setItem(
+      getEdgeColorStorageKey('u', 'v'),
+      JSON.stringify({ 'a::b': EDGE_COLOR_LIST[4] }),
+    );
+
+    const { result } = renderHook(() => useEdgeColorMap('u', 'v'));
+
+    expect(result.current.getColorForPair('a', 'b')).toBe(EDGE_COLOR_LIST[4]);
+  });
+
+  it('continues the palette after restored colours instead of repeating', () => {
+    localStorage.setItem(
+      getEdgeColorStorageKey('u', 'v'),
+      JSON.stringify({ 'a::b': EDGE_COLOR_LIST[0] }),
+    );
+
+    const { result } = renderHook(() => useEdgeColorMap('u', 'v'));
+
+    expect(result.current.getColorForPair('x', 'y')).toBe(EDGE_COLOR_LIST[1]);
+  });
+
+  it('survives corrupt stored data', () => {
+    localStorage.setItem(getEdgeColorStorageKey('u', 'v'), 'not json');
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useEdgeColorMap('u', 'v'));
+
+    expect(result.current.getColorForPair('a', 'b')).toBe(EDGE_COLOR_LIST[0]);
+    warn.mockRestore();
+  });
+});

--- a/src/__tests__/components/flow/useFlowCanvasEvents.test.ts
+++ b/src/__tests__/components/flow/useFlowCanvasEvents.test.ts
@@ -1,0 +1,95 @@
+import { Edge, Node } from 'reactflow';
+import {
+  deselectAllNodes,
+  normalizeMetaModelRelations,
+  selectOnlyEdge,
+} from '../../../components/flow/useFlowCanvasEvents';
+
+const edge = (id: string, selected = false): Edge => ({ id, source: 'a', target: 'b', selected } as Edge);
+const node = (id: string, selected = false): Node =>
+  ({ id, position: { x: 0, y: 0 }, data: {}, selected } as Node);
+
+describe('selectOnlyEdge', () => {
+  it('selects a previously unselected edge', () => {
+    const result = selectOnlyEdge([edge('a'), edge('b')], 'a', false);
+
+    expect(result[0].selected).toBe(true);
+  });
+
+  it('deselects the edge when it was already selected', () => {
+    const result = selectOnlyEdge([edge('a', true)], 'a', true);
+
+    expect(result[0].selected).toBe(false);
+  });
+
+  it('clears every other edge', () => {
+    const result = selectOnlyEdge([edge('a'), edge('b', true), edge('c', true)], 'a', false);
+
+    expect(result.map(e => e.selected)).toEqual([true, false, false]);
+  });
+
+  it('leaves the list unchanged in length and order', () => {
+    const result = selectOnlyEdge([edge('a'), edge('b')], 'missing', false);
+
+    expect(result.map(e => e.id)).toEqual(['a', 'b']);
+    expect(result.every(e => e.selected === false)).toBe(true);
+  });
+});
+
+describe('deselectAllNodes', () => {
+  it('clears the selection flag on every node', () => {
+    const result = deselectAllNodes([node('a', true), node('b')]);
+
+    expect(result.every(n => n.selected === false)).toBe(true);
+  });
+
+  it('preserves the other node fields', () => {
+    const result = deselectAllNodes([node('a', true)]);
+
+    expect(result[0]).toMatchObject({ id: 'a', position: { x: 0, y: 0 } });
+  });
+});
+
+describe('normalizeMetaModelRelations', () => {
+  it('returns an empty list for missing input', () => {
+    expect(normalizeMetaModelRelations(undefined)).toEqual([]);
+  });
+
+  it('reads the canonical field names', () => {
+    expect(normalizeMetaModelRelations([
+      { id: 1, sourceId: 10, targetId: 20, reactionFileId: 30 },
+    ])).toEqual([{ id: 1, sourceId: 10, targetId: 20, reactionFileId: 30 }]);
+  });
+
+  it('accepts the older metamodel-suffixed field names', () => {
+    expect(normalizeMetaModelRelations([
+      { id: 2, sourceMetaModelId: 11, targetMetaModelId: 21, reactionFileStorageId: 31 },
+    ])).toEqual([{ id: 2, sourceId: 11, targetId: 21, reactionFileId: 31 }]);
+  });
+
+  it('prefers the canonical name when both spellings are present', () => {
+    const [relation] = normalizeMetaModelRelations([
+      { id: 3, sourceId: 1, sourceMetaModelId: 99, targetId: 2, targetMetaModelId: 98 },
+    ]);
+
+    expect(relation.sourceId).toBe(1);
+    expect(relation.targetId).toBe(2);
+  });
+
+  it('defaults a missing reaction file id to null', () => {
+    expect(normalizeMetaModelRelations([{ id: 4, sourceId: 1, targetId: 2 }])[0].reactionFileId)
+      .toBeNull();
+  });
+
+  it('defaults a non-numeric id to zero', () => {
+    expect(normalizeMetaModelRelations([{ sourceId: 1, targetId: 2 }])[0].id).toBe(0);
+  });
+
+  it('drops relations without a usable source or target', () => {
+    expect(normalizeMetaModelRelations([
+      { id: 1, sourceId: 1 },
+      { id: 2, targetId: 2 },
+      { id: 3, sourceId: 1, targetId: 2 },
+    ]).map(r => r.id)).toEqual([3]);
+  });
+});

--- a/src/components/flow/FlowCanvas.tsx
+++ b/src/components/flow/FlowCanvas.tsx
@@ -7,7 +7,6 @@ import React, {
   useCallback,
   useMemo,
 } from 'react';
-import ReactDOM from 'react-dom';
 import ReactFlow, {
   Background,
   ReactFlowInstance,
@@ -20,18 +19,40 @@ import { useDragAndDrop } from '../../hooks/useDragAndDrop';
 import { EditableNode } from './EditableNode';
 import { UMLRelationship } from './UMLRelationship';
 import { ReactionRelationship } from './ReactionRelationship';
-import { EcoreFileBox, cardColor, darken } from './EcoreFileBox';
+import { EcoreFileBox } from './EcoreFileBox';
 import { ConnectionLine } from './ConnectionLine';
 import { ReactionEditorModal } from './ReactionEditorModal';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
-import { ModelDetailModal } from '../ui/ModelLibraryTable';
-import { apiService, MetaModelRelationRequest } from '../../services/api';
+import { apiService } from '../../services/api';
 import { WorkspaceSnapshot } from '../../types/workspace';
 import { extractNsUriFromEcore } from '../../utils';
-import { useCircleContainment, clampAllNodesToCircle, computeInitialCircle, Circle } from '../../hooks/useCircleContainment';
-import { CircleOverlay } from './canvas/CircleOverlay';
+import {
+  useCircleContainment,
+  clampAllNodesToCircle,
+  computeInitialCircle,
+  Circle,
+} from '../../hooks/useCircleContainment';
 import { useViewTypes, ViewTypeScope } from '../../hooks/useViewTypes';
+import { pickFocusUmlFlowNodes } from '../../utils/umlClassLayout';
+import { fetchReactionCode, persistReactionCode, resolveReactionFileId } from '../../utils/reactionFile';
+
+import { CircleOverlay } from './canvas/CircleOverlay';
+import { CanvasControls } from './canvas/CanvasControls';
+import { CanvasDropOverlay } from './canvas/CanvasDropOverlay';
+import { CanvasMinimap } from './canvas/CanvasMinimap';
+import { CanvasModeToggle } from './canvas/CanvasModeToggle';
+import { ModelDetailOverlay } from './canvas/ModelDetailOverlay';
+
 import { useFlowCanvasKeyboardShortcuts } from './useFlowCanvasKeyboard';
+import { useEdgeColorMap } from './useEdgeColorMap';
+import {
+  MetaModelRelation,
+  useEdgeControlPointEvents,
+  useEdgeSelectionEvents,
+  useMetaModelRelationEvents,
+  useReactionEdgeCreationEvents,
+  useWorkspaceLayoutEvents,
+} from './useFlowCanvasEvents';
 import {
   clampNodeChanges,
   getNodeDragFlags,
@@ -39,133 +60,84 @@ import {
   isReadOnlyBlockedNodeChange,
   shouldCloseDetailOnBoxDrag,
 } from './flowCanvasNodeChangeUtils';
-import {
-  findFreeEcorePosition,
-} from './flowCanvasLayoutUtils';
-import {
-  buildReactionEdgeFromNodes,
-  resolveEcoreFileSelectAction,
-} from './flowCanvasEcoreSelect';
-import { pickFocusUmlFlowNodes } from '../../utils/umlClassLayout';
-import { fetchReactionCode, persistReactionCode, resolveReactionFileId } from '../../utils/reactionFile';
-import { edgeIndicatorPos } from '../../utils/minimapGeometry';
+import { findFreeEcorePosition } from './flowCanvasLayoutUtils';
+import { buildReactionEdgeFromNodes, resolveEcoreFileSelectAction } from './flowCanvasEcoreSelect';
 import {
   applyPendingCanvasDelete,
   computeConnectionLinePositions,
   getEdgeDistributionData,
+  getPendingDeleteConfirmMessage,
+  getReactionModeCursor,
   getUmlMergeInfo,
   mapEcoreFlowNode,
   mapEditableFlowNode,
   mapFlowCanvasEdge,
 } from './flowCanvasRenderUtils';
-import { CodeEditorState, ConnectionDragState } from './flowCanvasTypes';
+import { applyAutoLayoutPositions, computeAutoLayoutPositions } from './flowCanvasAutoLayout';
+import { buildEdgeDistributionMap } from './flowCanvasEdgeDistribution';
+import { buildReactionEdge } from './flowCanvasEdgeFactory';
+import { computeParallelEdgeReorder } from './flowCanvasEdgeReorder';
+import {
+  dedupeEdgeIds,
+  removeOrphanEdges,
+  uniquifyLoadedEdgeIds,
+  uniquifyLoadedNodeIds,
+  withUniqueEdgeIds,
+} from './flowCanvasEdgeHygiene';
+import { optimizeEdgeHandles, updateEdgeHandles } from './flowCanvasHandleUtils';
+import {
+  findNodeByMetaModelId,
+  findEcoreTargetAtPosition,
+  getBackendMetaModelId,
+  getMetaModelSourceId,
+} from './flowCanvasNodeLookup';
+import { buildInitialReactionCode } from './flowCanvasReactionCode';
+import { buildWorkspaceSnapshot } from './flowCanvasSnapshot';
+import { getToolLabel } from './flowCanvasToolLabels';
+import { computeUmlMergeData } from './flowCanvasUmlMerge';
+import {
+  CanvasMode,
+  CodeEditorState,
+  ConnectionDragState,
+  HandlePosition,
+  PendingDeleteState,
+} from './flowCanvasTypes';
 
-const COLOR_LIST = [
-  '#ab1c91ff', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
-  '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf',
-  '#d636a3ff', '#ff9f40', '#4daf4a', '#ff6b6b', '#b388eb',
-  '#9c6644', '#f39ed1', '#a9a9a9', '#c9d22f', '#33c7c7',
-  '#2a86d6', '#ffb86b', '#63c37a', '#ff4f7a', '#b08fe8'
-];
-
-const NODE_DIMENSIONS = { width: 280, height: 180 };
-/** Matches EcoreFileBox card size (118×126). */
-const ECORE_FILE_BOX_SIZE = { width: 118, height: 126 };
-
-function buildWorkspaceSnapshotFrom(
-  nodes: Node[],
-  edges: Edge[],
-  getMetaModelSourceId: (nodeId?: string | null) => number | undefined,
-): WorkspaceSnapshot {
-  const metaModelIds = Array.from(
-    new Set(
-      nodes
-        .filter(node => node.type === 'ecoreFile')
-        .map(node => getMetaModelSourceId(node.id))
-        .filter((value): value is number => typeof value === 'number'),
-    ),
-  );
-
-  const metaModelRelationRequests: MetaModelRelationRequest[] = edges
-    .filter(edge => edge.type === 'reactions')
-    .map(edge => {
-      const sourceId = getMetaModelSourceId(edge.source);
-      const targetId = getMetaModelSourceId(edge.target);
-      const reactionFileId =
-        typeof edge.data?.reactionFileId === 'number' ? edge.data.reactionFileId : 0;
-
-      if (typeof sourceId !== 'number' || typeof targetId !== 'number') {
-        return null;
-      }
-
-      return { sourceId, targetId, reactionFileId };
-    })
-    .filter((req): req is MetaModelRelationRequest => req !== null);
-
-  return { metaModelIds, metaModelRelationRequests };
-}
-
-function getReactionModeCursor(
-  addReactionMode: boolean | undefined,
-  reactionSourceId: string | null,
-): React.CSSProperties['cursor'] {
-  if (!addReactionMode) return undefined;
-  if (reactionSourceId) return 'crosshair';
-  return 'cell';
-}
-
-type PendingDeleteState = { nodeIds: string[]; edgeIds: string[]; fileId: string | null };
-
-function getPendingDeleteConfirmMessage(pendingDelete: PendingDeleteState | null): string {
-  if (!pendingDelete) {
-    return 'Do you really want to remove this element from the canvas?';
-  }
-
-  const hasFile = Boolean(pendingDelete.fileId);
-  const hasEdges = pendingDelete.edgeIds.length > 0;
-  const hasOtherNodes = pendingDelete.nodeIds.length > 0;
-
-  if (hasFile && (hasEdges || hasOtherNodes)) {
-    return 'Remove the selected connection(s) and the meta model from the canvas?';
-  }
-  if (hasEdges) {
-    return 'Remove the selected connection from the canvas?';
-  }
-  return 'Do you really want to remove this element from the canvas?';
-}
-
-// Layout constants for auto-layout algorithm (defined outside component for stable references)
-const LAYOUT_CONFIG = {
-  BOX_WIDTH: 280,
-  BOX_HEIGHT: 180,
-  MIN_HORIZONTAL_SPACING: 150,
-  MIN_VERTICAL_SPACING: 120,
-  START_X: 100,
-  START_Y: 100,
-  ITERATIONS: 150,
-  REPULSION_STRENGTH: 50000,
-  ATTRACTION_STRENGTH: 0.3,
-  DAMPING: 0.85,
-};
+export type { CanvasMode } from './flowCanvasTypes';
 
 const nodeTypes = {
   editable: EditableNode,
-  ecoreFile: EcoreFileBox
+  ecoreFile: EcoreFileBox,
 };
 const edgeTypes = {
   uml: UMLRelationship,
-  reactions: ReactionRelationship
+  reactions: ReactionRelationship,
 };
 
+/** Smallest radius the Views circle can be dragged down to. */
+const MIN_CIRCLE_RADIUS = 260;
+/** Padding, in screen pixels, kept around the circle when fitting the view. */
+const CIRCLE_FIT_PADDING = 60;
 
-const getLocalStorageKey = (userId?: string, vsumId?: string) => {
-  if (userId && vsumId) {
-    return `flow_edge_color_map_v1_user_${userId}_vsum_${vsumId}`;
-  }
-  return 'flow_edge_color_map_v1';
-};
-
-export type CanvasMode = 'modeling' | 'constraints' | 'views';
+export interface FlowCanvasHandle {
+  handleToolClick: (toolType: string, toolName: string, diagramType?: string) => void;
+  loadDiagramData: (nodes: any[], edges: any[]) => void;
+  getNodes: () => Node[];
+  getEdges: () => Edge[];
+  addEcoreFile: (fileName: string, fileContent: string, meta?: any) => void;
+  updateEcoreFileData: (fileName: string, fileContent: string, ecoreFileId?: number) => void;
+  resetExpandedFile: () => void;
+  undo: () => void;
+  redo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  getReactionEdges: () => Edge[];
+  getWorkspaceSnapshot: () => WorkspaceSnapshot;
+  autoLayoutEcoreBoxes: () => void;
+  fitUmlView: () => void;
+  openSelectedReactionEditor: () => boolean;
+  establishBaseline: () => void;
+}
 
 interface FlowCanvasProps {
   onDeploy?: (nodes: Node[], edges: Edge[]) => void;
@@ -200,337 +172,62 @@ interface FlowCanvasProps {
   readOnly?: boolean;
 }
 
-type HandlePosition = 'top' | 'bottom' | 'left' | 'right';
-
-const pairKey = (a: string, b: string) => (a < b ? `${a}::${b}` : `${b}::${a}`);
-
-// Read-only change guards live in flowCanvasNodeChangeUtils.ts
-
-// ── CustomMinimap ─────────────────────────────────────────────────────────────
-
-const MINI_NODE_W = 118;
-const MINI_NODE_H = 126;
-
-interface CustomMinimapProps {
-  nodes: Node[];
-  edges: Edge[];
-  circle?: Circle;
-  viewport: { x: number; y: number; zoom: number };
-  containerW: number;
-  containerH: number;
-  width: number;
-  height: number;
-}
-
-const CustomMinimap: React.FC<CustomMinimapProps> = ({
-  nodes, edges, circle, viewport, containerW, containerH, width, height,
-}) => {
-  const ecoreNodes = nodes.filter(n => n.type === 'ecoreFile');
-
-  // Viewport center in flow coordinates
-  const flowCX = (-viewport.x + containerW / 2) / viewport.zoom;
-  const flowCY = (-viewport.y + containerH / 2) / viewport.zoom;
-  const visW = containerW / viewport.zoom;
-  const visH = containerH / viewport.zoom;
-
-  // Scale: current viewport fills ~80 % of the minimap — clamped so extreme zooms stay sane.
-  // The minimap always tracks the viewport center, so it shows exactly what the user sees,
-  // scaled down proportionally to minimap size.
-  const mmScale = Math.max(0.03, Math.min(2, Math.min(
-    (width  * 0.8) / Math.max(visW, 50),
-    (height * 0.8) / Math.max(visH, 50),
-  )));
-
-  // Flow → SVG coordinate helpers (centered on current viewport center)
-  const toX = (fx: number) => (fx - flowCX) * mmScale + width  / 2;
-  const toY = (fy: number) => (fy - flowCY) * mmScale + height / 2;
-
-  const nodeMap = new Map(ecoreNodes.map(n => [n.id, n]));
-
-  // Viewport rectangle in SVG space
-  const vpX = toX(flowCX - visW / 2);
-  const vpY = toY(flowCY - visH / 2);
-  const vpW = visW * mmScale;
-  const vpH = visH * mmScale;
-
-  // Off-screen indicators: colored dots at minimap border pointing toward off-screen items
-  const indicators: { id: string; x: number; y: number; color: string }[] = [];
-  ecoreNodes.forEach(node => {
-    const sx = toX(node.position.x + MINI_NODE_W / 2);
-    const sy = toY(node.position.y + MINI_NODE_H / 2);
-    const ind = edgeIndicatorPos(sx, sy, width, height);
-    if (ind) indicators.push({ id: node.id, ...ind, color: cardColor(node.data?.domain) });
-  });
-  if (circle && circle.r > 0) {
-    const sx = toX(circle.cx), sy = toY(circle.cy);
-    const ind = edgeIndicatorPos(sx, sy, width, height);
-    if (ind) indicators.push({ id: 'circle-overlay', ...ind, color: 'rgba(4,148,132,0.85)' });
-  }
-
-  return (
-    <div style={{
-      position: 'absolute', right: 60, bottom: 16,
-      width, height, zIndex: 30,
-      background: '#f0f4f8', borderRadius: 8,
-      border: '1px solid #e2e8f0',
-      boxShadow: '0 2px 8px rgba(0,0,0,0.10)',
-      overflow: 'hidden',
-    }}>
-      <svg width={width} height={height} style={{ display: 'block' }}>
-        {/* Circle (only when circleVisible and it overlaps with visible minimap area) */}
-        {circle && circle.r > 0 && (() => {
-          const cx = toX(circle.cx), cy = toY(circle.cy), r = circle.r * mmScale;
-          if (cx + r < 0 || cx - r > width || cy + r < 0 || cy - r > height) return null;
-          return (
-            <circle cx={cx} cy={cy} r={r}
-              fill="rgba(4,148,132,0.05)" stroke="rgba(4,148,132,0.45)"
-              strokeWidth={1.5} strokeDasharray="4 3"
-            />
-          );
-        })()}
-
-        {/* Edges */}
-        {edges.map(edge => {
-          const src = nodeMap.get(edge.source);
-          const tgt = nodeMap.get(edge.target);
-          if (!src || !tgt) return null;
-          return (
-            <line key={edge.id}
-              x1={toX(src.position.x + MINI_NODE_W / 2)} y1={toY(src.position.y + MINI_NODE_H / 2)}
-              x2={toX(tgt.position.x + MINI_NODE_W / 2)} y2={toY(tgt.position.y + MINI_NODE_H / 2)}
-              stroke="#94a3b8" strokeWidth={1.2}
-            />
-          );
-        })}
-
-        {/* Nodes */}
-        {ecoreNodes.map(node => {
-          const sx = toX(node.position.x), sy = toY(node.position.y);
-          const nw = MINI_NODE_W * mmScale, nh = MINI_NODE_H * mmScale;
-          if (sx + nw < 0 || sx > width || sy + nh < 0 || sy > height) return null;
-          const color = cardColor(node.data?.domain);
-          return (
-            <rect key={node.id} x={sx} y={sy} width={nw} height={nh}
-              rx={Math.max(2, 8 * mmScale)}
-              fill={color} stroke={darken(color, 25)} strokeWidth={1}
-            />
-          );
-        })}
-
-        {/* Current viewport rectangle */}
-        <rect x={vpX} y={vpY} width={vpW} height={vpH}
-          fill="rgba(59,130,246,0.07)" stroke="rgba(59,130,246,0.55)"
-          strokeWidth={1.5} rx={2}
-        />
-
-        {/* Off-screen edge indicators */}
-        {indicators.map(ind => (
-          <circle key={ind.id} cx={ind.x} cy={ind.y} r={4.5}
-            fill={ind.color} stroke="white" strokeWidth={1.2}
-          />
-        ))}
-      </svg>
-    </div>
-  );
-};
-
-// ─────────────────────────────────────────────────────────────────────────────
-
-const createControlButton = (onClick: () => void, title: string, icon: React.ReactNode) => (
-  <button
-    onClick={onClick}
-    style={{
-      width: 36,
-      height: 36,
-      borderRadius: 10,
-      border: '1px solid #e5e7eb',
-      background: '#ffffff',
-      cursor: 'pointer',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      fontSize: 18,
-      transition: 'all 0.2s ease',
-      boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
-    }}
-    title={title}
-    onMouseEnter={(e) => (e.currentTarget.style.background = '#f0f0f0')}
-    onMouseLeave={(e) => (e.currentTarget.style.background = '#ffffff')}
-  >
-    {icon}
-  </button>
-);
-
-
-const TOOL_LABELS: Record<string, Record<string, string>> = {
-  element: {
-    'class': 'Class',
-    'abstract-class': 'AbstractClass',
-    'interface': 'Interface',
-    'enumeration': 'Enumeration',
-    'package': 'Package',
-  },
-  member: {
-    'attribute': '+ attribute: Type',
-    'method': '+ method(): ReturnType',
-    'private-attribute': '- privateAttribute: Type',
-    'protected-attribute': '# protectedAttribute: Type',
-    'private-method': '- privateMethod(): ReturnType',
-    'protected-method': '# protectedMethod(): ReturnType',
-  },
-  relationship: {
-    'association': 'Association',
-    'aggregation': 'Aggregation',
-    'composition': 'Composition',
-    'inheritance': 'Inheritance',
-    'realization': 'Realization',
-    'dependency': 'Dependency',
-  },
-  multiplicity: {
-    'one': '1',
-    'many': '*',
-    'optional': '0..1',
-    'range': '1..*',
-  },
-};
-
-const getToolLabel = (toolType: string, toolName: string): string => {
-  return TOOL_LABELS[toolType]?.[toolName] || toolName;
-};
-
-export const FlowCanvas = forwardRef<{
-  handleToolClick: (toolType: string, toolName: string, diagramType?: string) => void;
-  loadDiagramData: (nodes: any[], edges: any[]) => void;
-  getNodes: () => Node[];
-  getEdges: () => Edge[];
-  addEcoreFile: (fileName: string, fileContent: string, meta?: any) => void;
-  updateEcoreFileData: (fileName: string, fileContent: string, ecoreFileId?: number) => void;
-  resetExpandedFile: () => void;
-  undo: () => void;
-  redo: () => void;
-  canUndo: boolean;
-  canRedo: boolean;
-  getReactionEdges: () => Edge[];
-  getWorkspaceSnapshot: () => WorkspaceSnapshot;
-  fitUmlView: () => void;
-  openSelectedReactionEditor: () => boolean;
-  establishBaseline: () => void;
-}, FlowCanvasProps>(
+/**
+ * High-level coordinator for the workspace canvas.
+ *
+ * Layout maths, edge construction, and the presentational chrome live in the
+ * sibling `flowCanvas*` modules and `canvas/` components; what remains here is
+ * canvas state, the wiring between ReactFlow and that state, and the imperative
+ * handle the surrounding page drives the canvas through.
+ */
+export const FlowCanvas = forwardRef<FlowCanvasHandle, FlowCanvasProps>(
   function FlowCanvasComponent(
-  {
-    onDeploy,
-    onToolClick,
-    onDiagramChange,
-    onEcoreFileSelect,
-    onEcoreFileExpand,
-    onEcoreFileDelete,
-    onEcoreFileRename,
-    userId,
-    vsumId,
-    umlModalOpen,
-    addReactionMode,
-    onReactionModeEnd,
-    onHistoryChange,
-    projectTabsBelowModeToggle,
-    onCanvasModeChange,
-    canvasMode: canvasModeProp = 'modeling',
-    constraintHighlightNodeId,
-    constraintFilterNodeId,
-    onConstraintNodeFilter,
-    readOnly = false,
-  },
-  ref,
-) {
-
+    {
+      onDiagramChange,
+      onEcoreFileSelect,
+      onEcoreFileExpand,
+      onEcoreFileDelete,
+      onEcoreFileRename,
+      userId,
+      vsumId,
+      umlModalOpen,
+      addReactionMode,
+      onReactionModeEnd,
+      onHistoryChange,
+      projectTabsBelowModeToggle,
+      onCanvasModeChange,
+      canvasMode: canvasModeProp = 'modeling',
+      constraintHighlightNodeId,
+      constraintFilterNodeId,
+      onConstraintNodeFilter,
+      readOnly = false,
+    },
+    ref,
+  ) {
     const reactFlowWrapper = useRef<HTMLDivElement>(null);
     const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null);
     // Ref mirror of reactFlowInstance – always current, safe to read from any closure or setTimeout
     const reactFlowInstanceRef = useRef<ReactFlowInstance | null>(null);
+
     const [isDragOver, setIsDragOver] = useState(false);
     const [isInteractive, setIsInteractive] = useState(!readOnly);
     const editable = !readOnly && isInteractive;
 
-    useEffect(() => {
-      if (readOnly) setIsInteractive(false);
-    }, [readOnly]);
     const [selectedFileId, setSelectedFileId] = useState<string | null>(null);
     const [expandedFileId, setExpandedFileId] = useState<string | null>(null);
     const [connectionDragState, setConnectionDragState] = useState<ConnectionDragState | null>(null);
     const [codeEditorState, setCodeEditorState] = useState<CodeEditorState | null>(null);
     const [routingStyle] = useState<'curved' | 'orthogonal'>('orthogonal');
     const [hoveredMergeGroup, setHoveredMergeGroup] = useState<string | null>(null);
-    const [pendingDelete, setPendingDelete] = useState<{ nodeIds: string[]; edgeIds: string[]; fileId: string | null } | null>(null);
+    const [pendingDelete, setPendingDelete] = useState<PendingDeleteState | null>(null);
     const [detailModel, setDetailModel] = useState<{ model: any; ecoreContent: string } | null>(null);
-    const handleShowDetails = useCallback((modelObj: any, fileContent: string) => {
-      setDetailModel({ model: modelObj, ecoreContent: fileContent });
-    }, []);
-
-    // Close detail panel when clicking outside the modal content (capture phase)
-    useEffect(() => {
-      if (!detailModel) return;
-      const handleOutsideDetail = (e: Event) => {
-        const target = e.target as HTMLElement;
-        if (target.closest('[data-model-detail-modal]')) return;
-        if (target.closest('button, input, textarea, select, a, [role="dialog"]')) return;
-        setDetailModel(null);
-      };
-      document.addEventListener('pointerdown', handleOutsideDetail, true);
-      document.addEventListener('mousedown', handleOutsideDetail, true);
-      return () => {
-        document.removeEventListener('pointerdown', handleOutsideDetail, true);
-        document.removeEventListener('mousedown', handleOutsideDetail, true);
-      };
-    }, [detailModel]);
-
-    // Unified delete handler — used by both keyboard Delete and context menu
-    const handleRequestDelete = useCallback((nodeId: string) => {
-      if (readOnly) return;
-      setPendingDelete({ nodeIds: [], edgeIds: [], fileId: nodeId });
-    }, [readOnly]);
-    // Track ReactFlow viewport for CircleOverlay sync
     const [viewport, setViewport] = useState({ x: 0, y: 0, zoom: 1 });
-
-    // Canvas center in flow coordinates — fixed at origin, ReactFlow's default fitView center
     const [circleSelected, setCircleSelected] = useState(false);
     const [activeCanvasMode, setActiveCanvasMode] = useState<CanvasMode>(canvasModeProp);
-    const circleVisible = activeCanvasMode === 'views';
-
-    useEffect(() => {
-      setActiveCanvasMode(canvasModeProp);
-      if (canvasModeProp !== 'views') setCircleSelected(false);
-    }, [canvasModeProp]);
-
-    useEffect(() => {
-      if (readOnly && activeCanvasMode === 'constraints') {
-        setActiveCanvasMode('modeling');
-        onCanvasModeChange?.('modeling');
-      }
-    }, [readOnly, activeCanvasMode, onCanvasModeChange]);
-
-    // Ref flag: set to true just before setCircle() in autoLayoutEcoreBoxes so the
-    // useEffect below can call fitViewToCircle once React has committed the new circle.
-    const pendingFitToCircle = useRef(false);
-
     // Add-reaction mode: first clicked node becomes source, second creates the edge
     const [reactionSourceId, setReactionSourceId] = useState<string | null>(null);
 
-    useEffect(() => {
-      if (!circleVisible) return;
-      const displaced = clampAllNodesToCircle(nodes, circle);
-      if (displaced.size > 0) {
-        setNodes(prev => prev.map(n => {
-          const newPos = displaced.get(n.id);
-          return newPos ? { ...n, position: newPos } : n;
-        }));
-      }
-      // Nur wenn circleVisible sich ändert
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [circleVisible]);
-
-    // Circle geometry — radius changes only when ecoreFile node count changes
-
-
-    const storageKey = getLocalStorageKey(userId, vsumId);
+    const circleVisible = activeCanvasMode === 'views';
 
     const {
       nodes,
@@ -553,85 +250,67 @@ export const FlowCanvas = forwardRef<{
       setHistoryPaused,
       establishBaseline,
     } = useFlowState();
+
     const nodesRef = useRef(nodes);
     nodesRef.current = nodes;
+
     const [circle, setCircle] = useCircleContainment(nodes);
     const { viewTypes, addViewType, deleteViewType, updateAngle, unlinkNode } = useViewTypes(vsumId);
+    const { getColorForPair } = useEdgeColorMap(userId, vsumId);
 
+    // Ref flag: set just before setCircle() in autoLayoutEcoreBoxes so the effect
+    // below can call fitViewToCircle once React has committed the new circle.
+    const pendingFitToCircle = useRef(false);
 
-    // Helper function to calculate optimal handles based on which direction target is from source
-    const calculateOptimalHandles = useCallback((sourceNode: Node, targetNode: Node) => {
-      const dx = targetNode.position.x - sourceNode.position.x;
-      const dy = targetNode.position.y - sourceNode.position.y;
-
-      // Simple rule: compare vertical vs horizontal distance
-      if (Math.abs(dy) > Math.abs(dx)) {
-        // Vertical connection is dominant
-        if (dy > 0) {
-          // Target is BELOW source
-          return { sourceHandle: 'bottom-source', targetHandle: 'top-target' };
-        } else {
-          // Target is ABOVE source
-          return { sourceHandle: 'top-source', targetHandle: 'bottom-target' };
-        }
-      } else if (dx > 0) {
-        // Horizontal connection is dominant - Target is to the RIGHT of source
-        return { sourceHandle: 'right-source', targetHandle: 'left-target' };
-      } else {
-        // Horizontal connection is dominant - Target is to the LEFT of source
-        return { sourceHandle: 'left-source', targetHandle: 'right-target' };
-      }
+    const handleShowDetails = useCallback((modelObj: any, fileContent: string) => {
+      setDetailModel({ model: modelObj, ecoreContent: fileContent });
     }, []);
 
-    // Helper to update a single edge's handles based on node positions
-    const updateEdgeHandles = useCallback((edge: Edge, currentNodes: Node[]) => {
-      // Update handles for both reactions and UML edges
-      if (edge.type !== 'reactions' && edge.type !== 'uml') return edge;
+    const handleCloseDetails = useCallback(() => setDetailModel(null), []);
 
-      const sourceNode = currentNodes.find(n => n.id === edge.source);
-      const targetNode = currentNodes.find(n => n.id === edge.target);
+    // Unified delete handler — used by both keyboard Delete and context menu
+    const handleRequestDelete = useCallback((nodeId: string) => {
+      if (readOnly) return;
+      setPendingDelete({ nodeIds: [], edgeIds: [], fileId: nodeId });
+    }, [readOnly]);
 
-      if (!sourceNode || !targetNode) return edge;
+    useEffect(() => {
+      if (readOnly) setIsInteractive(false);
+    }, [readOnly]);
 
-      // Use calculateOptimalHandles to get new handles
-      const handles = calculateOptimalHandles(sourceNode, targetNode);
-      const newSourceHandle = edge.type === 'uml' ? handles.sourceHandle : handles.sourceHandle.replace('-source', '').replace('-target', '');
-      const newTargetHandle = edge.type === 'uml' ? handles.targetHandle : handles.targetHandle.replace('-target', '').replace('-source', '');
+    useEffect(() => {
+      setActiveCanvasMode(canvasModeProp);
+      if (canvasModeProp !== 'views') setCircleSelected(false);
+    }, [canvasModeProp]);
 
-      // Only update if handles changed
-      if (edge.sourceHandle === newSourceHandle && edge.targetHandle === newTargetHandle) {
-        return edge;
+    useEffect(() => {
+      if (readOnly && activeCanvasMode === 'constraints') {
+        setActiveCanvasMode('modeling');
+        onCanvasModeChange?.('modeling');
       }
+    }, [readOnly, activeCanvasMode, onCanvasModeChange]);
 
-      const dx = targetNode.position.x - sourceNode.position.x;
-      const dy = targetNode.position.y - sourceNode.position.y;
-      console.log(`✅ Auto-updating ${edge.type} edge ${edge.id} handles:`, {
-        positions: { dx, dy },
-        old: { source: edge.sourceHandle, target: edge.targetHandle },
-        new: { source: newSourceHandle, target: newTargetHandle }
-      });
+    // Pull stray nodes back inside the circle when Views mode is entered.
+    useEffect(() => {
+      if (!circleVisible) return;
+      const displaced = clampAllNodesToCircle(nodes, circle);
+      if (displaced.size > 0) {
+        setNodes(prev => prev.map(n => {
+          const newPos = displaced.get(n.id);
+          return newPos ? { ...n, position: newPos } : n;
+        }));
+      }
+      // Intentionally only re-runs when circle visibility toggles.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [circleVisible]);
 
-      return {
-        ...edge,
-        sourceHandle: newSourceHandle,
-        targetHandle: newTargetHandle,
-        // Clear custom control point since path needs recalculation
-        data: {
-          ...edge.data,
-          customControlPoint: undefined,
-        }
-      };
-    }, [calculateOptimalHandles]);
+    // ── Edge handles ──────────────────────────────────────────────────────────
 
-    // Recalculate edge handles after node drag ends
     const recalculateEdgeHandles = useCallback(() => {
-      console.log('🔄 Node drag finished, recalculating edge handles...');
-
       if (!reactFlowInstance) return;
-
       const currentNodes = reactFlowInstance.getNodes();
       setEdges(currentEdges => currentEdges.map(edge => updateEdgeHandles(edge, currentNodes)));
-    }, [reactFlowInstance, setEdges, updateEdgeHandles]);
+    }, [reactFlowInstance, setEdges]);
 
     const onNodesChange = useCallback((changes: any) => {
       if (readOnly && changes.some(isReadOnlyBlockedNodeChange)) return;
@@ -677,155 +356,10 @@ export const FlowCanvas = forwardRef<{
       onConnect(connection);
     }, [onConnect, readOnly]);
 
-    const edgeColorMapRef = useRef<Map<string, string>>(new Map());
-    const nextColorIndexRef = useRef<number>(0);
-
-
-    useEffect(() => {
-      console.log('Loading edge color map for:', { userId, vsumId, storageKey });
-      try {
-        const raw = localStorage.getItem(storageKey);
-        if (raw) {
-          const parsed = JSON.parse(raw) as Record<string, string>;
-          edgeColorMapRef.current = new Map(Object.entries(parsed));
-          const used = new Set(Object.values(parsed));
-          let maxIndex = 0;
-          COLOR_LIST.forEach((c, i) => {
-            if (used.has(c)) maxIndex = Math.max(maxIndex, i + 1);
-          });
-          nextColorIndexRef.current = maxIndex % COLOR_LIST.length;
-          console.log('Loaded edge color map:', edgeColorMapRef.current.size, 'entries');
-        } else {
-          console.log('No edge color map found, resetting');
-          edgeColorMapRef.current = new Map();
-          nextColorIndexRef.current = 0;
-        }
-      } catch (e) {
-        console.warn('Failed to load edge color map', e);
-        edgeColorMapRef.current = new Map();
-        nextColorIndexRef.current = 0;
-      }
-    }, [userId, vsumId, storageKey]);
-
-    useEffect(() => {
-      if (!reactFlowInstance) return;
-      const timeout = setTimeout(() => {
-      }, 500); // ← 100ms war zu wenig
-      return () => clearTimeout(timeout);
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [reactFlowInstance]);
-
-    const persistEdgeColorMap = useCallback(() => {
-      try {
-        const obj: Record<string, string> = {};
-        edgeColorMapRef.current.forEach((v, k) => {
-          obj[k] = v;
-        });
-        localStorage.setItem(storageKey, JSON.stringify(obj));
-        console.log('Persisted edge color map to:', storageKey);
-      } catch (e) {
-        console.error('Failed to persist edge color map', e);
-      }
-    }, [storageKey]);
-
-    const getColorForPair = useCallback((idA: string, idB: string) => {
-      const key = pairKey(idA, idB);
-      const existing = edgeColorMapRef.current.get(key);
-      if (existing) return existing;
-      const color = COLOR_LIST[nextColorIndexRef.current % COLOR_LIST.length];
-      edgeColorMapRef.current.set(key, color);
-      nextColorIndexRef.current += 1;
-      persistEdgeColorMap();
-      return color;
-    }, [persistEdgeColorMap]);
-
-    // Helper to collect edges for each side of a node
-    const collectNodeSideEdges = useCallback((node: Node, allEdges: Edge[]) => {
-      const sideMap = new Map<HandlePosition, string[]>();
-      (['top', 'bottom', 'left', 'right'] as HandlePosition[]).forEach(pos => {
-        sideMap.set(pos, []);
-      });
-
-      allEdges.forEach(edge => {
-        if (edge.type !== 'reactions') return;
-
-        if (edge.source === node.id && edge.sourceHandle) {
-          const handle = edge.sourceHandle as HandlePosition;
-          if (!sideMap.get(handle)?.includes(edge.id)) {
-            sideMap.get(handle)?.push(edge.id);
-          }
-        }
-
-        if (edge.target === node.id && edge.targetHandle) {
-          const handle = edge.targetHandle as HandlePosition;
-          if (!sideMap.get(handle)?.includes(edge.id)) {
-            sideMap.get(handle)?.push(edge.id);
-          }
-        }
-      });
-
-      return sideMap;
-    }, []);
-
-    // Helper to create edge sort comparator based on the other connected node
-    const createEdgeSortComparator = useCallback((nodeId: string, allEdges: Edge[]) => {
-      return (a: string, b: string) => {
-        const edgeA = allEdges.find(e => e.id === a);
-        const edgeB = allEdges.find(e => e.id === b);
-        if (!edgeA || !edgeB) return 0;
-
-        const otherNodeA = edgeA.source === nodeId ? edgeA.target : edgeA.source;
-        const otherNodeB = edgeB.source === nodeId ? edgeB.target : edgeB.source;
-
-        return otherNodeA.localeCompare(otherNodeB);
-      };
-    }, []);
-
-    // Helper to build distribution metadata for a node's sides
-    const buildNodeDistribution = useCallback((
-      nodeId: string,
-      sideMap: Map<HandlePosition, string[]>,
-      allEdges: Edge[]
-    ) => {
-      const nodeDistribution = new Map<HandlePosition, Array<{ edgeId: string; index: number; total: number }>>();
-      const comparator = createEdgeSortComparator(nodeId, allEdges);
-
-      sideMap.forEach((edgeIds, position) => {
-        const sortedEdgeIds = [...edgeIds].sort(comparator);
-        const total = sortedEdgeIds.length;
-        const distribution = sortedEdgeIds.map((edgeId, index) => ({ edgeId, index, total }));
-        nodeDistribution.set(position, distribution);
-
-        if (total > 1) {
-          console.log(`📊 Node ${nodeId} - ${position} handle: ${total} edges`, sortedEdgeIds);
-        }
-      });
-
-      return nodeDistribution;
-    }, [createEdgeSortComparator]);
-
-    // Calculate edge distribution metadata for each node side
-    const edgeDistributionMap = useMemo(() => {
-      const map = new Map<string, Map<HandlePosition, Array<{ edgeId: string; index: number; total: number }>>>();
-
-      nodes.forEach(node => {
-        if (node.type !== 'ecoreFile') return;
-
-        const sideMap = collectNodeSideEdges(node, edges);
-        const nodeDistribution = buildNodeDistribution(node.id, sideMap, edges);
-        map.set(node.id, nodeDistribution);
-      });
-
-      return map;
-    }, [nodes, edges, collectNodeSideEdges, buildNodeDistribution]);
-
-    useEffect(() => {
-      console.log('EDGES STATE CHANGED:', edges);
-      console.log('Number of edges:', edges.length);
-      if (edges.length > 0) {
-        console.log('First edge:', edges[0]);
-      }
-    }, [edges]);
+    const edgeDistributionMap = useMemo(
+      () => buildEdgeDistributionMap(nodes, edges),
+      [nodes, edges],
+    );
 
     const { onDrop, onDragOver } = useDragAndDrop({
       reactFlowInstance,
@@ -833,57 +367,6 @@ export const FlowCanvas = forwardRef<{
       addNode,
       addEdge,
     });
-
-    const isPositionInsideNode = useCallback((
-      position: { x: number; y: number },
-      node: Node
-    ): boolean => {
-      const { width, height } = node.type === 'ecoreFile' ? ECORE_FILE_BOX_SIZE : NODE_DIMENSIONS;
-      return (
-        position.x >= node.position.x &&
-        position.x <= node.position.x + width &&
-        position.y >= node.position.y &&
-        position.y <= node.position.y + height
-      );
-    }, []);
-
-    const findEcoreTargetAtPosition = useCallback((
-      flowPosition: { x: number; y: number },
-      sourceNodeId: string,
-    ): Node | null => {
-      const candidates = nodes.filter(
-        n => n.type === 'ecoreFile' && n.id !== sourceNodeId,
-      );
-      const hit = candidates.find(n => isPositionInsideNode(flowPosition, n));
-      if (hit) return hit;
-
-      let closest: Node | null = null;
-      let minDist = Infinity;
-      for (const n of candidates) {
-        const cx = n.position.x + ECORE_FILE_BOX_SIZE.width / 2;
-        const cy = n.position.y + ECORE_FILE_BOX_SIZE.height / 2;
-        const dist = Math.hypot(flowPosition.x - cx, flowPosition.y - cy);
-        if (dist < minDist && dist <= 80) {
-          minDist = dist;
-          closest = n;
-        }
-      }
-      return closest;
-    }, [nodes, isPositionInsideNode]);
-
-    const getMetaModelSourceIdForNode = useCallback((nodeId?: string | null) => {
-      if (!nodeId) return undefined;
-      const node = nodes.find(n => n.id === nodeId);
-      const value = node?.data?.metaModelSourceId ?? node?.data?.metaModelId;
-      return typeof value === 'number' ? value : undefined;
-    }, [nodes]);
-
-    const getBackendMetaModelIdForNode = useCallback((nodeId?: string | null) => {
-      if (!nodeId) return undefined;
-      const node = nodes.find(n => n.id === nodeId);
-      const value = node?.data?.metaModelId ?? node?.data?.metaModelSourceId;
-      return typeof value === 'number' ? value : undefined;
-    }, [nodes]);
 
     useFlowCanvasKeyboardShortcuts({
       readOnly,
@@ -898,80 +381,38 @@ export const FlowCanvas = forwardRef<{
       setPendingDelete,
     });
 
-    const buildInitialReactionCode = useCallback((sourceNodeId: string, targetNodeId: string): string => {
-      const sourceNode = nodes.find(n => n.id === sourceNodeId);
-      const targetNode = nodes.find(n => n.id === targetNodeId);
-
-      const getEPackageName = (node: Node | undefined) => {
-        const match = node?.data?.fileContent?.match(/<ecore:EPackage[^>]+name="([^"]+)"/);
-        return match?.[1] ?? node?.data?.fileName?.replace('.ecore', '') ?? 'source';
-      };
-
-      const sourcePackageName = getEPackageName(sourceNode);
-      const targetPackageName = getEPackageName(targetNode);
-      const sourceUri = sourceNode?.data?.nsUri ?? `http://vitruv.tools/${sourcePackageName}`;
-      const targetUri = targetNode?.data?.nsUri ?? `http://vitruv.tools/${targetPackageName}`;
-
-      return `import "${sourceUri}" as ${sourcePackageName}\nimport "${targetUri}" as ${targetPackageName}\n\nreactions: ${sourcePackageName}To${targetPackageName}\nin reaction to changes in ${sourcePackageName}\nexecute actions in ${targetPackageName}\n\n`;
-    }, [nodes]);
+    // ── Reaction edge creation ────────────────────────────────────────────────
 
     const uploadReactionFile = useCallback(async (
       sourceNodeId: string,
       targetNodeId: string,
-      edgeId: string
     ): Promise<number | null> => {
+      // Pad the content so two edges created in the same second are not
+      // deduplicated into one stored file by the backend.
       const uniquePadding = ' '.repeat((Date.now() % 50) + 1);
-      const initialContent = buildInitialReactionCode(sourceNodeId, targetNodeId) + uniquePadding;
+      const initialContent = buildInitialReactionCode(nodes, sourceNodeId, targetNodeId) + uniquePadding;
       const fileName = `reaction-${Date.now()}.reactions`;
       const file = new File([initialContent], fileName, { type: 'text/plain;charset=utf-8' });
 
       try {
         const uploadResult = await apiService.uploadFile(file, 'REACTION');
-        const reactionFileId = resolveReactionFileId(uploadResult?.data);
-        if (reactionFileId == null) {
-          console.error('❌ Upload succeeded but no file ID returned');
-        } else {
-          console.log('✅ Reaction file created for new edge:', edgeId, 'fileId:', reactionFileId);
-        }
-        return reactionFileId;
+        return resolveReactionFileId(uploadResult?.data);
       } catch (err) {
         console.error('Failed to create reaction file for new edge:', err);
         return null;
       }
-    }, [buildInitialReactionCode]);
+    }, [nodes]);
 
-
-    const buildNewEdge = useCallback((
-      sourceNodeId: string,
-      targetNode: Node,
-      reactionFileId: number | null,
-      color: string
-    ): Edge | null => {
-      const sourceNode = nodes.find(n => n.id === sourceNodeId);
-      if (!sourceNode) return null;
-
-      const handles = calculateOptimalHandles(sourceNode, targetNode);
-      const sourceHandle = handles.sourceHandle.replace('-source', '').replace('-target', '');
-      const targetHandle = handles.targetHandle.replace('-target', '').replace('-source', '');
-
-      const edgeId = `edge-${sourceNodeId}-${targetNode.id}-${Date.now()}`;
-      return {
-        id: edgeId,
-        source: sourceNodeId,
-        target: targetNode.id,
-        sourceHandle,
-        targetHandle,
-        type: 'reactions',
-        style: { stroke: color, strokeWidth: 2 },
-        data: {
-          reactionFileId,
-          sourceMetaModelId: getBackendMetaModelIdForNode(sourceNodeId),
-          targetMetaModelId: getBackendMetaModelIdForNode(targetNode.id),
-          sourceMetaModelSourceId: getMetaModelSourceIdForNode(sourceNodeId),
-          targetMetaModelSourceId: getMetaModelSourceIdForNode(targetNode.id),
-        },
-      };
-    }, [nodes, calculateOptimalHandles, getBackendMetaModelIdForNode, getMetaModelSourceIdForNode]);
+    const commitReactionEdge = useCallback((newEdge: Edge) => {
+      setEdges(prev => {
+        const exists = prev.some(
+          e => e.type === 'reactions' && e.source === newEdge.source && e.target === newEdge.target,
+        );
+        if (exists) return prev;
+        return [...prev, newEdge];
+      });
+      globalThis.setTimeout(() => recalculateEdgeHandles(), 0);
+    }, [setEdges, recalculateEdgeHandles]);
 
     const findEcoreTargetFromPointer = useCallback((
       clientX: number,
@@ -988,54 +429,46 @@ export const FlowCanvas = forwardRef<{
       }
       if (!reactFlowInstance) return null;
       const flowPosition = reactFlowInstance.screenToFlowPosition({ x: clientX, y: clientY });
-      return findEcoreTargetAtPosition(flowPosition, sourceNodeId);
-    }, [nodes, reactFlowInstance, findEcoreTargetAtPosition]);
-
-    const commitReactionEdge = useCallback((newEdge: Edge) => {
-      setEdges(prev => {
-        const exists = prev.some(
-          e => e.type === 'reactions' && e.source === newEdge.source && e.target === newEdge.target,
-        );
-        if (exists) return prev;
-        return [...prev, newEdge];
-      });
-      globalThis.setTimeout(() => recalculateEdgeHandles(), 0);
-    }, [setEdges, recalculateEdgeHandles]);
+      return findEcoreTargetAtPosition(nodes, flowPosition, sourceNodeId);
+    }, [nodes, reactFlowInstance]);
 
     const handleConnectionEnd = useCallback(async (e: MouseEvent) => {
       if (readOnly) return;
       const dragState = connectionDragState;
       setConnectionDragState(null);
 
-      if (!reactFlowInstance || !dragState?.isActive || !dragState.sourceNodeId) {
-        return;
-      }
+      if (!reactFlowInstance || !dragState?.isActive || !dragState.sourceNodeId) return;
 
       const sourceNodeId = dragState.sourceNodeId;
       const targetNode = findEcoreTargetFromPointer(e.clientX, e.clientY, sourceNodeId);
-
       if (!targetNode) return;
 
-      const alreadyConnected = edges.some(edge =>
-        edge.source === sourceNodeId && edge.target === targetNode.id,
+      const alreadyConnected = edges.some(
+        edge => edge.source === sourceNodeId && edge.target === targetNode.id,
       );
       if (alreadyConnected) return;
 
+      const sourceNode = nodes.find(n => n.id === sourceNodeId);
+      if (!sourceNode) return;
+
       const color = getColorForPair(sourceNodeId, targetNode.id);
-      const edgeId = `edge-${sourceNodeId}-${targetNode.id}-${Date.now()}`;
-      const reactionFileId = await uploadReactionFile(sourceNodeId, targetNode.id, edgeId);
-      const newEdge = buildNewEdge(sourceNodeId, targetNode, reactionFileId, color);
-      if (newEdge) {
-        commitReactionEdge(newEdge);
-      }
+      const reactionFileId = await uploadReactionFile(sourceNodeId, targetNode.id);
+
+      commitReactionEdge(buildReactionEdge({
+        id: `edge-${sourceNodeId}-${targetNode.id}-${Date.now()}`,
+        sourceNode,
+        targetNode,
+        color,
+        data: { reactionFileId },
+      }));
     }, [
       reactFlowInstance,
+      nodes,
       edges,
       connectionDragState,
       getColorForPair,
       findEcoreTargetFromPointer,
       uploadReactionFile,
-      buildNewEdge,
       commitReactionEdge,
       readOnly,
     ]);
@@ -1043,19 +476,11 @@ export const FlowCanvas = forwardRef<{
     const handleConnectionMove = useCallback((e: MouseEvent) => {
       if (!reactFlowInstance) return;
 
-      const flowPosition = reactFlowInstance.screenToFlowPosition({
-        x: e.clientX,
-        y: e.clientY,
-      });
-
-      console.log('🟨 handleConnectionMove - updating position:', flowPosition);
+      const flowPosition = reactFlowInstance.screenToFlowPosition({ x: e.clientX, y: e.clientY });
 
       setConnectionDragState(prev => {
         if (!prev?.isActive) return prev;
-        return {
-          ...prev,
-          currentPosition: flowPosition,
-        };
+        return { ...prev, currentPosition: flowPosition };
       });
     }, [reactFlowInstance]);
 
@@ -1066,10 +491,8 @@ export const FlowCanvas = forwardRef<{
       const handleEnd = (e: any) => handleConnectionEnd(e);
       const captureOptions = { capture: true };
 
-      // Add listeners to both document and globalThis for cross-browser compatibility
       document.addEventListener('pointermove', handleMove, captureOptions);
       document.addEventListener('pointerup', handleEnd, captureOptions);
-
       document.body.style.cursor = 'crosshair';
 
       return () => {
@@ -1081,208 +504,10 @@ export const FlowCanvas = forwardRef<{
       };
     }, [connectionDragState?.isActive, handleConnectionMove, handleConnectionEnd]);
 
-
-    const handleEdgeDoubleClick = useCallback(async (edgeId: string) => {
-      const edge = edges.find(e => e.id === edgeId);
-      if (!edge) return;
-
-      const getFileName = (nodeId: string) => {
-        const node = nodes.find(n => n.id === nodeId);
-        return node?.type === 'ecoreFile' ? node.data.fileName : undefined;
-      };
-
-      let initialCode = edge.data?.code || '';
-      const reactionFileId = edge.data?.reactionFileId;
-
-      initialCode = await fetchReactionCode(
-        initialCode,
-        reactionFileId,
-        () => buildInitialReactionCode(edge.source, edge.target),
-      );
-
-      setCodeEditorState({
-        isOpen: true,
-        edgeId,
-        initialCode,
-        sourceFileName: getFileName(edge.source),
-        targetFileName: getFileName(edge.target),
-        reactionFileId,
-      });
-    }, [edges, nodes, buildInitialReactionCode]);
-
-    const openSelectedReactionEditor = useCallback((): boolean => {
-      const selected = edges.filter(e => e.selected && e.type === 'reactions');
-      if (selected.length === 0) return false;
-      void handleEdgeDoubleClick(selected[0].id);
-      return true;
-    }, [edges, handleEdgeDoubleClick]);
-
-    const handleCloseCodeEditor = useCallback(() => {
-      setCodeEditorState(null);
-    }, []);
-
-    const handleSaveCode = useCallback(async (code: string) => {
-      if (!codeEditorState?.edgeId) {
-        return;
-      }
-
-      const edgeId = codeEditorState.edgeId;
-
-      try {
-        const reactionFileId = await persistReactionCode(code, codeEditorState.reactionFileId);
-
-        updateEdgeCode(edgeId, code);
-
-        setCodeEditorState(prev =>
-          prev
-            ? {
-              ...prev,
-              reactionFileId,
-            }
-            : prev
-        );
-
-        setEdges(prev =>
-          prev.map(edge =>
-            edge.id === edgeId
-              ? {
-                ...edge,
-                data: {
-                  ...edge.data,
-                  reactionFileId: reactionFileId ?? edge.data?.reactionFileId ?? null,
-                  sourceMetaModelId:
-                    getBackendMetaModelIdForNode(edge.source) ??
-                    edge.data?.sourceMetaModelId,
-                  targetMetaModelId:
-                    getBackendMetaModelIdForNode(edge.target) ??
-                    edge.data?.targetMetaModelId,
-                  sourceMetaModelSourceId:
-                    getMetaModelSourceIdForNode(edge.source) ??
-                    edge.data?.sourceMetaModelSourceId,
-                  targetMetaModelSourceId:
-                    getMetaModelSourceIdForNode(edge.target) ??
-                    edge.data?.targetMetaModelSourceId,
-                },
-              }
-              : edge
-          )
-        );
-      } catch (err) {
-        console.error('Failed to save reaction file', err);
-        throw err;
-      }
-    }, [codeEditorState, updateEdgeCode, setEdges, getBackendMetaModelIdForNode, getMetaModelSourceIdForNode]);
-
-    const handleDeleteEdge = useCallback(() => {
-      if (codeEditorState?.edgeId) {
-        removeEdge(codeEditorState.edgeId);
-        setCodeEditorState(null);
-      }
-    }, [codeEditorState, removeEdge]);
-
-    const handleToolClick = useCallback((toolType: string, toolName: string, diagramType?: string) => {
-      if (!reactFlowInstance || !reactFlowWrapper.current) return;
-
-      const canvasBounds = reactFlowWrapper.current.getBoundingClientRect();
-      const position = reactFlowInstance.project({
-        x: canvasBounds.width / 2,
-        y: canvasBounds.height / 2,
-      });
-
-      const label = getToolLabel(toolType, toolName);
-
-      const newNode: Omit<Node, 'id'> = {
-        type: 'editable',
-        position,
-        data: {
-          label,
-          toolType,
-          toolName,
-          diagramType
-        }
-      };
-
-      console.log('Adding new node from tool click:', newNode);
-      addNode(newNode);
-    }, [reactFlowInstance, addNode]);
-
-    const loadDiagramData = useCallback((newNodes: any[], newEdges: any[]) => {
-      console.log('Loading diagram data (raw):', { newNodes, newEdges });
-
-      const nodesWithIds = newNodes.map((n, idx) => ({
-        ...n,
-        id: n.id ?? `loaded-node-${idx}-${Date.now()}`,
-      }));
-
-      const seen = new Set<string>();
-      const edgesWithUniqueIds = newEdges.map((e, idx) => {
-        let baseId = e.id ?? `loaded-edge-${idx}`;
-        if (seen.has(baseId)) {
-          let k = 1;
-          let newId = `${baseId}-${k}`;
-          while (seen.has(newId)) {
-            k += 1;
-            newId = `${baseId}-${k}`;
-          }
-          console.warn('🔁 Renaming duplicate loaded edge id:', baseId, '→', newId, e);
-          baseId = newId;
-        }
-        seen.add(baseId);
-
-        return {
-          ...e,
-          id: baseId,
-        };
-      });
-
-      console.log(
-        'Edges after uniquify:',
-        edgesWithUniqueIds.map(e => e.id)
-      );
-
-      setHistoryPaused(true);
-      setNodes([]);
-      setEdges([]);
-      if (nodesWithIds.length > 0) setNodes(nodesWithIds);
-      if (edgesWithUniqueIds.length > 0) setEdges(edgesWithUniqueIds);
-
-      // Reset undo baseline to the loaded diagram (not the pre-load empty state).
-      requestAnimationFrame(() => {
-        establishBaseline({
-          nodes: nodesWithIds,
-          edges: edgesWithUniqueIds,
-        });
-        setHistoryPaused(false);
-      });
-
-      console.log('Diagram data loaded successfully');
-    }, [setNodes, setEdges, setHistoryPaused, establishBaseline]);
-
-
-    const handleDragOver = useCallback((event: React.DragEvent) => {
-      onDragOver(event);
-      setIsDragOver(true);
-    }, [onDragOver]);
-
-    const handleDragLeave = useCallback(() => {
-      setIsDragOver(false);
-    }, []);
-
-    const handleDrop = useCallback((event: React.DragEvent) => {
-      setIsDragOver(false);
-      if (readOnly) return;
-      onDrop(event);
-    }, [onDrop, readOnly]);
-
-    const handleLabelChange = useCallback((id: string, newLabel: string) => {
-      if (readOnly) return;
-      updateNodeLabel(id, newLabel);
-    }, [updateNodeLabel, readOnly]);
-
     const handleConnectionStart = useCallback((
       nodeId: string,
       handle: HandlePosition,
-      tipScreenPos: { x: number; y: number }
+      tipScreenPos: { x: number; y: number },
     ) => {
       if (readOnly || !reactFlowInstance) return;
 
@@ -1298,9 +523,223 @@ export const FlowCanvas = forwardRef<{
       });
     }, [reactFlowInstance, readOnly]);
 
+    const createReactionEdgeFromEvent = useCallback((detail: {
+      sourceNodeId: string;
+      targetNodeId: string;
+      code: string;
+      originalEdgeId: number;
+    }) => {
+      const { sourceNodeId, targetNodeId, code, originalEdgeId } = detail;
 
-    // Uses the ref mirror so it is safe to call from any closure or setTimeout without
-    // worrying about stale captures of reactFlowInstance.
+      const sourceNode = nodes.find(n => n.id === sourceNodeId);
+      const targetNode = nodes.find(n => n.id === targetNodeId);
+      if (!sourceNode || !targetNode) {
+        console.warn('Could not find nodes for edge creation:', detail);
+        return;
+      }
+
+      addEdge(buildReactionEdge({
+        id: `edge-${sourceNodeId}-${targetNodeId}-${Date.now()}`,
+        sourceNode,
+        targetNode,
+        color: getColorForPair(sourceNodeId, targetNodeId),
+        data: { code, originalEdgeId },
+      }));
+    }, [nodes, addEdge, getColorForPair]);
+
+    useReactionEdgeCreationEvents({ readOnly, createReactionEdgeFromEvent });
+
+    const processRelation = useCallback((
+      relation: MetaModelRelation,
+      preserveExisting: boolean,
+    ) => {
+      const sourceNode = findNodeByMetaModelId(nodes, relation.sourceId);
+      const targetNode = findNodeByMetaModelId(nodes, relation.targetId);
+
+      if (!sourceNode || !targetNode) {
+        console.warn('Could not find nodes for relation:', relation);
+        return;
+      }
+
+      const existsByBackendId = edges.some(edge => edge.data?.backendRelationId === relation.id);
+      if (existsByBackendId) return;
+
+      const alreadyConnected = edges.some(
+        edge => edge.type === 'reactions'
+          && ((edge.source === sourceNode.id && edge.target === targetNode.id)
+            || (edge.source === targetNode.id && edge.target === sourceNode.id)),
+      );
+      if (preserveExisting && alreadyConnected) return;
+
+      addEdge(buildReactionEdge({
+        id: `edge-backend-${relation.id}-${Date.now()}`,
+        sourceNode,
+        targetNode,
+        color: getColorForPair(sourceNode.id, targetNode.id),
+        data: {
+          code: '',
+          backendRelationId: relation.id,
+          reactionFileId: relation.reactionFileId ?? null,
+        },
+      }));
+    }, [nodes, edges, getColorForPair, addEdge]);
+
+    useMetaModelRelationEvents({ processRelation });
+
+    // ── Reaction code editor ──────────────────────────────────────────────────
+
+    const handleEdgeDoubleClick = useCallback(async (edgeId: string) => {
+      const edge = edges.find(e => e.id === edgeId);
+      if (!edge) return;
+
+      const getFileName = (nodeId: string) => {
+        const node = nodes.find(n => n.id === nodeId);
+        return node?.type === 'ecoreFile' ? node.data.fileName : undefined;
+      };
+
+      const reactionFileId = edge.data?.reactionFileId;
+      const initialCode = await fetchReactionCode(
+        edge.data?.code || '',
+        reactionFileId,
+        () => buildInitialReactionCode(nodes, edge.source, edge.target),
+      );
+
+      setCodeEditorState({
+        isOpen: true,
+        edgeId,
+        initialCode,
+        sourceFileName: getFileName(edge.source),
+        targetFileName: getFileName(edge.target),
+        reactionFileId,
+      });
+    }, [edges, nodes]);
+
+    const openSelectedReactionEditor = useCallback((): boolean => {
+      const selected = edges.filter(e => e.selected && e.type === 'reactions');
+      if (selected.length === 0) return false;
+      void handleEdgeDoubleClick(selected[0].id);
+      return true;
+    }, [edges, handleEdgeDoubleClick]);
+
+    const handleCloseCodeEditor = useCallback(() => setCodeEditorState(null), []);
+
+    const handleSaveCode = useCallback(async (code: string) => {
+      if (!codeEditorState?.edgeId) return;
+      const edgeId = codeEditorState.edgeId;
+
+      try {
+        const reactionFileId = await persistReactionCode(code, codeEditorState.reactionFileId);
+
+        updateEdgeCode(edgeId, code);
+        setCodeEditorState(prev => (prev ? { ...prev, reactionFileId } : prev));
+
+        setEdges(prev =>
+          prev.map(edge =>
+            edge.id === edgeId
+              ? {
+                ...edge,
+                data: {
+                  ...edge.data,
+                  reactionFileId: reactionFileId ?? edge.data?.reactionFileId ?? null,
+                  sourceMetaModelId:
+                    getBackendMetaModelId(nodes, edge.source) ?? edge.data?.sourceMetaModelId,
+                  targetMetaModelId:
+                    getBackendMetaModelId(nodes, edge.target) ?? edge.data?.targetMetaModelId,
+                  sourceMetaModelSourceId:
+                    getMetaModelSourceId(nodes, edge.source) ?? edge.data?.sourceMetaModelSourceId,
+                  targetMetaModelSourceId:
+                    getMetaModelSourceId(nodes, edge.target) ?? edge.data?.targetMetaModelSourceId,
+                },
+              }
+              : edge,
+          ),
+        );
+      } catch (err) {
+        console.error('Failed to save reaction file', err);
+        throw err;
+      }
+    }, [codeEditorState, updateEdgeCode, setEdges, nodes]);
+
+    const handleDeleteEdge = useCallback(() => {
+      if (codeEditorState?.edgeId) {
+        removeEdge(codeEditorState.edgeId);
+        setCodeEditorState(null);
+      }
+    }, [codeEditorState, removeEdge]);
+
+    // ── Imperative surface ────────────────────────────────────────────────────
+
+    const handleToolClick = useCallback((toolType: string, toolName: string, diagramType?: string) => {
+      if (!reactFlowInstance || !reactFlowWrapper.current) return;
+
+      const canvasBounds = reactFlowWrapper.current.getBoundingClientRect();
+      const position = reactFlowInstance.project({
+        x: canvasBounds.width / 2,
+        y: canvasBounds.height / 2,
+      });
+
+      addNode({
+        type: 'editable',
+        position,
+        data: {
+          label: getToolLabel(toolType, toolName),
+          toolType,
+          toolName,
+          diagramType,
+        },
+      });
+    }, [reactFlowInstance, addNode]);
+
+    const loadDiagramData = useCallback((newNodes: any[], newEdges: any[]) => {
+      const nodesWithIds = uniquifyLoadedNodeIds(newNodes);
+      const edgesWithUniqueIds = uniquifyLoadedEdgeIds(newEdges);
+
+      setHistoryPaused(true);
+      setNodes([]);
+      setEdges([]);
+      if (nodesWithIds.length > 0) setNodes(nodesWithIds);
+      if (edgesWithUniqueIds.length > 0) setEdges(edgesWithUniqueIds);
+
+      // Reset undo baseline to the loaded diagram (not the pre-load empty state).
+      requestAnimationFrame(() => {
+        establishBaseline({ nodes: nodesWithIds, edges: edgesWithUniqueIds });
+        setHistoryPaused(false);
+      });
+    }, [setNodes, setEdges, setHistoryPaused, establishBaseline]);
+
+    const getReactionEdges = useCallback(
+      () => edges.filter(e => e.type === 'reactions'),
+      [edges],
+    );
+
+    const getWorkspaceSnapshot = useCallback(
+      (): WorkspaceSnapshot => buildWorkspaceSnapshot(nodes, edges),
+      [nodes, edges],
+    );
+
+    // ── Drag & drop ───────────────────────────────────────────────────────────
+
+    const handleDragOver = useCallback((event: React.DragEvent) => {
+      onDragOver(event);
+      setIsDragOver(true);
+    }, [onDragOver]);
+
+    const handleDragLeave = useCallback(() => setIsDragOver(false), []);
+
+    const handleDrop = useCallback((event: React.DragEvent) => {
+      setIsDragOver(false);
+      if (readOnly) return;
+      onDrop(event);
+    }, [onDrop, readOnly]);
+
+    const handleLabelChange = useCallback((id: string, newLabel: string) => {
+      if (readOnly) return;
+      updateNodeLabel(id, newLabel);
+    }, [updateNodeLabel, readOnly]);
+
+    // ── Viewport ──────────────────────────────────────────────────────────────
+
+    // Reads reactFlowInstanceRef so it stays correct when called from a timeout.
     const fitUmlView = useCallback(() => {
       const inst = reactFlowInstanceRef.current;
       if (!inst) return;
@@ -1319,14 +758,14 @@ export const FlowCanvas = forwardRef<{
     const fitEcoreWorkspace = useCallback(() => {
       const inst = reactFlowInstanceRef.current;
       if (!inst) return;
-      const ecoreNodes = inst.getNodes().filter(n => n.type === 'ecoreFile');
-      if (ecoreNodes.length === 0) return;
+      const ecoreOnly = inst.getNodes().filter(n => n.type === 'ecoreFile');
+      if (ecoreOnly.length === 0) return;
       inst.fitView({
         padding: 0.25,
         minZoom: 0.2,
         maxZoom: 1.2,
         duration: 250,
-        nodes: ecoreNodes,
+        nodes: ecoreOnly,
       });
     }, []);
 
@@ -1335,12 +774,13 @@ export const FlowCanvas = forwardRef<{
       if (!inst || !reactFlowWrapper.current) return;
       const { width, height } = reactFlowWrapper.current.getBoundingClientRect();
       if (!width || !height) return;
-      const padding = 60;
+
       const zoom = Math.min(
-        (width - padding * 2) / (c.r * 2),
-        (height - padding * 2) / (c.r * 2)
+        (width - CIRCLE_FIT_PADDING * 2) / (c.r * 2),
+        (height - CIRCLE_FIT_PADDING * 2) / (c.r * 2),
       );
       const clampedZoom = Math.min(Math.max(zoom, 0.05), 2);
+
       inst.setViewport({
         x: width / 2 - c.cx * clampedZoom,
         y: height / 2 - c.cy * clampedZoom,
@@ -1359,12 +799,13 @@ export const FlowCanvas = forwardRef<{
     const handleCircleResizePreview = useCallback((newR: number) => {
       if (!reactFlowInstance || !reactFlowWrapper.current) return;
       const { width, height } = reactFlowWrapper.current.getBoundingClientRect();
-      const padding = 60;
+
       const zoom = Math.min(
-        (width - padding * 2) / (newR * 2),
-        (height - padding * 2) / (newR * 2)
+        (width - CIRCLE_FIT_PADDING * 2) / (newR * 2),
+        (height - CIRCLE_FIT_PADDING * 2) / (newR * 2),
       );
       const clampedZoom = Math.min(Math.max(zoom, 0.05), 2);
+
       reactFlowInstance.setViewport({
         x: width / 2 - circle.cx * clampedZoom,
         y: height / 2 - circle.cy * clampedZoom,
@@ -1372,19 +813,9 @@ export const FlowCanvas = forwardRef<{
       });
     }, [reactFlowInstance, circle.cx, circle.cy]);
 
-    const handleAddViewType = useCallback((
-      label: string, scope: ViewTypeScope, linkedNodeIds: string[], angle: number, editable: boolean
-    ) => {
-      if (readOnly) return;
-      addViewType({ label, scope, angle, linkedNodeIds, editable });
-    }, [addViewType, readOnly]);
-
-
     const handleCircleResize = useCallback((newR: number) => {
       if (readOnly) return;
-      const MIN_RADIUS = 260;
-      const safeR = Math.max(MIN_RADIUS, newR);
-      const newCircle: Circle = { ...circle, r: safeR };
+      const newCircle: Circle = { ...circle, r: Math.max(MIN_CIRCLE_RADIUS, newR) };
       setCircle(newCircle);
 
       const displaced = clampAllNodesToCircle(nodes, newCircle);
@@ -1397,10 +828,44 @@ export const FlowCanvas = forwardRef<{
       fitViewToCircle(newCircle);
     }, [readOnly, circle, setCircle, nodes, setNodes, fitViewToCircle]);
 
+    const handleAddViewType = useCallback((
+      label: string,
+      scope: ViewTypeScope,
+      linkedNodeIds: string[],
+      angle: number,
+      viewTypeEditable: boolean,
+    ) => {
+      if (readOnly) return;
+      addViewType({ label, scope, angle, linkedNodeIds, editable: viewTypeEditable });
+    }, [addViewType, readOnly]);
+
+    // ── Auto-layout ───────────────────────────────────────────────────────────
+
+    const autoLayoutEcoreBoxes = useCallback(() => {
+      const ecoreOnly = nodes.filter(n => n.type === 'ecoreFile');
+      if (ecoreOnly.length === 0) return;
+
+      const positionMap = computeAutoLayoutPositions(ecoreOnly, edges);
+      const updatedNodes = applyAutoLayoutPositions(nodes, positionMap);
+      setNodes(updatedNodes);
+
+      // Re-point the edges and recentre once the moved nodes have committed.
+      // pendingFitToCircle signals the effect above to fit after the circle lands.
+      setTimeout(() => {
+        setEdges(optimizeEdgeHandles(updatedNodes, edges));
+
+        const newCircle = computeInitialCircle(updatedNodes.filter(n => n.type === 'ecoreFile'));
+        pendingFitToCircle.current = true;
+        setCircle(newCircle);
+      }, 50);
+    }, [nodes, edges, setNodes, setEdges, setCircle]);
+
+    useWorkspaceLayoutEvents({ autoLayoutEcoreBoxes, fitEcoreWorkspace });
+
+    // ── Ecore file lifecycle ──────────────────────────────────────────────────
+
     const handleEcoreFileSelect = useCallback((fileName: string) => {
-      const ecoreNode = nodes.find(
-        n => n.type === 'ecoreFile' && n.data.fileName === fileName
-      );
+      const ecoreNode = nodes.find(n => n.type === 'ecoreFile' && n.data.fileName === fileName);
       if (!ecoreNode) return;
 
       const action = resolveEcoreFileSelectAction({
@@ -1426,12 +891,7 @@ export const FlowCanvas = forwardRef<{
           const sourceNode = nodes.find(n => n.id === action.sourceId);
           if (sourceNode) {
             const color = getColorForPair(sourceNode.id, action.targetNode.id);
-            commitReactionEdge(buildReactionEdgeFromNodes(
-              sourceNode,
-              action.targetNode,
-              color,
-              calculateOptimalHandles,
-            ));
+            commitReactionEdge(buildReactionEdgeFromNodes(sourceNode, action.targetNode, color));
           }
           setReactionSourceId(null);
           onReactionModeEnd?.();
@@ -1446,7 +906,7 @@ export const FlowCanvas = forwardRef<{
           setSelectedFileId(action.nodeId);
           onEcoreFileSelect?.(action.fileName);
       }
-    }, [nodes, onEcoreFileSelect, addReactionMode, reactionSourceId, getColorForPair, calculateOptimalHandles, commitReactionEdge, onReactionModeEnd, activeCanvasMode, onConstraintNodeFilter, constraintFilterNodeId, readOnly]);
+    }, [nodes, onEcoreFileSelect, addReactionMode, reactionSourceId, getColorForPair, commitReactionEdge, onReactionModeEnd, activeCanvasMode, onConstraintNodeFilter, constraintFilterNodeId, readOnly]);
 
     // Clear reaction source when mode is toggled off
     useEffect(() => {
@@ -1459,9 +919,7 @@ export const FlowCanvas = forwardRef<{
     }, [canUndo, canRedo, onHistoryChange]);
 
     const handleEcoreFileExpand = useCallback((fileName: string, fileContent: string) => {
-      const ecoreNode = nodes.find(
-        n => n.type === 'ecoreFile' && n.data.fileName === fileName
-      );
+      const ecoreNode = nodes.find(n => n.type === 'ecoreFile' && n.data.fileName === fileName);
 
       if (ecoreNode) {
         setExpandedFileId(ecoreNode.id);
@@ -1485,13 +943,13 @@ export const FlowCanvas = forwardRef<{
         current.map(n =>
           n.type === 'ecoreFile' && n.data.fileName === fileName
             ? {
-                ...n,
-                data: {
-                  ...n.data,
-                  fileContent,
-                  ...(ecoreFileId == null ? {} : { ecoreFileId }),
-                },
-              }
+              ...n,
+              data: {
+                ...n.data,
+                fileContent,
+                ...(ecoreFileId == null ? {} : { ecoreFileId }),
+              },
+            }
             : n,
         ),
       );
@@ -1510,32 +968,26 @@ export const FlowCanvas = forwardRef<{
 
     const addEcoreFile = useCallback((fileName: string, fileContent: string, meta?: any) => {
       if (readOnly && !meta?.fromServerLoad) return;
+
       const ecoreNodes = nodesRef.current.filter(n => n.type === 'ecoreFile');
       const metaModelId = typeof meta?.metaModelId === 'number' ? meta.metaModelId : undefined;
       const metaModelSourceId = typeof meta?.metaModelSourceId === 'number'
         ? meta.metaModelSourceId
         : metaModelId;
-      if (
-        metaModelId != null
-        && ecoreNodes.some(
-          n => n.data?.metaModelId === metaModelId || n.data?.metaModelSourceId === metaModelSourceId,
-        )
-      ) {
-        return;
-      }
-      const position = findFreeEcorePosition(ecoreNodes, meta?.position ?? { x: 60, y: 60 });
 
-      const nsUri = extractNsUriFromEcore(fileContent);
-
+      const alreadyOnCanvas = metaModelId != null && ecoreNodes.some(
+        n => n.data?.metaModelId === metaModelId || n.data?.metaModelSourceId === metaModelSourceId,
+      );
+      if (alreadyOnCanvas) return;
 
       const newEcoreNode: Node = {
         id: `ecore-${meta?.metaModelId ?? meta?.metaModelSourceId ?? Date.now()}`,
         type: 'ecoreFile',
-        position: position,
+        position: findFreeEcorePosition(ecoreNodes, meta?.position ?? { x: 60, y: 60 }),
         data: {
           fileName,
           fileContent,
-          nsUri,
+          nsUri: extractNsUriFromEcore(fileContent),
           description: meta?.description,
           keywords: meta?.keywords,
           domain: meta?.domain,
@@ -1557,570 +1009,82 @@ export const FlowCanvas = forwardRef<{
 
       addNode(newEcoreNode);
       setSelectedFileId(newEcoreNode.id);
-
-      if (onEcoreFileSelect) {
-        onEcoreFileSelect(fileName);
-      }
+      onEcoreFileSelect?.(fileName);
     }, [addNode, handleEcoreFileExpand, handleEcoreFileSelect, onEcoreFileSelect, onEcoreFileDelete, onEcoreFileRename, handleRequestDelete, handleShowDetails, readOnly]);
 
-    useEffect(() => {
-      const handleCreateReactionEdge = (e: Event) => {
-        if (readOnly) return;
-        const custom = e as CustomEvent<{
-          sourceNodeId: string;
-          targetNodeId: string;
-          code: string;
-          originalEdgeId: number;
-        }>;
-
-        const { sourceNodeId, targetNodeId, code, originalEdgeId } = custom.detail;
-
-        const sourceNode = nodes.find(n => n.id === sourceNodeId);
-        const targetNode = nodes.find(n => n.id === targetNodeId);
-
-        if (!sourceNode || !targetNode) {
-          console.warn('Could not find nodes for edge creation:', custom.detail);
-          return;
-        }
-
-        const color = getColorForPair(sourceNodeId, targetNodeId);
-        const handles = calculateOptimalHandles(sourceNode, targetNode);
-
-        // Strip -source and -target suffixes from handles for ReactFlow compatibility
-        const cleanSourceHandle = handles.sourceHandle.replace('-source', '').replace('-target', '');
-        const cleanTargetHandle = handles.targetHandle.replace('-target', '').replace('-source', '');
-
-        const newEdge: Edge = {
-          id: `edge-${sourceNodeId}-${targetNodeId}-${Date.now()}`,
-          source: sourceNodeId,
-          target: targetNodeId,
-          sourceHandle: cleanSourceHandle,
-          targetHandle: cleanTargetHandle,
-          type: 'reactions',
-          data: {
-            code: code,
-            originalEdgeId: originalEdgeId,
-            sourceMetaModelId: getBackendMetaModelIdForNode(sourceNodeId),
-            targetMetaModelId: getBackendMetaModelIdForNode(targetNodeId),
-            sourceMetaModelSourceId: getMetaModelSourceIdForNode(sourceNodeId),
-            targetMetaModelSourceId: getMetaModelSourceIdForNode(targetNodeId),
-          },
-          style: {
-            stroke: color,
-            strokeWidth: 2,
-          },
-        };
-
-        console.log('Creating reaction edge from event:', newEdge);
-        addEdge(newEdge);
-      };
-
-      globalThis.addEventListener('vitruv.createReactionEdge', handleCreateReactionEdge as EventListener);
-
-      return () => {
-        globalThis.removeEventListener('vitruv.createReactionEdge', handleCreateReactionEdge as EventListener);
-      };
-    }, [nodes, addEdge, getColorForPair, getBackendMetaModelIdForNode, getMetaModelSourceIdForNode, calculateOptimalHandles, readOnly]);
-
-    // Helper to find node by meta model ID
-    const findNodeByMetaModelId = useCallback((metaModelId: number) => {
-      return nodes.find(n =>
-        n.type === 'ecoreFile' &&
-        (n.data?.metaModelId === metaModelId || n.data?.metaModelSourceId === metaModelId)
-      );
-    }, [nodes]);
-
-    // Helper to check if edge already exists between nodes
-    const edgeExistsBetweenNodes = useCallback((sourceId: string, targetId: string) => {
-      return edges.some(edge =>
-        edge.type === 'reactions' &&
-        ((edge.source === sourceId && edge.target === targetId) ||
-          (edge.source === targetId && edge.target === sourceId))
-      );
-    }, [edges]);
-
-    // Helper to process a single relation and create edge
-    const processRelation = useCallback((
-      relation: { id: number; sourceId: number; targetId: number; reactionFileId?: number | null },
-      preserveExisting: boolean
-    ) => {
-      const sourceNode = findNodeByMetaModelId(relation.sourceId);
-      const targetNode = findNodeByMetaModelId(relation.targetId);
-
-      if (!sourceNode || !targetNode) {
-        console.warn('Could not find nodes for relation:', relation, 'Available nodes:', nodes.filter(n => n.type === 'ecoreFile').map(n => ({ id: n.id, metaModelId: n.data?.metaModelId, metaModelSourceId: n.data?.metaModelSourceId })));
-        return;
-      }
-
-      const existsByBackendId = edges.some(edge => edge.data?.backendRelationId === relation.id);
-      if (existsByBackendId) return;
-
-      if (preserveExisting && edgeExistsBetweenNodes(sourceNode.id, targetNode.id)) {
-        console.log('Preserving existing edge between nodes:', sourceNode.id, targetNode.id);
-        return;
-      }
-
-      const color = getColorForPair(sourceNode.id, targetNode.id);
-      const handles = calculateOptimalHandles(sourceNode, targetNode);
-      const cleanSourceHandle = handles.sourceHandle.replace('-source', '').replace('-target', '');
-      const cleanTargetHandle = handles.targetHandle.replace('-target', '').replace('-source', '');
-
-      console.log(`✅ Creating metamodel connection: ${sourceNode.data?.fileName} → ${targetNode.data?.fileName}`, {
-        handles: { source: cleanSourceHandle, target: cleanTargetHandle },
-        positions: { source: sourceNode.position, target: targetNode.position }
-      });
-
-      const newEdge: Edge = {
-        id: `edge-backend-${relation.id}-${Date.now()}`,
-        source: sourceNode.id,
-        target: targetNode.id,
-        type: 'reactions',
-        sourceHandle: cleanSourceHandle,
-        targetHandle: cleanTargetHandle,
-        data: {
-          code: '',
-          backendRelationId: relation.id,
-          reactionFileId: relation.reactionFileId ?? null,
-          sourceMetaModelId: sourceNode.data?.metaModelId ?? sourceNode.data?.metaModelSourceId,
-          targetMetaModelId: targetNode.data?.metaModelId ?? targetNode.data?.metaModelSourceId,
-          sourceMetaModelSourceId: sourceNode.data?.metaModelSourceId ?? sourceNode.data?.metaModelId,
-          targetMetaModelSourceId: targetNode.data?.metaModelSourceId ?? targetNode.data?.metaModelId,
-        },
-        style: {
-          stroke: color,
-          strokeWidth: 2,
-        },
-      };
-
-      addEdge(newEdge);
-    }, [nodes, edges, findNodeByMetaModelId, edgeExistsBetweenNodes, getColorForPair, calculateOptimalHandles, addEdge]);
-
-    useEffect(() => {
-      const handleLoadMetaModelRelations = (e: Event) => {
-        const custom = e as CustomEvent<{
-          relations?: Array<Record<string, unknown>>;
-          preserveExisting?: boolean;
-        }>;
-
-        const preserveExisting = custom.detail?.preserveExisting ?? false;
-        const relations = (custom.detail?.relations ?? [])
-          .map(rel => ({
-            id: typeof rel.id === 'number' ? rel.id : 0,
-            sourceId: (rel.sourceId ?? rel.sourceMetaModelId) as number,
-            targetId: (rel.targetId ?? rel.targetMetaModelId) as number,
-            reactionFileId: (rel.reactionFileId ?? rel.reactionFileStorageId ?? null) as number | null,
-          }))
-          .filter(
-            rel => typeof rel.sourceId === 'number' && typeof rel.targetId === 'number',
-          );
-
-        relations.forEach(relation => processRelation(relation, preserveExisting));
-      };
-
-      globalThis.addEventListener('vitruv.loadMetaModelRelations', handleLoadMetaModelRelations);
-      globalThis.addEventListener('vitruv.loadRelations', handleLoadMetaModelRelations);
-      return () => {
-        globalThis.removeEventListener('vitruv.loadMetaModelRelations', handleLoadMetaModelRelations);
-        globalThis.removeEventListener('vitruv.loadRelations', handleLoadMetaModelRelations);
-      };
-    }, [processRelation, reactFlowInstance, fitViewToCircle, circle]);
+    // ── Edge hygiene ──────────────────────────────────────────────────────────
 
     useEffect(() => {
       onDiagramChange?.(nodes, edges);
     }, [nodes, edges, onDiagramChange]);
 
-    const getReactionEdges = useCallback(() => {
-      return edges.filter(e => e.type === 'reactions');
-    }, [edges]);
-
-    const buildWorkspaceSnapshot = useCallback(
-      (): WorkspaceSnapshot => buildWorkspaceSnapshotFrom(nodes, edges, getMetaModelSourceIdForNode),
-      [nodes, edges, getMetaModelSourceIdForNode],
-    );
-
     useEffect(() => {
       if (!nodes.length || !edges.length) return;
-
-      const nodeIds = new Set(nodes.map(n => n.id));
-      const filteredEdges = edges.filter(
-        (e) => nodeIds.has(e.source) && nodeIds.has(e.target)
-      );
-
-      if (filteredEdges.length !== edges.length) {
-        console.log('🧹 Removing orphan reaction edges after node deletion');
-        setEdges(filteredEdges);
-      }
+      const filteredEdges = removeOrphanEdges(nodes, edges);
+      if (filteredEdges.length !== edges.length) setEdges(filteredEdges);
     }, [nodes, edges, setEdges]);
 
     useEffect(() => {
       if (!edges.length) return;
-
-      const seen = new Map<string, number>();
-      let changed = false;
-
-      const fixedEdges = edges.map((edge) => {
-        const count = seen.get(edge.id) ?? 0;
-
-        if (count === 0) {
-          seen.set(edge.id, 1);
-          return edge;
-        }
-
-        const newId = `${edge.id}__${count}`;
-        seen.set(edge.id, count + 1);
-        changed = true;
-        console.warn('🔁 Renaming duplicate edge id:', edge.id, '→', newId, edge);
-        return { ...edge, id: newId };
-      });
-
-      if (changed) {
-        setEdges(fixedEdges);
-      }
+      const fixedEdges = dedupeEdgeIds(edges);
+      if (fixedEdges) setEdges(fixedEdges);
     }, [edges, setEdges]);
 
-    // Helper to calculate repulsive forces between nodes
-    const calculateRepulsiveForces = useCallback((
-      componentNodes: string[],
-      positions: Map<string, { x: number; y: number }>,
-      forces: Map<string, { x: number; y: number }>
+    // ── Edge interaction ──────────────────────────────────────────────────────
+
+    const updateEdgeControlPoint = useCallback((
+      edgeId: string,
+      controlPoint: { x: number; y: number } | null,
     ) => {
-      for (let i = 0; i < componentNodes.length; i++) {
-        for (let j = i + 1; j < componentNodes.length; j++) {
-          const nodeA = componentNodes[i];
-          const nodeB = componentNodes[j];
-          const posA = positions.get(nodeA)!;
-          const posB = positions.get(nodeB)!;
-
-          const dx = posB.x - posA.x;
-          const dy = posB.y - posA.y;
-          const distance = Math.hypot(dx, dy) || 1;
-
-          const force = LAYOUT_CONFIG.REPULSION_STRENGTH / (distance * distance);
-          const fx = (dx / distance) * force;
-          const fy = (dy / distance) * force;
-
-          const forceA = forces.get(nodeA)!;
-          const forceB = forces.get(nodeB)!;
-          forceA.x -= fx;
-          forceA.y -= fy;
-          forceB.x += fx;
-          forceB.y += fy;
-        }
-      }
-    }, []);
-
-    // Helper to calculate attractive forces for connected nodes
-    const calculateAttractiveForces = useCallback((
-      componentNodes: string[],
-      positions: Map<string, { x: number; y: number }>,
-      forces: Map<string, { x: number; y: number }>,
-      adjacencyMap: Map<string, Set<string>>,
-      idealEdgeLength: number
-    ) => {
-      componentNodes.forEach(nodeId => {
-        const neighbors = adjacencyMap.get(nodeId) || new Set();
-        neighbors.forEach(neighborId => {
-          if (!componentNodes.includes(neighborId)) return;
-
-          const posA = positions.get(nodeId)!;
-          const posB = positions.get(neighborId)!;
-
-          const dx = posB.x - posA.x;
-          const dy = posB.y - posA.y;
-          const distance = Math.hypot(dx, dy) || 1;
-
-          const force = LAYOUT_CONFIG.ATTRACTION_STRENGTH * (distance - idealEdgeLength);
-          const fx = (dx / distance) * force;
-          const fy = (dy / distance) * force;
-
-          const forceA = forces.get(nodeId)!;
-          forceA.x += fx;
-          forceA.y += fy;
-        });
-      });
-    }, []);
-
-    // Force-directed layout for a single component
-    const layoutComponent = useCallback((
-      componentNodes: string[],
-      startX: number,
-      startY: number,
-      adjacencyMap: Map<string, Set<string>>
-    ) => {
-      if (componentNodes.length === 1) {
-        return new Map([[componentNodes[0], { x: startX, y: startY }]]);
-      }
-
-      const positions = new Map<string, { x: number; y: number }>();
-      componentNodes.forEach((nodeId, idx) => {
-        const angle = (idx / componentNodes.length) * 2 * Math.PI;
-        const radius = Math.max(200, componentNodes.length * 40);
-        positions.set(nodeId, {
-          x: startX + radius + radius * Math.cos(angle),
-          y: startY + radius + radius * Math.sin(angle)
-        });
-      });
-
-      const idealEdgeLength = LAYOUT_CONFIG.BOX_WIDTH + LAYOUT_CONFIG.MIN_HORIZONTAL_SPACING;
-
-      for (let iter = 0; iter < LAYOUT_CONFIG.ITERATIONS; iter++) {
-        const forces = new Map<string, { x: number; y: number }>();
-        componentNodes.forEach(nodeId => forces.set(nodeId, { x: 0, y: 0 }));
-
-        calculateRepulsiveForces(componentNodes, positions, forces);
-        calculateAttractiveForces(componentNodes, positions, forces, adjacencyMap, idealEdgeLength);
-
-        // Apply forces with damping
-        componentNodes.forEach(nodeId => {
-          const pos = positions.get(nodeId)!;
-          const force = forces.get(nodeId)!;
-          pos.x += force.x * LAYOUT_CONFIG.DAMPING;
-          pos.y += force.y * LAYOUT_CONFIG.DAMPING;
-        });
-      }
-
-      // Normalize positions to start from (startX, startY)
-      let minX = Infinity, minY = Infinity;
-      positions.forEach(pos => {
-        minX = Math.min(minX, pos.x);
-        minY = Math.min(minY, pos.y);
-      });
-
-      positions.forEach(pos => {
-        pos.x = pos.x - minX + startX;
-        pos.y = pos.y - minY + startY;
-      });
-
-      return positions;
-    }, [calculateRepulsiveForces, calculateAttractiveForces]);
-
-    // Build adjacency map from edges
-    const buildAdjacencyMap = useCallback((ecoreNodes: Node[], allEdges: Edge[]) => {
-      const adjacencyMap = new Map<string, Set<string>>();
-      ecoreNodes.forEach(node => adjacencyMap.set(node.id, new Set()));
-
-      allEdges.forEach(edge => {
-        if (edge.type === 'reactions') {
-          adjacencyMap.get(edge.source)?.add(edge.target);
-          adjacencyMap.get(edge.target)?.add(edge.source);
-        }
-      });
-
-      return adjacencyMap;
-    }, []);
-
-    // Find connected components using BFS
-    const findConnectedComponents = useCallback((
-      ecoreNodes: Node[],
-      adjacencyMap: Map<string, Set<string>>
-    ) => {
-      const visited = new Set<string>();
-      const components: string[][] = [];
-      const isolatedNodes: string[] = [];
-
-      // Identify isolated nodes
-      ecoreNodes.forEach(node => {
-        if ((adjacencyMap.get(node.id)?.size || 0) === 0) {
-          isolatedNodes.push(node.id);
-          visited.add(node.id);
-        }
-      });
-
-      // BFS for connected components
-      ecoreNodes.forEach(startNode => {
-        if (visited.has(startNode.id)) return;
-
-        const component: string[] = [];
-        const queue = [startNode.id];
-        visited.add(startNode.id);
-
-        while (queue.length > 0) {
-          const nodeId = queue.shift()!;
-          component.push(nodeId);
-
-          const neighbors = adjacencyMap.get(nodeId);
-          neighbors?.forEach(neighborId => {
-            if (!visited.has(neighborId)) {
-              visited.add(neighborId);
-              queue.push(neighborId);
-            }
-          });
-        }
-
-        if (component.length > 0) {
-          components.push(component);
-        }
-      });
-
-      return { components, isolatedNodes };
-    }, []);
-
-    // Helper to optimize edge handles for a set of nodes
-    const optimizeEdgeHandles = useCallback((targetNodes: Node[], allEdges: Edge[]) => {
-      return allEdges.map(edge => {
-        if (edge.type !== 'reactions') return edge;
-
-        const sourceNode = targetNodes.find(n => n.id === edge.source);
-        const targetNode = targetNodes.find(n => n.id === edge.target);
-
-        if (!sourceNode || !targetNode) return edge;
-
-        const handles = calculateOptimalHandles(sourceNode, targetNode);
-        const cleanSourceHandle = handles.sourceHandle.replace('-source', '').replace('-target', '');
-        const cleanTargetHandle = handles.targetHandle.replace('-target', '').replace('-source', '');
-
-        return {
-          ...edge,
-          sourceHandle: cleanSourceHandle,
-          targetHandle: cleanTargetHandle,
-          data: {
-            ...edge.data,
-            customControlPoint: undefined
-          }
-        };
-      });
-    }, [calculateOptimalHandles]);
-
-    // Advanced auto-layout with force-directed algorithm for optimal positioning
-    const autoLayoutEcoreBoxes = useCallback(() => {
-      const ecoreNodes = nodes.filter(n => n.type === 'ecoreFile');
-      if (ecoreNodes.length === 0) return;
-
-      console.log('📐 Auto-layouting', ecoreNodes.length, 'ecore boxes with', edges.length, 'edges');
-
-      const adjacencyMap = buildAdjacencyMap(ecoreNodes, edges);
-      const { components, isolatedNodes } = findConnectedComponents(ecoreNodes, adjacencyMap);
-
-      console.log(`📊 Layout analysis: ${components.length} components, ${isolatedNodes.length} isolated nodes`);
-
-      // Layout each component
-      const positionMap = new Map<string, { x: number; y: number }>();
-      let currentY = LAYOUT_CONFIG.START_Y;
-
-      components.forEach(component => {
-        const componentPositions = layoutComponent(component, LAYOUT_CONFIG.START_X, currentY, adjacencyMap);
-        componentPositions.forEach((pos, nodeId) => positionMap.set(nodeId, pos));
-
-        let maxY = 0;
-        componentPositions.forEach(pos => maxY = Math.max(maxY, pos.y));
-        currentY = maxY + LAYOUT_CONFIG.BOX_HEIGHT + LAYOUT_CONFIG.MIN_VERTICAL_SPACING * 2;
-      });
-
-      // Layout isolated nodes in a compact grid
-      if (isolatedNodes.length > 0) {
-        const itemsPerRow = Math.ceil(Math.sqrt(isolatedNodes.length * 2));
-        isolatedNodes.forEach((nodeId, idx) => {
-          const row = Math.floor(idx / itemsPerRow);
-          const col = idx % itemsPerRow;
-          positionMap.set(nodeId, {
-            x: LAYOUT_CONFIG.START_X + col * (LAYOUT_CONFIG.BOX_WIDTH + LAYOUT_CONFIG.MIN_HORIZONTAL_SPACING),
-            y: currentY + row * (LAYOUT_CONFIG.BOX_HEIGHT + LAYOUT_CONFIG.MIN_VERTICAL_SPACING)
-          });
-        });
-      }
-
-      // Apply positions to nodes
-      const updatedNodes = nodes.map(node => {
-        if (node.type !== 'ecoreFile') return node;
-        const position = positionMap.get(node.id);
-        return position ? { ...node, position } : node;
-      });
-
-      setNodes(updatedNodes);
-
-      // Optimize edge handles after layout, then center view on the circle.
-      // pendingFitToCircle.current = true signals the useEffect([circle]) below to call
-      // fitViewToCircle() once React has committed the new circle state.
-      // fitViewToCircle now reads reactFlowInstanceRef (a ref, always current) so there
-      // are no stale-closure issues regardless of when the effect fires.
-      setTimeout(() => {
-        const optimizedEdges = optimizeEdgeHandles(updatedNodes, edges);
-        setEdges(optimizedEdges);
-
-        // Recompute circle center from final node positions
-        const ecoreUpdated = updatedNodes.filter(n => n.type === 'ecoreFile');
-        const newCircle = computeInitialCircle(ecoreUpdated);
-        pendingFitToCircle.current = true;   // signal the useEffect to fit after commit
-        setCircle(newCircle);
-      }, 50);
-    }, [nodes, edges, setNodes, setEdges, buildAdjacencyMap, findConnectedComponents, layoutComponent, optimizeEdgeHandles, setCircle]);
-
-    // Listen for auto-layout trigger
-    useEffect(() => {
-      const handleAutoLayout = () => {
-        console.log('📐 Auto-layout triggered via event');
-        autoLayoutEcoreBoxes();
-      };
-      const handleFitEcore = () => {
-        fitEcoreWorkspace();
-      };
-
-      globalThis.addEventListener('vitruv.autoLayoutWorkspace', handleAutoLayout as EventListener);
-      globalThis.addEventListener('vitruv.fitEcoreWorkspace', handleFitEcore as EventListener);
-
-      return () => {
-        globalThis.removeEventListener('vitruv.autoLayoutWorkspace', handleAutoLayout as EventListener);
-        globalThis.removeEventListener('vitruv.fitEcoreWorkspace', handleFitEcore as EventListener);
-      };
-    }, [autoLayoutEcoreBoxes, fitEcoreWorkspace]);
-
-    // Listen for edge clicks to toggle selection
-    useEffect(() => {
-      const updateEdgeSelection = (edges: Edge[], edgeId: string, currentlySelected: boolean) =>
-        edges.map(edge => ({ ...edge, selected: edge.id === edgeId ? !currentlySelected : false }));
-
-      const deselectAllNodes = (nodes: Node[]) =>
-        nodes.map(node => ({ ...node, selected: false }));
-
-      const handleEdgeClick = (e: Event) => {
-        const { edgeId, currentlySelected } = (e as CustomEvent<{ edgeId: string; currentlySelected: boolean }>).detail;
-        setEdges(prev => updateEdgeSelection(prev, edgeId, currentlySelected));
-        setNodes(prev => deselectAllNodes(prev));
-        setSelectedFileId(null);
-      };
-
-      globalThis.addEventListener('edge-clicked', handleEdgeClick as EventListener);
-
-      return () => {
-        globalThis.removeEventListener('edge-clicked', handleEdgeClick as EventListener);
-      };
-    }, [setEdges, setNodes]);
-
-    // Helper to update a single edge's control point
-    const updateEdgeControlPoint = useCallback((edgeId: string, controlPoint: { x: number; y: number } | null) => {
       setEdges(prevEdges => prevEdges.map(edge =>
         edge.id === edgeId
           ? { ...edge, data: { ...edge.data, customControlPoint: controlPoint } }
-          : edge
+          : edge,
       ));
     }, [setEdges]);
 
-    // Listen for UML edge control point dragging
-    useEffect(() => {
-      const handleControlDrag = (e: Event) => {
-        const customEvent = e as CustomEvent<{ edgeId: string; x: number; y: number }>;
-        const { edgeId, x, y } = customEvent.detail;
+    useEdgeControlPointEvents({ reactFlowInstance, updateEdgeControlPoint });
+    useEdgeSelectionEvents({ setEdges, setNodes, setSelectedFileId });
 
-        if (!reactFlowInstance) return;
+    const handleEdgeHandleChange = useCallback((
+      edgeId: string,
+      newSourceHandle: string,
+      newTargetHandle: string,
+    ) => {
+      if (readOnly) return;
+      setEdges(prevEdges => prevEdges.map(edge =>
+        edge.id === edgeId
+          ? {
+            ...edge,
+            sourceHandle: newSourceHandle,
+            targetHandle: newTargetHandle,
+            data: { ...edge.data, customControlPoint: undefined },
+          }
+          : edge,
+      ));
+    }, [setEdges, readOnly]);
 
-        const flowPosition = reactFlowInstance.screenToFlowPosition({ x, y });
-        updateEdgeControlPoint(edgeId, flowPosition);
-      };
+    const handleEdgeReorderRequest = useCallback((
+      edgeId: string,
+      controlPoint: { x: number; y: number },
+    ) => {
+      if (readOnly) return;
+      setEdges(prevEdges => computeParallelEdgeReorder(prevEdges, { edgeId, controlPoint, nodes }));
+    }, [setEdges, nodes, readOnly]);
 
-      const handleControlDrop = (e: Event) => {
-        const customEvent = e as CustomEvent<{ edgeId: string; point: { x: number; y: number } | null }>;
-        const { edgeId, point } = customEvent.detail;
-        updateEdgeControlPoint(edgeId, point);
-      };
+    const handleMergeGroupHover = useCallback((groupId: string | null) => {
+      setHoveredMergeGroup(groupId);
+    }, []);
 
-      globalThis.addEventListener('uml-edge-control-drag', handleControlDrag as EventListener);
-      globalThis.addEventListener('uml-edge-control-drop', handleControlDrop as EventListener);
+    const handleEdgeDragStart = useCallback((_edgeId: string) => {}, []);
 
-      return () => {
-        globalThis.removeEventListener('uml-edge-control-drag', handleControlDrag as EventListener);
-        globalThis.removeEventListener('uml-edge-control-drop', handleControlDrop as EventListener);
-      };
-    }, [reactFlowInstance, updateEdgeControlPoint]);
+    const handleEdgeDrag = useCallback((_edgeId: string, _point: { x: number; y: number }) => {}, []);
+
+    const handleEdgeDragEnd = useCallback((edgeId: string, point: { x: number; y: number }) => {
+      updateEdgeControlPoint(edgeId, point);
+    }, [updateEdgeControlPoint]);
+
+    // ── Imperative handle ─────────────────────────────────────────────────────
 
     useImperativeHandle(ref, () => ({
       handleToolClick,
@@ -2135,12 +1099,14 @@ export const FlowCanvas = forwardRef<{
       canUndo,
       canRedo,
       getReactionEdges,
-      getWorkspaceSnapshot: buildWorkspaceSnapshot,
+      getWorkspaceSnapshot,
       autoLayoutEcoreBoxes,
       fitUmlView,
       openSelectedReactionEditor,
       establishBaseline,
-    }), [handleToolClick, loadDiagramData, nodes, edges, addEcoreFile, updateEcoreFileData, resetExpandedFile, undo, redo, canUndo, canRedo, getReactionEdges, buildWorkspaceSnapshot, autoLayoutEcoreBoxes, fitUmlView, openSelectedReactionEditor, establishBaseline]);
+    }), [handleToolClick, loadDiagramData, nodes, edges, addEcoreFile, updateEcoreFileData, resetExpandedFile, undo, redo, canUndo, canRedo, getReactionEdges, getWorkspaceSnapshot, autoLayoutEcoreBoxes, fitUmlView, openSelectedReactionEditor, establishBaseline]);
+
+    // ── Render mapping ────────────────────────────────────────────────────────
 
     const mappedNodes = nodes.map(node => {
       if (node.type === 'editable') {
@@ -2169,223 +1135,13 @@ export const FlowCanvas = forwardRef<{
       return node;
     });
 
-    const uniqueEdges = useMemo(() => {
-      const idCount = new Map<string, number>();
+    const uniqueEdges = useMemo(() => withUniqueEdgeIds(edges), [edges]);
 
-      return edges.map((e, index) => {
-        const baseId = e.id || `edge-${index}`;
-        const count = idCount.get(baseId) ?? 0;
-        idCount.set(baseId, count + 1);
+    const umlMergeData = useMemo(
+      () => computeUmlMergeData(uniqueEdges, nodes),
+      [uniqueEdges, nodes],
+    );
 
-        if (count === 0) {
-          return { ...e, id: baseId };
-        }
-
-        const newId = `${baseId}-dup-${count}`;
-        console.warn('🔁 Renaming duplicate edge id:', baseId, '→', newId, e);
-        return { ...e, id: newId };
-      });
-    }, [edges]);
-
-    const handleEdgeHandleChange = useCallback((edgeId: string, newSourceHandle: string, newTargetHandle: string) => {
-      if (readOnly) return;
-      console.log(`🔄 Changing handles for edge ${edgeId}:`, { newSource: newSourceHandle, newTarget: newTargetHandle });
-      setEdges(prevEdges => prevEdges.map(edge =>
-        edge.id === edgeId
-          ? { ...edge, sourceHandle: newSourceHandle, targetHandle: newTargetHandle, data: { ...edge.data, customControlPoint: undefined } }
-          : edge
-      ));
-    }, [setEdges, readOnly]);
-
-    // Helper to calculate default control point for an edge
-    const calculateDefaultControlPoint = useCallback((e: Edge) => {
-      const src = nodes.find(n => n.id === e.source);
-      const tgt = nodes.find(n => n.id === e.target);
-      if (!src || !tgt) return { x: 0, y: 0 };
-      return {
-        x: (src.position.x + tgt.position.x + NODE_DIMENSIONS.width) / 2,
-        y: (src.position.y + tgt.position.y + NODE_DIMENSIONS.height) / 2
-      };
-    }, [nodes]);
-
-    // Helper to create edge sort comparator for reordering
-    const createEdgeReorderComparator = useCallback((
-      targetEdgeId: string,
-      controlPoint: { x: number; y: number },
-      handle: string
-    ) => {
-      return (a: Edge, b: Edge) => {
-        const aPos = a.id === targetEdgeId ? controlPoint : (a.data?.customControlPoint || calculateDefaultControlPoint(a));
-        const bPos = b.id === targetEdgeId ? controlPoint : (b.data?.customControlPoint || calculateDefaultControlPoint(b));
-        return (handle === 'top' || handle === 'bottom') ? aPos.x - bPos.x : aPos.y - bPos.y;
-      };
-    }, [calculateDefaultControlPoint]);
-
-    // Helper to apply reordering data to edges
-    const applyEdgeReorderData = useCallback((
-      prevEdges: Edge[],
-      reorderedSourceEdges: Edge[],
-      reorderedTargetEdges: Edge[]
-    ) => {
-      const sourceIndexById = new Map(
-        reorderedSourceEdges.map((re, index) => [re.id, index] as const),
-      );
-      const targetIndexById = new Map(
-        reorderedTargetEdges.map((re, index) => [re.id, index] as const),
-      );
-
-      return prevEdges.map(e => {
-        const sourceIndex = sourceIndexById.get(e.id);
-        const targetIndex = targetIndexById.get(e.id);
-        const inSource = sourceIndex !== undefined;
-        const inTarget = targetIndex !== undefined;
-
-        if (inSource || inTarget) {
-          return {
-            ...e,
-            data: {
-              ...e.data,
-              sourceParallelIndex: inSource ? sourceIndex : e.data?.sourceParallelIndex,
-              sourceParallelCount: inSource ? reorderedSourceEdges.length : e.data?.sourceParallelCount,
-              targetParallelIndex: inTarget ? targetIndex : e.data?.targetParallelIndex,
-              targetParallelCount: inTarget ? reorderedTargetEdges.length : e.data?.targetParallelCount,
-            }
-          };
-        }
-        return e;
-      });
-    }, []);
-
-    const performEdgeReorder = useCallback((edgeId: string, controlPoint: { x: number; y: number }) => {
-      const edge = edges.find(e => e.id === edgeId);
-      if (edge?.type !== 'reactions') return;
-
-      const sourceNode = nodes.find(n => n.id === edge.source);
-      const targetNode = nodes.find(n => n.id === edge.target);
-      if (!sourceNode || !targetNode) return;
-
-      setEdges(prevEdges => {
-        const sameSourceEdges = prevEdges.filter(e =>
-          e.type === 'reactions' && e.source === edge.source && e.sourceHandle === edge.sourceHandle
-        );
-        const sameTargetEdges = prevEdges.filter(e =>
-          e.type === 'reactions' && e.target === edge.target && e.targetHandle === edge.targetHandle
-        );
-
-        const sourceComparator = createEdgeReorderComparator(edgeId, controlPoint, edge.sourceHandle!);
-        const targetComparator = createEdgeReorderComparator(edgeId, controlPoint, edge.targetHandle!);
-
-        const reorderedSourceEdges = sameSourceEdges.length > 1 ? [...sameSourceEdges].sort(sourceComparator) : sameSourceEdges;
-        const reorderedTargetEdges = sameTargetEdges.length > 1 ? [...sameTargetEdges].sort(targetComparator) : sameTargetEdges;
-
-        return applyEdgeReorderData(prevEdges, reorderedSourceEdges, reorderedTargetEdges);
-      });
-    }, [edges, nodes, setEdges, createEdgeReorderComparator, applyEdgeReorderData]);
-
-
-
-    const handleEdgeReorderRequest = useCallback((edgeId: string, controlPoint: { x: number; y: number }) => {
-      if (readOnly) return;
-      performEdgeReorder(edgeId, controlPoint);
-    }, [performEdgeReorder, readOnly]);
-
-    // Helper to calculate average source position for merge point
-    const calculateAverageSourcePosition = useCallback((eligibleEdges: Edge[]) => {
-      let sumX = 0, sumY = 0, count = 0;
-      eligibleEdges.forEach(edge => {
-        const sourceNode = nodes.find(n => n.id === edge.source);
-        if (sourceNode) {
-          sumX += sourceNode.position.x + NODE_DIMENSIONS.width / 2;
-          sumY += sourceNode.position.y + NODE_DIMENSIONS.height / 2;
-          count++;
-        }
-      });
-      return count > 0 ? { x: sumX / count, y: sumY / count } : { x: 0, y: 0 };
-    }, [nodes]);
-
-    // Helper to calculate merge point between source average and target
-    const calculateMergePoint = useCallback((avgSource: { x: number; y: number }, targetNode: Node) => {
-      const targetCenterX = targetNode.position.x + NODE_DIMENSIONS.width / 2;
-      const targetCenterY = targetNode.position.y + NODE_DIMENSIONS.height / 2;
-
-      // Place merge point vertically under/above the target center so
-      // the last segment into the class box is a straight line into
-      // the middle (no diagonal hit on the left/right side).
-      return {
-        x: targetCenterX,
-        y: avgSource.y + (targetCenterY - avgSource.y) * 0.4,
-      };
-    }, []);
-
-    // Calculate merge points for UML inheritance edges with same target.
-    // We keep merge visualization ONLY for inheritance (like multiple
-    // subclasses pointing to the same superclass), not for other UML
-    // relationships. This gives a clean "fan-in" into the superclass
-    // while keeping compositions and associations as simple lines.
-    const umlMergeData = useMemo(() => {
-      const mergePointsMap = new Map<string, { x: number; y: number; mergeGroupId: string }>();
-      const firstInGroupMap = new Map<string, string>();
-      const mergeGroupSourceNodesMap = new Map<string, string[]>();
-      const hasRelationshipType = (data: unknown): data is { relationshipType?: string } =>
-        typeof data === 'object' && data !== null && 'relationshipType' in data;
-
-      // Consider only UML inheritance edges for merging
-      const umlInheritanceEdges = uniqueEdges.filter(
-        (e) => e.type === 'uml' && hasRelationshipType(e.data) && e.data.relationshipType === 'inheritance'
-      );
-
-      if (umlInheritanceEdges.length === 0) {
-        return { mergePointsMap, firstInGroupMap, mergeGroupSourceNodesMap };
-      }
-
-      // Count inheritance edges per source node
-      const edgesPerSource = new Map<string, number>();
-      umlInheritanceEdges.forEach((edge) => {
-        edgesPerSource.set(edge.source, (edgesPerSource.get(edge.source) || 0) + 1);
-      });
-
-      // Group inheritance edges by target (superclass)
-      const edgesByTarget = new Map<string, Edge[]>();
-      umlInheritanceEdges.forEach((edge) => {
-        const existing = edgesByTarget.get(edge.target) || [];
-        existing.push(edge);
-        edgesByTarget.set(edge.target, existing);
-      });
-
-      // For each superclass, create one merge point for eligible subclasses
-      edgesByTarget.forEach((edgesGroup, targetId) => {
-        if (edgesGroup.length < 2) return;
-
-        // Only merge subclasses that connect to this superclass once
-        const eligibleEdges = edgesGroup.filter(
-          (edge) => (edgesPerSource.get(edge.source) || 0) === 1
-        );
-        if (eligibleEdges.length < 2) return;
-
-        eligibleEdges.sort((a, b) => a.source.localeCompare(b.source));
-
-        const targetNode = nodes.find((n) => n.id === targetId);
-        if (!targetNode) return;
-
-        const avgSourcePos = calculateAverageSourcePosition(eligibleEdges);
-        const mergePoint = calculateMergePoint(avgSourcePos, targetNode);
-        const mergeGroupId = `merge-${targetId}`;
-
-        mergeGroupSourceNodesMap.set(
-          mergeGroupId,
-          eligibleEdges.map((e) => e.source)
-        );
-        eligibleEdges.forEach((edge) => {
-          mergePointsMap.set(edge.id, { ...mergePoint, mergeGroupId });
-        });
-
-        firstInGroupMap.set(mergeGroupId, eligibleEdges[0].id);
-      });
-
-      return { mergePointsMap, firstInGroupMap, mergeGroupSourceNodesMap };
-    }, [uniqueEdges, nodes, calculateAverageSourcePosition, calculateMergePoint]);
-
-    // Helper to get edge distribution data
     const resolveEdgeDistribution = useCallback(
       (edge: Edge) => getEdgeDistributionData(edge, edgeDistributionMap),
       [edgeDistributionMap],
@@ -2395,21 +1151,6 @@ export const FlowCanvas = forwardRef<{
       (edge: Edge) => getUmlMergeInfo(edge, umlMergeData),
       [umlMergeData],
     );
-
-    // Callbacks for reaction edges (defined once, not per-edge)
-    const handleMergeGroupHover = useCallback((groupId: string | null) => {
-      setHoveredMergeGroup(groupId);
-    }, []);
-
-    const handleEdgeDragStart = useCallback((_edgeId: string) => {
-    }, []);
-
-    const handleEdgeDrag = useCallback((_edgeId: string, _point: { x: number; y: number }) => {
-    }, []);
-
-    const handleEdgeDragEnd = useCallback((edgeId: string, point: { x: number; y: number }) => {
-      updateEdgeControlPoint(edgeId, point);
-    }, [updateEdgeControlPoint]);
 
     const edgeMapContext = useMemo(() => ({
       readOnly,
@@ -2445,13 +1186,15 @@ export const FlowCanvas = forwardRef<{
     );
 
     const ecoreNodes = nodes.filter(n => n.type === 'ecoreFile');
-
-    const connectionLinePositions = computeConnectionLinePositions(
-      connectionDragState,
-      reactFlowInstance,
-    );
+    const connectionLinePositions = computeConnectionLinePositions(connectionDragState, reactFlowInstance);
     const umlViewActive = !!umlModalOpen;
-    const reactionModeCursor = getReactionModeCursor(addReactionMode, reactionSourceId);
+    const interactionsAllowed = umlViewActive || readOnly || isInteractive;
+
+    const handleSelectCanvasMode = useCallback((mode: CanvasMode) => {
+      setActiveCanvasMode(mode);
+      onCanvasModeChange?.(mode);
+      if (mode !== 'views') setCircleSelected(false);
+    }, [onCanvasModeChange]);
 
     return (
       <div
@@ -2462,7 +1205,7 @@ export const FlowCanvas = forwardRef<{
           position: 'relative',
           border: isDragOver ? '3px dashed #3498db' : 'none',
           transition: 'border 0.2s ease',
-          cursor: reactionModeCursor,
+          cursor: getReactionModeCursor(addReactionMode, reactionSourceId),
         }}
       >
         <ReactFlow
@@ -2476,7 +1219,7 @@ export const FlowCanvas = forwardRef<{
           onDragLeave={handleDragLeave}
           nodeTypes={nodeTypes}
           edgeTypes={edgeTypes}
-          onInit={(instance) => {
+          onInit={instance => {
             setReactFlowInstance(instance);
             reactFlowInstanceRef.current = instance;
             setViewport(instance.getViewport());
@@ -2484,13 +1227,13 @@ export const FlowCanvas = forwardRef<{
           onMove={(_event, vp) => setViewport(vp)}
           nodesDraggable={umlViewActive || (editable && !connectionDragState?.isActive)}
           nodesConnectable={!umlViewActive && editable}
-          elementsSelectable={umlViewActive || readOnly || isInteractive}
+          elementsSelectable={interactionsAllowed}
           edgesUpdatable={false}
-          edgesFocusable={umlViewActive || readOnly || isInteractive}
-          panOnDrag={umlViewActive || readOnly || isInteractive}
-          panOnScroll={umlViewActive || readOnly || isInteractive}
-          zoomOnScroll={umlViewActive || readOnly || isInteractive}
-          zoomOnPinch={umlViewActive || readOnly || isInteractive}
+          edgesFocusable={interactionsAllowed}
+          panOnDrag={interactionsAllowed}
+          panOnScroll={interactionsAllowed}
+          zoomOnScroll={interactionsAllowed}
+          zoomOnPinch={interactionsAllowed}
           minZoom={umlViewActive ? 0.45 : 0.05}
           maxZoom={umlViewActive ? 2.5 : 2}
           translateExtent={[[-12000, -12000], [12000, 12000]]}
@@ -2501,11 +1244,15 @@ export const FlowCanvas = forwardRef<{
             setCircleSelected(false);
             setNodes(nds => nds.map(n => ({ ...n, selected: false })));
             setEdges(eds => eds.map(e => ({ ...e, selected: false })));
-            if (addReactionMode) { setReactionSourceId(null); onReactionModeEnd?.(); }
+            if (addReactionMode) {
+              setReactionSourceId(null);
+              onReactionModeEnd?.();
+            }
           }}
         >
           <Background />
         </ReactFlow>
+
         {circleVisible && !umlModalOpen && (
           <CircleOverlay
             circle={circle}
@@ -2535,7 +1282,7 @@ export const FlowCanvas = forwardRef<{
           />
         )}
 
-        <CustomMinimap
+        <CanvasMinimap
           nodes={nodes}
           edges={edges}
           circle={circleVisible ? circle : undefined}
@@ -2546,123 +1293,23 @@ export const FlowCanvas = forwardRef<{
           height={204}
         />
 
-        {/* ── Mode toggle + project tabs (stacked) ── */}
-        <div
-          style={{
-            position: 'absolute',
-            top: 14,
-            left: '50%',
-            transform: 'translateX(-50%)',
-            zIndex: 31,
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            gap: 4,
-            fontFamily: 'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              background: '#ffffff',
-              borderRadius: 8,
-              boxShadow: '0 4px 16px rgba(0,0,0,0.13), 0 0 0 1px rgba(0,0,0,0.07)',
-              height: 44,
-              padding: '0 4px',
-              gap: 2,
-            }}
-          >
-            {([
-              { label: 'Modeling', mode: 'modeling' as CanvasMode, icon: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="9" y1="21" x2="9" y2="9"/></svg> },
-              ...(readOnly ? [] : [{ label: 'Constraints', mode: 'constraints' as CanvasMode, icon: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg> }]),
-              { label: 'Views', mode: 'views' as CanvasMode, icon: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="9"/><line x1="12" y1="3" x2="12" y2="21"/><line x1="3" y1="12" x2="21" y2="12"/></svg> },
-            ]).map(({ label, mode, icon }) => (
-              <button type="button"
-                key={label}
-                onClick={() => {
-                  setActiveCanvasMode(mode);
-                  onCanvasModeChange?.(mode);
-                  if (mode !== 'views' && circleSelected) {
-                    setCircleSelected(false);
-                  }
-                }}
-                style={{
-                  display: 'flex', alignItems: 'center', gap: 6,
-                  height: 34,
-                  padding: '0 14px',
-                  border: activeCanvasMode === mode ? '1px solid #049484' : '1px solid transparent',
-                  borderRadius: 6,
-                  background: activeCanvasMode === mode ? '#049484' : 'transparent',
-                  color: activeCanvasMode === mode ? '#ffffff' : '#64748b',
-                  fontSize: 12,
-                  fontWeight: 600,
-                  cursor: 'pointer',
-                  transition: 'all 0.15s',
-                  whiteSpace: 'nowrap',
-                  fontFamily: 'inherit',
-                }}
-                onMouseEnter={e => {
-                  if (activeCanvasMode === mode) return;
-                  e.currentTarget.style.background = '#f1f5f9';
-                  e.currentTarget.style.color = '#1e293b';
-                }}
-                onMouseLeave={e => {
-                  if (activeCanvasMode === mode) return;
-                  e.currentTarget.style.background = 'transparent';
-                  e.currentTarget.style.color = '#64748b';
-                }}
-              >
-                {icon}
-                {label}
-              </button>
-            ))}
-          </div>
-          {projectTabsBelowModeToggle}
-        </div>
+        <CanvasModeToggle
+          activeCanvasMode={activeCanvasMode}
+          onSelectMode={handleSelectCanvasMode}
+          readOnly={readOnly}
+          projectTabsBelowModeToggle={projectTabsBelowModeToggle}
+        />
 
-        <div
-          style={{
-            position: 'absolute',
-            right: 16,
-            bottom: 16,
-            zIndex: 31,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 20
-          }}
-        >
-          {createControlButton(() => reactFlowInstance?.zoomIn?.(), 'Zoom in', '+')}
-          {createControlButton(() => reactFlowInstance?.zoomOut?.(), 'Zoom out', '–')}
-          {createControlButton(() => fitViewToCircle(circle), 'Fit view', '⛶')}
-          {!readOnly && createControlButton(
-            () => setIsInteractive(prev => !prev),
-            isInteractive ? 'Lock interactions' : 'Unlock interactions',
-            isInteractive ? '🔓' : '🔒'
-          )}
-        </div>
+        <CanvasControls
+          onZoomIn={() => reactFlowInstance?.zoomIn?.()}
+          onZoomOut={() => reactFlowInstance?.zoomOut?.()}
+          onFitView={() => fitViewToCircle(circle)}
+          onToggleInteractive={() => setIsInteractive(prev => !prev)}
+          isInteractive={isInteractive}
+          readOnly={readOnly}
+        />
 
-        {isDragOver && (
-          <div style={{
-            position: 'absolute',
-            top: '50%',
-            left: '50%',
-            transform: 'translate(-50%, -50%)',
-            background: 'rgba(52, 152, 219, 0.95)',
-            color: 'white',
-            padding: '24px 48px',
-            borderRadius: '12px',
-            fontSize: '20px',
-            fontWeight: 'bold',
-            zIndex: 1000,
-            pointerEvents: 'none',
-            boxShadow: '0 8px 32px rgba(52, 152, 219, 0.3)',
-            border: '2px solid rgba(255, 255, 255, 0.3)',
-            backdropFilter: 'blur(10px)'
-          }}>
-            Drop files here
-          </div>
-        )}
+        {isDragOver && <CanvasDropOverlay />}
 
         {codeEditorState && (
           <ReactionEditorModal
@@ -2696,44 +1343,12 @@ export const FlowCanvas = forwardRef<{
           }}
         />
 
-        {detailModel && ReactDOM.createPortal(
-          <>
-            <div
-              aria-hidden="true"
-              data-model-detail-dismiss
-              style={{
-                position: 'fixed',
-                inset: 0,
-                zIndex: 10000,
-                background: 'rgba(0, 0, 0, 0.5)',
-                backdropFilter: 'blur(8px)',
-                WebkitBackdropFilter: 'blur(8px)',
-                pointerEvents: 'none',
-              }}
-            />
-            <div
-              style={{
-                position: 'fixed',
-                inset: 0,
-                zIndex: 10001,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                pointerEvents: 'none',
-              }}
-            >
-              <div style={{ pointerEvents: 'auto' }} data-model-detail-modal>
-                <ModelDetailModal
-                  model={detailModel.model}
-                  ecoreContent={detailModel.ecoreContent}
-                  onClose={() => setDetailModel(null)}
-                  onUpdated={() => setDetailModel(null)}
-                  embedded
-                />
-              </div>
-            </div>
-          </>,
-          document.body,
+        {detailModel && (
+          <ModelDetailOverlay
+            model={detailModel.model}
+            ecoreContent={detailModel.ecoreContent}
+            onClose={handleCloseDetails}
+          />
         )}
       </div>
     );

--- a/src/components/flow/FlowCanvas.tsx
+++ b/src/components/flow/FlowCanvas.tsx
@@ -140,8 +140,6 @@ export interface FlowCanvasHandle {
 }
 
 interface FlowCanvasProps {
-  onDeploy?: (nodes: Node[], edges: Edge[]) => void;
-  onToolClick?: (toolType: string, toolName: string, diagramType?: string) => void;
   onDiagramChange?: (nodes: Node[], edges: Edge[]) => void;
   onEcoreFileSelect?: (fileName: string) => void;
   onEcoreFileExpand?: (fileName: string, fileContent: string, meta?: {

--- a/src/components/flow/canvas/CanvasControls.tsx
+++ b/src/components/flow/canvas/CanvasControls.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+interface CanvasControlButtonProps {
+  onClick: () => void;
+  title: string;
+  icon: React.ReactNode;
+}
+
+export const CanvasControlButton: React.FC<CanvasControlButtonProps> = ({ onClick, title, icon }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    style={{
+      width: 36,
+      height: 36,
+      borderRadius: 10,
+      border: '1px solid #e5e7eb',
+      background: '#ffffff',
+      cursor: 'pointer',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      fontSize: 18,
+      transition: 'all 0.2s ease',
+      boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+    }}
+    title={title}
+    onMouseEnter={e => (e.currentTarget.style.background = '#f0f0f0')}
+    onMouseLeave={e => (e.currentTarget.style.background = '#ffffff')}
+  >
+    {icon}
+  </button>
+);
+
+export interface CanvasControlsProps {
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onFitView: () => void;
+  onToggleInteractive: () => void;
+  isInteractive: boolean;
+  readOnly: boolean;
+}
+
+/** Zoom / fit / lock stack anchored to the bottom-right of the canvas. */
+export const CanvasControls: React.FC<CanvasControlsProps> = ({
+  onZoomIn,
+  onZoomOut,
+  onFitView,
+  onToggleInteractive,
+  isInteractive,
+  readOnly,
+}) => (
+  <div
+    style={{
+      position: 'absolute',
+      right: 16,
+      bottom: 16,
+      zIndex: 31,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 20,
+    }}
+  >
+    <CanvasControlButton onClick={onZoomIn} title="Zoom in" icon="+" />
+    <CanvasControlButton onClick={onZoomOut} title="Zoom out" icon="–" />
+    <CanvasControlButton onClick={onFitView} title="Fit view" icon="⛶" />
+    {!readOnly && (
+      <CanvasControlButton
+        onClick={onToggleInteractive}
+        title={isInteractive ? 'Lock interactions' : 'Unlock interactions'}
+        icon={isInteractive ? '🔓' : '🔒'}
+      />
+    )}
+  </div>
+);

--- a/src/components/flow/canvas/CanvasDropOverlay.tsx
+++ b/src/components/flow/canvas/CanvasDropOverlay.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+/** Full-canvas hint shown while files are dragged over the workspace. */
+export const CanvasDropOverlay: React.FC = () => (
+  <div style={{
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    background: 'rgba(52, 152, 219, 0.95)',
+    color: 'white',
+    padding: '24px 48px',
+    borderRadius: '12px',
+    fontSize: '20px',
+    fontWeight: 'bold',
+    zIndex: 1000,
+    pointerEvents: 'none',
+    boxShadow: '0 8px 32px rgba(52, 152, 219, 0.3)',
+    border: '2px solid rgba(255, 255, 255, 0.3)',
+    backdropFilter: 'blur(10px)',
+  }}>
+    Drop files here
+  </div>
+);

--- a/src/components/flow/canvas/CanvasMinimap.tsx
+++ b/src/components/flow/canvas/CanvasMinimap.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { Edge, Node } from 'reactflow';
+import { Circle } from '../../../hooks/useCircleContainment';
+import { edgeIndicatorPos } from '../../../utils/minimapGeometry';
+import { cardColor, darken } from '../EcoreFileBox';
+import { ECORE_FILE_BOX_SIZE } from '../flowCanvasConstants';
+
+const MINI_NODE_W = ECORE_FILE_BOX_SIZE.width;
+const MINI_NODE_H = ECORE_FILE_BOX_SIZE.height;
+
+export interface CanvasMinimapProps {
+  nodes: Node[];
+  edges: Edge[];
+  circle?: Circle;
+  viewport: { x: number; y: number; zoom: number };
+  containerW: number;
+  containerH: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Minimap that tracks the viewport centre rather than the whole graph, so it
+ * always shows what the user is looking at, scaled down. Items outside the
+ * visible slice are represented by coloured dots on the border.
+ */
+export const CanvasMinimap: React.FC<CanvasMinimapProps> = ({
+  nodes, edges, circle, viewport, containerW, containerH, width, height,
+}) => {
+  const ecoreNodes = nodes.filter(n => n.type === 'ecoreFile');
+
+  // Viewport centre in flow coordinates
+  const flowCX = (-viewport.x + containerW / 2) / viewport.zoom;
+  const flowCY = (-viewport.y + containerH / 2) / viewport.zoom;
+  const visW = containerW / viewport.zoom;
+  const visH = containerH / viewport.zoom;
+
+  // Scale so the current viewport fills ~80% of the minimap, clamped so extreme
+  // zoom levels stay legible.
+  const mmScale = Math.max(0.03, Math.min(2, Math.min(
+    (width * 0.8) / Math.max(visW, 50),
+    (height * 0.8) / Math.max(visH, 50),
+  )));
+
+  const toX = (fx: number) => (fx - flowCX) * mmScale + width / 2;
+  const toY = (fy: number) => (fy - flowCY) * mmScale + height / 2;
+
+  const nodeMap = new Map(ecoreNodes.map(n => [n.id, n]));
+
+  const vpX = toX(flowCX - visW / 2);
+  const vpY = toY(flowCY - visH / 2);
+  const vpW = visW * mmScale;
+  const vpH = visH * mmScale;
+
+  const indicators: { id: string; x: number; y: number; color: string }[] = [];
+  ecoreNodes.forEach(node => {
+    const sx = toX(node.position.x + MINI_NODE_W / 2);
+    const sy = toY(node.position.y + MINI_NODE_H / 2);
+    const ind = edgeIndicatorPos(sx, sy, width, height);
+    if (ind) indicators.push({ id: node.id, ...ind, color: cardColor(node.data?.domain) });
+  });
+  if (circle && circle.r > 0) {
+    const ind = edgeIndicatorPos(toX(circle.cx), toY(circle.cy), width, height);
+    if (ind) indicators.push({ id: 'circle-overlay', ...ind, color: 'rgba(4,148,132,0.85)' });
+  }
+
+  return (
+    <div style={{
+      position: 'absolute', right: 60, bottom: 16,
+      width, height, zIndex: 30,
+      background: '#f0f4f8', borderRadius: 8,
+      border: '1px solid #e2e8f0',
+      boxShadow: '0 2px 8px rgba(0,0,0,0.10)',
+      overflow: 'hidden',
+    }}>
+      <svg width={width} height={height} style={{ display: 'block' }}>
+        {/* Views circle, drawn only when it overlaps the visible slice */}
+        {circle && circle.r > 0 && (() => {
+          const cx = toX(circle.cx);
+          const cy = toY(circle.cy);
+          const r = circle.r * mmScale;
+          if (cx + r < 0 || cx - r > width || cy + r < 0 || cy - r > height) return null;
+          return (
+            <circle cx={cx} cy={cy} r={r}
+              fill="rgba(4,148,132,0.05)" stroke="rgba(4,148,132,0.45)"
+              strokeWidth={1.5} strokeDasharray="4 3"
+            />
+          );
+        })()}
+
+        {edges.map(edge => {
+          const src = nodeMap.get(edge.source);
+          const tgt = nodeMap.get(edge.target);
+          if (!src || !tgt) return null;
+          return (
+            <line key={edge.id}
+              x1={toX(src.position.x + MINI_NODE_W / 2)} y1={toY(src.position.y + MINI_NODE_H / 2)}
+              x2={toX(tgt.position.x + MINI_NODE_W / 2)} y2={toY(tgt.position.y + MINI_NODE_H / 2)}
+              stroke="#94a3b8" strokeWidth={1.2}
+            />
+          );
+        })}
+
+        {ecoreNodes.map(node => {
+          const sx = toX(node.position.x);
+          const sy = toY(node.position.y);
+          const nw = MINI_NODE_W * mmScale;
+          const nh = MINI_NODE_H * mmScale;
+          if (sx + nw < 0 || sx > width || sy + nh < 0 || sy > height) return null;
+          const color = cardColor(node.data?.domain);
+          return (
+            <rect key={node.id} x={sx} y={sy} width={nw} height={nh}
+              rx={Math.max(2, 8 * mmScale)}
+              fill={color} stroke={darken(color, 25)} strokeWidth={1}
+            />
+          );
+        })}
+
+        <rect x={vpX} y={vpY} width={vpW} height={vpH}
+          fill="rgba(59,130,246,0.07)" stroke="rgba(59,130,246,0.55)"
+          strokeWidth={1.5} rx={2}
+        />
+
+        {indicators.map(ind => (
+          <circle key={ind.id} cx={ind.x} cy={ind.y} r={4.5}
+            fill={ind.color} stroke="white" strokeWidth={1.2}
+          />
+        ))}
+      </svg>
+    </div>
+  );
+};

--- a/src/components/flow/canvas/CanvasModeToggle.tsx
+++ b/src/components/flow/canvas/CanvasModeToggle.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { CanvasMode } from '../flowCanvasTypes';
+
+const ModelingIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="3" width="18" height="18" rx="2" />
+    <line x1="3" y1="9" x2="21" y2="9" />
+    <line x1="9" y1="21" x2="9" y2="9" />
+  </svg>
+);
+
+const ConstraintsIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+  </svg>
+);
+
+const ViewsIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="9" />
+    <line x1="12" y1="3" x2="12" y2="21" />
+    <line x1="3" y1="12" x2="21" y2="12" />
+  </svg>
+);
+
+interface ModeOption {
+  label: string;
+  mode: CanvasMode;
+  icon: React.ReactNode;
+}
+
+export interface CanvasModeToggleProps {
+  activeCanvasMode: CanvasMode;
+  onSelectMode: (mode: CanvasMode) => void;
+  /** Constraints mode is hidden for read-only viewers. */
+  readOnly: boolean;
+  /** Rendered directly beneath the toggle (e.g. project tabs). */
+  projectTabsBelowModeToggle?: React.ReactNode;
+}
+
+/** Modeling / Constraints / Views switch floating at the top of the canvas. */
+export const CanvasModeToggle: React.FC<CanvasModeToggleProps> = ({
+  activeCanvasMode,
+  onSelectMode,
+  readOnly,
+  projectTabsBelowModeToggle,
+}) => {
+  const options: ModeOption[] = [
+    { label: 'Modeling', mode: 'modeling', icon: <ModelingIcon /> },
+    ...(readOnly ? [] : [{ label: 'Constraints', mode: 'constraints' as CanvasMode, icon: <ConstraintsIcon /> }]),
+    { label: 'Views', mode: 'views', icon: <ViewsIcon /> },
+  ];
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 14,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 31,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 4,
+        fontFamily: 'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          background: '#ffffff',
+          borderRadius: 8,
+          boxShadow: '0 4px 16px rgba(0,0,0,0.13), 0 0 0 1px rgba(0,0,0,0.07)',
+          height: 44,
+          padding: '0 4px',
+          gap: 2,
+        }}
+      >
+        {options.map(({ label, mode, icon }) => {
+          const isActive = activeCanvasMode === mode;
+          return (
+            <button
+              type="button"
+              key={label}
+              onClick={() => onSelectMode(mode)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                height: 34,
+                padding: '0 14px',
+                border: isActive ? '1px solid #049484' : '1px solid transparent',
+                borderRadius: 6,
+                background: isActive ? '#049484' : 'transparent',
+                color: isActive ? '#ffffff' : '#64748b',
+                fontSize: 12,
+                fontWeight: 600,
+                cursor: 'pointer',
+                transition: 'all 0.15s',
+                whiteSpace: 'nowrap',
+                fontFamily: 'inherit',
+              }}
+              onMouseEnter={e => {
+                if (isActive) return;
+                e.currentTarget.style.background = '#f1f5f9';
+                e.currentTarget.style.color = '#1e293b';
+              }}
+              onMouseLeave={e => {
+                if (isActive) return;
+                e.currentTarget.style.background = 'transparent';
+                e.currentTarget.style.color = '#64748b';
+              }}
+            >
+              {icon}
+              {label}
+            </button>
+          );
+        })}
+      </div>
+      {projectTabsBelowModeToggle}
+    </div>
+  );
+};

--- a/src/components/flow/canvas/ModelDetailOverlay.tsx
+++ b/src/components/flow/canvas/ModelDetailOverlay.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect } from 'react';
+import ReactDOM from 'react-dom';
+import { ModelDetailModal } from '../../ui/ModelLibraryTable';
+
+export interface ModelDetailOverlayProps {
+  model: any;
+  ecoreContent: string;
+  onClose: () => void;
+}
+
+/**
+ * Model detail panel, portalled to `document.body` so it escapes the canvas
+ * stacking context.
+ *
+ * Dismissal is handled here rather than by a backdrop click target: the
+ * backdrop is `pointer-events: none` so the canvas stays visible through it,
+ * so we listen on the document in the capture phase instead and ignore clicks
+ * that land on the modal or on any interactive element.
+ */
+export const ModelDetailOverlay: React.FC<ModelDetailOverlayProps> = ({
+  model,
+  ecoreContent,
+  onClose,
+}) => {
+  useEffect(() => {
+    const handleOutsideDetail = (e: Event) => {
+      const target = e.target as HTMLElement;
+      if (target.closest('[data-model-detail-modal]')) return;
+      if (target.closest('button, input, textarea, select, a, [role="dialog"]')) return;
+      onClose();
+    };
+    document.addEventListener('pointerdown', handleOutsideDetail, true);
+    document.addEventListener('mousedown', handleOutsideDetail, true);
+    return () => {
+      document.removeEventListener('pointerdown', handleOutsideDetail, true);
+      document.removeEventListener('mousedown', handleOutsideDetail, true);
+    };
+  }, [onClose]);
+
+  return ReactDOM.createPortal(
+    <>
+      <div
+        aria-hidden="true"
+        data-model-detail-dismiss
+        style={{
+          position: 'fixed',
+          inset: 0,
+          zIndex: 10000,
+          background: 'rgba(0, 0, 0, 0.5)',
+          backdropFilter: 'blur(8px)',
+          WebkitBackdropFilter: 'blur(8px)',
+          pointerEvents: 'none',
+        }}
+      />
+      <div
+        style={{
+          position: 'fixed',
+          inset: 0,
+          zIndex: 10001,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          pointerEvents: 'none',
+        }}
+      >
+        <div style={{ pointerEvents: 'auto' }} data-model-detail-modal>
+          <ModelDetailModal
+            model={model}
+            ecoreContent={ecoreContent}
+            onClose={onClose}
+            onUpdated={onClose}
+            embedded
+          />
+        </div>
+      </div>
+    </>,
+    document.body,
+  );
+};

--- a/src/components/flow/flowCanvasAutoLayout.ts
+++ b/src/components/flow/flowCanvasAutoLayout.ts
@@ -1,0 +1,237 @@
+import { Edge, Node } from 'reactflow';
+
+export type Point = { x: number; y: number };
+
+/** Tuning for the force-directed workspace layout. */
+export const LAYOUT_CONFIG = {
+  BOX_WIDTH: 280,
+  BOX_HEIGHT: 180,
+  MIN_HORIZONTAL_SPACING: 150,
+  MIN_VERTICAL_SPACING: 120,
+  START_X: 100,
+  START_Y: 100,
+  ITERATIONS: 150,
+  REPULSION_STRENGTH: 50000,
+  ATTRACTION_STRENGTH: 0.3,
+  DAMPING: 0.85,
+};
+
+/** Every node pushes every other node apart, falling off with the square of distance. */
+export function calculateRepulsiveForces(
+  componentNodes: string[],
+  positions: Map<string, Point>,
+  forces: Map<string, Point>,
+): void {
+  for (let i = 0; i < componentNodes.length; i++) {
+    for (let j = i + 1; j < componentNodes.length; j++) {
+      const nodeA = componentNodes[i];
+      const nodeB = componentNodes[j];
+      const posA = positions.get(nodeA)!;
+      const posB = positions.get(nodeB)!;
+
+      const dx = posB.x - posA.x;
+      const dy = posB.y - posA.y;
+      const distance = Math.hypot(dx, dy) || 1;
+
+      const force = LAYOUT_CONFIG.REPULSION_STRENGTH / (distance * distance);
+      const fx = (dx / distance) * force;
+      const fy = (dy / distance) * force;
+
+      const forceA = forces.get(nodeA)!;
+      const forceB = forces.get(nodeB)!;
+      forceA.x -= fx;
+      forceA.y -= fy;
+      forceB.x += fx;
+      forceB.y += fy;
+    }
+  }
+}
+
+/** Connected nodes pull toward each other until they sit one ideal edge length apart. */
+export function calculateAttractiveForces(
+  componentNodes: string[],
+  positions: Map<string, Point>,
+  forces: Map<string, Point>,
+  adjacencyMap: Map<string, Set<string>>,
+  idealEdgeLength: number,
+): void {
+  componentNodes.forEach(nodeId => {
+    const neighbors = adjacencyMap.get(nodeId) || new Set<string>();
+    neighbors.forEach(neighborId => {
+      if (!componentNodes.includes(neighborId)) return;
+
+      const posA = positions.get(nodeId)!;
+      const posB = positions.get(neighborId)!;
+
+      const dx = posB.x - posA.x;
+      const dy = posB.y - posA.y;
+      const distance = Math.hypot(dx, dy) || 1;
+
+      const force = LAYOUT_CONFIG.ATTRACTION_STRENGTH * (distance - idealEdgeLength);
+      const forceA = forces.get(nodeId)!;
+      forceA.x += (dx / distance) * force;
+      forceA.y += (dy / distance) * force;
+    });
+  });
+}
+
+/**
+ * Runs the force simulation for one connected component, seeded on a circle,
+ * then normalises the result so its top-left corner sits at (startX, startY).
+ */
+export function layoutComponent(
+  componentNodes: string[],
+  startX: number,
+  startY: number,
+  adjacencyMap: Map<string, Set<string>>,
+): Map<string, Point> {
+  if (componentNodes.length === 1) {
+    return new Map([[componentNodes[0], { x: startX, y: startY }]]);
+  }
+
+  const positions = new Map<string, Point>();
+  componentNodes.forEach((nodeId, idx) => {
+    const angle = (idx / componentNodes.length) * 2 * Math.PI;
+    const radius = Math.max(200, componentNodes.length * 40);
+    positions.set(nodeId, {
+      x: startX + radius + radius * Math.cos(angle),
+      y: startY + radius + radius * Math.sin(angle),
+    });
+  });
+
+  const idealEdgeLength = LAYOUT_CONFIG.BOX_WIDTH + LAYOUT_CONFIG.MIN_HORIZONTAL_SPACING;
+
+  for (let iter = 0; iter < LAYOUT_CONFIG.ITERATIONS; iter++) {
+    const forces = new Map<string, Point>();
+    componentNodes.forEach(nodeId => forces.set(nodeId, { x: 0, y: 0 }));
+
+    calculateRepulsiveForces(componentNodes, positions, forces);
+    calculateAttractiveForces(componentNodes, positions, forces, adjacencyMap, idealEdgeLength);
+
+    componentNodes.forEach(nodeId => {
+      const pos = positions.get(nodeId)!;
+      const force = forces.get(nodeId)!;
+      pos.x += force.x * LAYOUT_CONFIG.DAMPING;
+      pos.y += force.y * LAYOUT_CONFIG.DAMPING;
+    });
+  }
+
+  let minX = Infinity;
+  let minY = Infinity;
+  positions.forEach(pos => {
+    minX = Math.min(minX, pos.x);
+    minY = Math.min(minY, pos.y);
+  });
+
+  positions.forEach(pos => {
+    pos.x = pos.x - minX + startX;
+    pos.y = pos.y - minY + startY;
+  });
+
+  return positions;
+}
+
+/** Undirected adjacency over reaction edges only. */
+export function buildAdjacencyMap(ecoreNodes: Node[], allEdges: Edge[]): Map<string, Set<string>> {
+  const adjacencyMap = new Map<string, Set<string>>();
+  ecoreNodes.forEach(node => adjacencyMap.set(node.id, new Set()));
+
+  allEdges.forEach(edge => {
+    if (edge.type === 'reactions') {
+      adjacencyMap.get(edge.source)?.add(edge.target);
+      adjacencyMap.get(edge.target)?.add(edge.source);
+    }
+  });
+
+  return adjacencyMap;
+}
+
+/** Splits the graph into connected components (BFS), pulling out unconnected nodes. */
+export function findConnectedComponents(
+  ecoreNodes: Node[],
+  adjacencyMap: Map<string, Set<string>>,
+): { components: string[][]; isolatedNodes: string[] } {
+  const visited = new Set<string>();
+  const components: string[][] = [];
+  const isolatedNodes: string[] = [];
+
+  ecoreNodes.forEach(node => {
+    if ((adjacencyMap.get(node.id)?.size || 0) === 0) {
+      isolatedNodes.push(node.id);
+      visited.add(node.id);
+    }
+  });
+
+  ecoreNodes.forEach(startNode => {
+    if (visited.has(startNode.id)) return;
+
+    const component: string[] = [];
+    const queue = [startNode.id];
+    visited.add(startNode.id);
+
+    while (queue.length > 0) {
+      const nodeId = queue.shift()!;
+      component.push(nodeId);
+
+      adjacencyMap.get(nodeId)?.forEach(neighborId => {
+        if (!visited.has(neighborId)) {
+          visited.add(neighborId);
+          queue.push(neighborId);
+        }
+      });
+    }
+
+    if (component.length > 0) {
+      components.push(component);
+    }
+  });
+
+  return { components, isolatedNodes };
+}
+
+/**
+ * Computes a fresh position for every ecoreFile node: connected components are
+ * laid out one below the other with the force simulation, and isolated nodes
+ * are packed into a grid underneath them.
+ */
+export function computeAutoLayoutPositions(ecoreNodes: Node[], edges: Edge[]): Map<string, Point> {
+  const adjacencyMap = buildAdjacencyMap(ecoreNodes, edges);
+  const { components, isolatedNodes } = findConnectedComponents(ecoreNodes, adjacencyMap);
+
+  const positionMap = new Map<string, Point>();
+  let currentY = LAYOUT_CONFIG.START_Y;
+
+  components.forEach(component => {
+    const componentPositions = layoutComponent(component, LAYOUT_CONFIG.START_X, currentY, adjacencyMap);
+    componentPositions.forEach((pos, nodeId) => positionMap.set(nodeId, pos));
+
+    let maxY = 0;
+    componentPositions.forEach(pos => {
+      maxY = Math.max(maxY, pos.y);
+    });
+    currentY = maxY + LAYOUT_CONFIG.BOX_HEIGHT + LAYOUT_CONFIG.MIN_VERTICAL_SPACING * 2;
+  });
+
+  if (isolatedNodes.length > 0) {
+    const itemsPerRow = Math.ceil(Math.sqrt(isolatedNodes.length * 2));
+    isolatedNodes.forEach((nodeId, idx) => {
+      const row = Math.floor(idx / itemsPerRow);
+      const col = idx % itemsPerRow;
+      positionMap.set(nodeId, {
+        x: LAYOUT_CONFIG.START_X + col * (LAYOUT_CONFIG.BOX_WIDTH + LAYOUT_CONFIG.MIN_HORIZONTAL_SPACING),
+        y: currentY + row * (LAYOUT_CONFIG.BOX_HEIGHT + LAYOUT_CONFIG.MIN_VERTICAL_SPACING),
+      });
+    });
+  }
+
+  return positionMap;
+}
+
+/** Applies computed positions, leaving non-ecoreFile nodes untouched. */
+export function applyAutoLayoutPositions(nodes: Node[], positionMap: Map<string, Point>): Node[] {
+  return nodes.map(node => {
+    if (node.type !== 'ecoreFile') return node;
+    const position = positionMap.get(node.id);
+    return position ? { ...node, position } : node;
+  });
+}

--- a/src/components/flow/flowCanvasConstants.ts
+++ b/src/components/flow/flowCanvasConstants.ts
@@ -1,0 +1,16 @@
+import { ECORE_H, ECORE_W } from './flowCanvasLayoutUtils';
+
+/** Footprint of an editable UML class node. */
+export const NODE_DIMENSIONS = { width: 280, height: 180 };
+
+/** Footprint of an EcoreFileBox card — kept in step with the layout helpers. */
+export const ECORE_FILE_BOX_SIZE = { width: ECORE_W, height: ECORE_H };
+
+/** Palette cycled through when a new metamodel pair first gets an edge. */
+export const EDGE_COLOR_LIST = [
+  '#ab1c91ff', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
+  '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf',
+  '#d636a3ff', '#ff9f40', '#4daf4a', '#ff6b6b', '#b388eb',
+  '#9c6644', '#f39ed1', '#a9a9a9', '#c9d22f', '#33c7c7',
+  '#2a86d6', '#ffb86b', '#63c37a', '#ff4f7a', '#b08fe8',
+];

--- a/src/components/flow/flowCanvasEcoreSelect.ts
+++ b/src/components/flow/flowCanvasEcoreSelect.ts
@@ -1,6 +1,6 @@
 import { Edge, Node } from 'reactflow';
-
-type CanvasMode = 'modeling' | 'constraints' | 'views';
+import { CanvasMode } from './flowCanvasTypes';
+import { buildReactionEdge } from './flowCanvasEdgeFactory';
 
 export type EcoreSelectAction =
   | { kind: 'handled' }
@@ -44,32 +44,21 @@ export function resolveEcoreFileSelectAction(params: ResolveEcoreSelectParams): 
   return { kind: 'select', nodeId: ecoreNode.id, fileName };
 }
 
+/** Edge created by picking a source and then a target in add-reaction mode. */
 export function buildReactionEdgeFromNodes(
   sourceNode: Node,
   targetNode: Node,
   color: string,
-  calculateOptimalHandles: (source: Node, target: Node) => { sourceHandle: string; targetHandle: string },
 ): Edge {
-  const handles = calculateOptimalHandles(sourceNode, targetNode);
-  const cleanSrc = handles.sourceHandle.replace('-source', '').replace('-target', '');
-  const cleanTgt = handles.targetHandle.replace('-target', '').replace('-source', '');
-
-  return {
+  return buildReactionEdge({
     id: `edge-reaction-${Date.now()}`,
-    source: sourceNode.id,
-    target: targetNode.id,
-    type: 'reactions',
-    sourceHandle: cleanSrc,
-    targetHandle: cleanTgt,
+    sourceNode,
+    targetNode,
+    color,
     data: {
       code: '',
       backendRelationId: null,
       reactionFileId: null,
-      sourceMetaModelId: sourceNode.data?.metaModelId ?? sourceNode.data?.metaModelSourceId,
-      targetMetaModelId: targetNode.data?.metaModelId ?? targetNode.data?.metaModelSourceId,
-      sourceMetaModelSourceId: sourceNode.data?.metaModelSourceId ?? sourceNode.data?.metaModelId,
-      targetMetaModelSourceId: targetNode.data?.metaModelSourceId ?? targetNode.data?.metaModelId,
     },
-    style: { stroke: color, strokeWidth: 2 },
-  };
+  });
 }

--- a/src/components/flow/flowCanvasEdgeDistribution.ts
+++ b/src/components/flow/flowCanvasEdgeDistribution.ts
@@ -1,0 +1,88 @@
+import { Edge, Node } from 'reactflow';
+import { HandlePosition } from './flowCanvasTypes';
+import { EdgeDistributionSlot } from './flowCanvasRenderUtils';
+
+const HANDLE_POSITIONS: HandlePosition[] = ['top', 'bottom', 'left', 'right'];
+
+export type NodeEdgeDistribution = Map<HandlePosition, EdgeDistributionSlot[]>;
+export type EdgeDistributionMap = Map<string, NodeEdgeDistribution>;
+
+/** Groups the reaction edges touching a node by the handle they attach to. */
+export function collectNodeSideEdges(node: Node, allEdges: Edge[]): Map<HandlePosition, string[]> {
+  const sideMap = new Map<HandlePosition, string[]>();
+  HANDLE_POSITIONS.forEach(pos => sideMap.set(pos, []));
+
+  allEdges.forEach(edge => {
+    if (edge.type !== 'reactions') return;
+
+    if (edge.source === node.id && edge.sourceHandle) {
+      const handle = edge.sourceHandle as HandlePosition;
+      if (!sideMap.get(handle)?.includes(edge.id)) {
+        sideMap.get(handle)?.push(edge.id);
+      }
+    }
+
+    if (edge.target === node.id && edge.targetHandle) {
+      const handle = edge.targetHandle as HandlePosition;
+      if (!sideMap.get(handle)?.includes(edge.id)) {
+        sideMap.get(handle)?.push(edge.id);
+      }
+    }
+  });
+
+  return sideMap;
+}
+
+/**
+ * Orders edges on a handle by the id of the node at their far end, so the fan
+ * of parallel edges keeps a stable order across renders.
+ */
+export function createEdgeSortComparator(nodeId: string, allEdges: Edge[]) {
+  return (a: string, b: string): number => {
+    const edgeA = allEdges.find(e => e.id === a);
+    const edgeB = allEdges.find(e => e.id === b);
+    if (!edgeA || !edgeB) return 0;
+
+    const otherNodeA = edgeA.source === nodeId ? edgeA.target : edgeA.source;
+    const otherNodeB = edgeB.source === nodeId ? edgeB.target : edgeB.source;
+
+    return otherNodeA.localeCompare(otherNodeB);
+  };
+}
+
+/** Assigns each edge on a handle its slot (index of total) for fan-out spacing. */
+export function buildNodeDistribution(
+  nodeId: string,
+  sideMap: Map<HandlePosition, string[]>,
+  allEdges: Edge[],
+): NodeEdgeDistribution {
+  const nodeDistribution: NodeEdgeDistribution = new Map();
+  const comparator = createEdgeSortComparator(nodeId, allEdges);
+
+  sideMap.forEach((edgeIds, position) => {
+    const sortedEdgeIds = [...edgeIds].sort(comparator);
+    const total = sortedEdgeIds.length;
+    nodeDistribution.set(
+      position,
+      sortedEdgeIds.map((edgeId, index) => ({ edgeId, index, total })),
+    );
+  });
+
+  return nodeDistribution;
+}
+
+/**
+ * Builds the per-node, per-handle slot metadata that ReactionRelationship uses
+ * to spread parallel edges along a box side. Only ecoreFile nodes participate.
+ */
+export function buildEdgeDistributionMap(nodes: Node[], edges: Edge[]): EdgeDistributionMap {
+  const map: EdgeDistributionMap = new Map();
+
+  nodes.forEach(node => {
+    if (node.type !== 'ecoreFile') return;
+    const sideMap = collectNodeSideEdges(node, edges);
+    map.set(node.id, buildNodeDistribution(node.id, sideMap, edges));
+  });
+
+  return map;
+}

--- a/src/components/flow/flowCanvasEdgeFactory.ts
+++ b/src/components/flow/flowCanvasEdgeFactory.ts
@@ -1,0 +1,62 @@
+import { Edge, Node } from 'reactflow';
+import { calculateReactionHandles } from './flowCanvasHandleUtils';
+
+const REACTION_EDGE_STROKE_WIDTH = 2;
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+export interface ReactionEdgeMetaModelIds {
+  sourceMetaModelId?: number;
+  targetMetaModelId?: number;
+  sourceMetaModelSourceId?: number;
+  targetMetaModelSourceId?: number;
+}
+
+/**
+ * Both id flavours for an edge's endpoints. Nodes created before the
+ * backend/source id split carry only one of the two, hence the fallbacks.
+ */
+export function metaModelIdsFromNodes(sourceNode: Node, targetNode: Node): ReactionEdgeMetaModelIds {
+  return {
+    sourceMetaModelId: asNumber(sourceNode.data?.metaModelId ?? sourceNode.data?.metaModelSourceId),
+    targetMetaModelId: asNumber(targetNode.data?.metaModelId ?? targetNode.data?.metaModelSourceId),
+    sourceMetaModelSourceId: asNumber(sourceNode.data?.metaModelSourceId ?? sourceNode.data?.metaModelId),
+    targetMetaModelSourceId: asNumber(targetNode.data?.metaModelSourceId ?? targetNode.data?.metaModelId),
+  };
+}
+
+export interface BuildReactionEdgeOptions {
+  id: string;
+  sourceNode: Node;
+  targetNode: Node;
+  color: string;
+  /** Merged over the derived metamodel ids, so callers can add or override. */
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Single construction point for reaction edges, whichever gesture created them
+ * — drag-to-connect, add-reaction mode, a relation loaded from the backend, or
+ * the `vitruv.createReactionEdge` event. Handles are derived from the current
+ * box positions so the edge enters each box on its facing side.
+ */
+export function buildReactionEdge(options: BuildReactionEdgeOptions): Edge {
+  const { id, sourceNode, targetNode, color, data } = options;
+  const handles = calculateReactionHandles(sourceNode, targetNode);
+
+  return {
+    id,
+    source: sourceNode.id,
+    target: targetNode.id,
+    type: 'reactions',
+    sourceHandle: handles.sourceHandle,
+    targetHandle: handles.targetHandle,
+    data: {
+      ...metaModelIdsFromNodes(sourceNode, targetNode),
+      ...data,
+    },
+    style: { stroke: color, strokeWidth: REACTION_EDGE_STROKE_WIDTH },
+  };
+}

--- a/src/components/flow/flowCanvasEdgeHygiene.ts
+++ b/src/components/flow/flowCanvasEdgeHygiene.ts
@@ -1,0 +1,81 @@
+import { Edge, Node } from 'reactflow';
+
+/**
+ * Duplicate edge ids make ReactFlow drop edges silently, so they get repaired
+ * at three separate points, each with its own id scheme so the three passes
+ * cannot fight over the same name:
+ *
+ * - {@link uniquifyLoadedEdgeIds} on load (`id-1`, `id-2`, …)
+ * - {@link dedupeEdgeIds} as a state-level repair (`id__1`)
+ * - {@link withUniqueEdgeIds} as a last resort at render time (`id-dup-1`)
+ */
+
+/** Drops edges whose source or target node no longer exists. */
+export function removeOrphanEdges(nodes: Node[], edges: Edge[]): Edge[] {
+  const nodeIds = new Set(nodes.map(n => n.id));
+  return edges.filter(e => nodeIds.has(e.source) && nodeIds.has(e.target));
+}
+
+/** Renames later occurrences of a repeated id. Returns `null` when nothing changed. */
+export function dedupeEdgeIds(edges: Edge[]): Edge[] | null {
+  const seen = new Map<string, number>();
+  let changed = false;
+
+  const fixedEdges = edges.map(edge => {
+    const count = seen.get(edge.id) ?? 0;
+
+    if (count === 0) {
+      seen.set(edge.id, 1);
+      return edge;
+    }
+
+    seen.set(edge.id, count + 1);
+    changed = true;
+    return { ...edge, id: `${edge.id}__${count}` };
+  });
+
+  return changed ? fixedEdges : null;
+}
+
+/** Render-time guard; also fills in an id for edges that arrived without one. */
+export function withUniqueEdgeIds(edges: Edge[]): Edge[] {
+  const idCount = new Map<string, number>();
+
+  return edges.map((e, index) => {
+    const baseId = e.id || `edge-${index}`;
+    const count = idCount.get(baseId) ?? 0;
+    idCount.set(baseId, count + 1);
+
+    return count === 0 ? { ...e, id: baseId } : { ...e, id: `${baseId}-dup-${count}` };
+  });
+}
+
+/** Assigns ids to loaded nodes that lack one. */
+export function uniquifyLoadedNodeIds(newNodes: any[]): Node[] {
+  return newNodes.map((n, idx) => ({
+    ...n,
+    id: n.id ?? `loaded-node-${idx}-${Date.now()}`,
+  }));
+}
+
+/** Assigns collision-free ids to loaded edges, probing upward on a clash. */
+export function uniquifyLoadedEdgeIds(newEdges: any[]): Edge[] {
+  const seen = new Set<string>();
+
+  return newEdges.map((e, idx) => {
+    let baseId = e.id ?? `loaded-edge-${idx}`;
+
+    if (seen.has(baseId)) {
+      let k = 1;
+      let newId = `${baseId}-${k}`;
+      while (seen.has(newId)) {
+        k += 1;
+        newId = `${baseId}-${k}`;
+      }
+      baseId = newId;
+    }
+
+    seen.add(baseId);
+    return { ...e, id: baseId };
+  });
+}

--- a/src/components/flow/flowCanvasEdgeReorder.ts
+++ b/src/components/flow/flowCanvasEdgeReorder.ts
@@ -76,9 +76,9 @@ export function computeParallelEdgeReorder(
   const edge = prevEdges.find(e => e.id === edgeId);
   if (edge?.type !== 'reactions') return prevEdges;
 
-  const sourceNode = nodes.find(n => n.id === edge.source);
-  const targetNode = nodes.find(n => n.id === edge.target);
-  if (!sourceNode || !targetNode) return prevEdges;
+  const hasBothEndpoints = nodes.some(n => n.id === edge.source)
+    && nodes.some(n => n.id === edge.target);
+  if (!hasBothEndpoints) return prevEdges;
 
   const sameSourceEdges = prevEdges.filter(
     e => e.type === 'reactions' && e.source === edge.source && e.sourceHandle === edge.sourceHandle,

--- a/src/components/flow/flowCanvasEdgeReorder.ts
+++ b/src/components/flow/flowCanvasEdgeReorder.ts
@@ -1,0 +1,97 @@
+import { Edge, Node } from 'reactflow';
+import { NODE_DIMENSIONS } from './flowCanvasConstants';
+import { Point } from './flowCanvasAutoLayout';
+
+/** Midpoint between the two boxes — the control point an edge uses by default. */
+export function calculateDefaultControlPoint(edge: Edge, nodes: Node[]): Point {
+  const src = nodes.find(n => n.id === edge.source);
+  const tgt = nodes.find(n => n.id === edge.target);
+  if (!src || !tgt) return { x: 0, y: 0 };
+
+  return {
+    x: (src.position.x + tgt.position.x + NODE_DIMENSIONS.width) / 2,
+    y: (src.position.y + tgt.position.y + NODE_DIMENSIONS.height) / 2,
+  };
+}
+
+/**
+ * Orders edges along the axis the handle runs on — horizontally for top/bottom
+ * handles, vertically for left/right — using the dragged edge's provisional
+ * control point so it slots in where the user dropped it.
+ */
+export function createEdgeReorderComparator(
+  targetEdgeId: string,
+  controlPoint: Point,
+  handle: string,
+  nodes: Node[],
+) {
+  return (a: Edge, b: Edge): number => {
+    const aPos = a.id === targetEdgeId ? controlPoint : (a.data?.customControlPoint || calculateDefaultControlPoint(a, nodes));
+    const bPos = b.id === targetEdgeId ? controlPoint : (b.data?.customControlPoint || calculateDefaultControlPoint(b, nodes));
+    return (handle === 'top' || handle === 'bottom') ? aPos.x - bPos.x : aPos.y - bPos.y;
+  };
+}
+
+/** Writes the new slot index/count onto every edge that took part in a reorder. */
+export function applyEdgeReorderData(
+  prevEdges: Edge[],
+  reorderedSourceEdges: Edge[],
+  reorderedTargetEdges: Edge[],
+): Edge[] {
+  const sourceIndexById = new Map(reorderedSourceEdges.map((re, index) => [re.id, index] as const));
+  const targetIndexById = new Map(reorderedTargetEdges.map((re, index) => [re.id, index] as const));
+
+  return prevEdges.map(e => {
+    const sourceIndex = sourceIndexById.get(e.id);
+    const targetIndex = targetIndexById.get(e.id);
+    const inSource = sourceIndex !== undefined;
+    const inTarget = targetIndex !== undefined;
+
+    if (!inSource && !inTarget) return e;
+
+    return {
+      ...e,
+      data: {
+        ...e.data,
+        sourceParallelIndex: inSource ? sourceIndex : e.data?.sourceParallelIndex,
+        sourceParallelCount: inSource ? reorderedSourceEdges.length : e.data?.sourceParallelCount,
+        targetParallelIndex: inTarget ? targetIndex : e.data?.targetParallelIndex,
+        targetParallelCount: inTarget ? reorderedTargetEdges.length : e.data?.targetParallelCount,
+      },
+    };
+  });
+}
+
+/**
+ * Recomputes the slot order of every reaction edge sharing a handle with the
+ * dragged one. Returns `prevEdges` untouched when the edge is not a reaction
+ * edge or either endpoint is missing.
+ */
+export function computeParallelEdgeReorder(
+  prevEdges: Edge[],
+  options: { edgeId: string; controlPoint: Point; nodes: Node[] },
+): Edge[] {
+  const { edgeId, controlPoint, nodes } = options;
+
+  const edge = prevEdges.find(e => e.id === edgeId);
+  if (edge?.type !== 'reactions') return prevEdges;
+
+  const sourceNode = nodes.find(n => n.id === edge.source);
+  const targetNode = nodes.find(n => n.id === edge.target);
+  if (!sourceNode || !targetNode) return prevEdges;
+
+  const sameSourceEdges = prevEdges.filter(
+    e => e.type === 'reactions' && e.source === edge.source && e.sourceHandle === edge.sourceHandle,
+  );
+  const sameTargetEdges = prevEdges.filter(
+    e => e.type === 'reactions' && e.target === edge.target && e.targetHandle === edge.targetHandle,
+  );
+
+  const sourceComparator = createEdgeReorderComparator(edgeId, controlPoint, edge.sourceHandle!, nodes);
+  const targetComparator = createEdgeReorderComparator(edgeId, controlPoint, edge.targetHandle!, nodes);
+
+  const reorderedSourceEdges = sameSourceEdges.length > 1 ? [...sameSourceEdges].sort(sourceComparator) : sameSourceEdges;
+  const reorderedTargetEdges = sameTargetEdges.length > 1 ? [...sameTargetEdges].sort(targetComparator) : sameTargetEdges;
+
+  return applyEdgeReorderData(prevEdges, reorderedSourceEdges, reorderedTargetEdges);
+}

--- a/src/components/flow/flowCanvasHandleUtils.ts
+++ b/src/components/flow/flowCanvasHandleUtils.ts
@@ -1,0 +1,103 @@
+import { Edge, Node } from 'reactflow';
+
+/**
+ * UML handles keep their `-source` / `-target` suffix; reaction handles use the
+ * bare side name. Both are derived from the same directional calculation.
+ */
+export interface OptimalHandles {
+  sourceHandle: string;
+  targetHandle: string;
+}
+
+/** Strips the `-source` / `-target` suffix so ReactFlow accepts the handle id. */
+export function cleanHandleId(handle: string): string {
+  return handle.replace('-source', '').replace('-target', '');
+}
+
+/**
+ * Picks the pair of handles that face each other, based on which axis dominates
+ * the offset between the two nodes.
+ */
+export function calculateOptimalHandles(sourceNode: Node, targetNode: Node): OptimalHandles {
+  const dx = targetNode.position.x - sourceNode.position.x;
+  const dy = targetNode.position.y - sourceNode.position.y;
+
+  if (Math.abs(dy) > Math.abs(dx)) {
+    return dy > 0
+      ? { sourceHandle: 'bottom-source', targetHandle: 'top-target' }
+      : { sourceHandle: 'top-source', targetHandle: 'bottom-target' };
+  }
+
+  return dx > 0
+    ? { sourceHandle: 'right-source', targetHandle: 'left-target' }
+    : { sourceHandle: 'left-source', targetHandle: 'right-target' };
+}
+
+/** Optimal handles for a reaction edge, with the suffixes already stripped. */
+export function calculateReactionHandles(sourceNode: Node, targetNode: Node): OptimalHandles {
+  const handles = calculateOptimalHandles(sourceNode, targetNode);
+  return {
+    sourceHandle: cleanHandleId(handles.sourceHandle),
+    targetHandle: cleanHandleId(handles.targetHandle),
+  };
+}
+
+/**
+ * Re-points a single edge at the handles that now face each other. Returns the
+ * edge untouched when it is not a reaction/UML edge, when either endpoint is
+ * missing, or when the handles are already correct — so callers can map over
+ * every edge and rely on reference equality to detect "nothing changed".
+ */
+export function updateEdgeHandles(edge: Edge, currentNodes: Node[]): Edge {
+  if (edge.type !== 'reactions' && edge.type !== 'uml') return edge;
+
+  const sourceNode = currentNodes.find(n => n.id === edge.source);
+  const targetNode = currentNodes.find(n => n.id === edge.target);
+  if (!sourceNode || !targetNode) return edge;
+
+  const handles = calculateOptimalHandles(sourceNode, targetNode);
+  const newSourceHandle = edge.type === 'uml' ? handles.sourceHandle : cleanHandleId(handles.sourceHandle);
+  const newTargetHandle = edge.type === 'uml' ? handles.targetHandle : cleanHandleId(handles.targetHandle);
+
+  if (edge.sourceHandle === newSourceHandle && edge.targetHandle === newTargetHandle) {
+    return edge;
+  }
+
+  return {
+    ...edge,
+    sourceHandle: newSourceHandle,
+    targetHandle: newTargetHandle,
+    // Clear the custom control point — the path has to be recalculated.
+    data: {
+      ...edge.data,
+      customControlPoint: undefined,
+    },
+  };
+}
+
+/**
+ * Re-points every reaction edge after an auto-layout moved the boxes. Unlike
+ * {@link updateEdgeHandles} this always rewrites the handles and clears the
+ * control point, because every position changed.
+ */
+export function optimizeEdgeHandles(targetNodes: Node[], allEdges: Edge[]): Edge[] {
+  return allEdges.map(edge => {
+    if (edge.type !== 'reactions') return edge;
+
+    const sourceNode = targetNodes.find(n => n.id === edge.source);
+    const targetNode = targetNodes.find(n => n.id === edge.target);
+    if (!sourceNode || !targetNode) return edge;
+
+    const handles = calculateReactionHandles(sourceNode, targetNode);
+
+    return {
+      ...edge,
+      sourceHandle: handles.sourceHandle,
+      targetHandle: handles.targetHandle,
+      data: {
+        ...edge.data,
+        customControlPoint: undefined,
+      },
+    };
+  });
+}

--- a/src/components/flow/flowCanvasNodeLookup.ts
+++ b/src/components/flow/flowCanvasNodeLookup.ts
@@ -1,0 +1,71 @@
+import { Node } from 'reactflow';
+import { ECORE_FILE_BOX_SIZE, NODE_DIMENSIONS } from './flowCanvasConstants';
+
+/**
+ * The id the *canvas* keys metamodels by. Falls back to the backend id when a
+ * node predates the source/backend id split.
+ */
+export function getMetaModelSourceId(nodes: Node[], nodeId?: string | null): number | undefined {
+  if (!nodeId) return undefined;
+  const node = nodes.find(n => n.id === nodeId);
+  const value = node?.data?.metaModelSourceId ?? node?.data?.metaModelId;
+  return typeof value === 'number' ? value : undefined;
+}
+
+/** The id the *backend* keys metamodels by — the same fallback in reverse. */
+export function getBackendMetaModelId(nodes: Node[], nodeId?: string | null): number | undefined {
+  if (!nodeId) return undefined;
+  const node = nodes.find(n => n.id === nodeId);
+  const value = node?.data?.metaModelId ?? node?.data?.metaModelSourceId;
+  return typeof value === 'number' ? value : undefined;
+}
+
+/** Finds the ecoreFile node carrying either flavour of the given metamodel id. */
+export function findNodeByMetaModelId(nodes: Node[], metaModelId: number): Node | undefined {
+  return nodes.find(
+    n => n.type === 'ecoreFile'
+      && (n.data?.metaModelId === metaModelId || n.data?.metaModelSourceId === metaModelId),
+  );
+}
+
+/** Whether a flow-space point falls within a node's footprint. */
+export function isPositionInsideNode(position: { x: number; y: number }, node: Node): boolean {
+  const { width, height } = node.type === 'ecoreFile' ? ECORE_FILE_BOX_SIZE : NODE_DIMENSIONS;
+  return (
+    position.x >= node.position.x
+    && position.x <= node.position.x + width
+    && position.y >= node.position.y
+    && position.y <= node.position.y + height
+  );
+}
+
+/** Snap radius, in flow units, for dropping a connection near (not on) a box. */
+export const ECORE_DROP_SNAP_DISTANCE = 80;
+
+/**
+ * Resolves which ecoreFile box a dropped connection belongs to: a direct hit
+ * wins, otherwise the nearest box within {@link ECORE_DROP_SNAP_DISTANCE}.
+ */
+export function findEcoreTargetAtPosition(
+  nodes: Node[],
+  flowPosition: { x: number; y: number },
+  sourceNodeId: string,
+): Node | null {
+  const candidates = nodes.filter(n => n.type === 'ecoreFile' && n.id !== sourceNodeId);
+
+  const hit = candidates.find(n => isPositionInsideNode(flowPosition, n));
+  if (hit) return hit;
+
+  let closest: Node | null = null;
+  let minDist = Infinity;
+  for (const n of candidates) {
+    const cx = n.position.x + ECORE_FILE_BOX_SIZE.width / 2;
+    const cy = n.position.y + ECORE_FILE_BOX_SIZE.height / 2;
+    const dist = Math.hypot(flowPosition.x - cx, flowPosition.y - cy);
+    if (dist < minDist && dist <= ECORE_DROP_SNAP_DISTANCE) {
+      minDist = dist;
+      closest = n;
+    }
+  }
+  return closest;
+}

--- a/src/components/flow/flowCanvasReactionCode.ts
+++ b/src/components/flow/flowCanvasReactionCode.ts
@@ -1,0 +1,30 @@
+import { Node } from 'reactflow';
+
+/**
+ * Package name declared inside the .ecore file, falling back to the file name
+ * and finally to a generic placeholder.
+ */
+function getEPackageName(node: Node | undefined): string {
+  const match = node?.data?.fileContent?.match(/<ecore:EPackage[^>]+name="([^"]+)"/);
+  return match?.[1] ?? node?.data?.fileName?.replace('.ecore', '') ?? 'source';
+}
+
+/**
+ * Skeleton .reactions file for a freshly drawn edge: imports both metamodels
+ * and opens an empty reactions block from source to target.
+ */
+export function buildInitialReactionCode(
+  nodes: Node[],
+  sourceNodeId: string,
+  targetNodeId: string,
+): string {
+  const sourceNode = nodes.find(n => n.id === sourceNodeId);
+  const targetNode = nodes.find(n => n.id === targetNodeId);
+
+  const sourcePackageName = getEPackageName(sourceNode);
+  const targetPackageName = getEPackageName(targetNode);
+  const sourceUri = sourceNode?.data?.nsUri ?? `http://vitruv.tools/${sourcePackageName}`;
+  const targetUri = targetNode?.data?.nsUri ?? `http://vitruv.tools/${targetPackageName}`;
+
+  return `import "${sourceUri}" as ${sourcePackageName}\nimport "${targetUri}" as ${targetPackageName}\n\nreactions: ${sourcePackageName}To${targetPackageName}\nin reaction to changes in ${sourcePackageName}\nexecute actions in ${targetPackageName}\n\n`;
+}

--- a/src/components/flow/flowCanvasRenderUtils.ts
+++ b/src/components/flow/flowCanvasRenderUtils.ts
@@ -1,8 +1,38 @@
 import React from 'react';
 import { Edge, Node, ReactFlowInstance } from 'reactflow';
-import { ConnectionDragState } from './flowCanvasTypes';
+import { ConnectionDragState, HandlePosition, PendingDeleteState } from './flowCanvasTypes';
 
-type HandlePosition = 'top' | 'bottom' | 'left' | 'right';
+/**
+ * Cursor communicating add-reaction mode: `cell` while waiting for the source
+ * box, `crosshair` once a source is picked and a target is expected.
+ */
+export function getReactionModeCursor(
+  addReactionMode: boolean | undefined,
+  reactionSourceId: string | null,
+): React.CSSProperties['cursor'] {
+  if (!addReactionMode) return undefined;
+  if (reactionSourceId) return 'crosshair';
+  return 'cell';
+}
+
+/** Wording for the delete confirmation, matched to what is actually selected. */
+export function getPendingDeleteConfirmMessage(pendingDelete: PendingDeleteState | null): string {
+  if (!pendingDelete) {
+    return 'Do you really want to remove this element from the canvas?';
+  }
+
+  const hasFile = Boolean(pendingDelete.fileId);
+  const hasEdges = pendingDelete.edgeIds.length > 0;
+  const hasOtherNodes = pendingDelete.nodeIds.length > 0;
+
+  if (hasFile && (hasEdges || hasOtherNodes)) {
+    return 'Remove the selected connection(s) and the meta model from the canvas?';
+  }
+  if (hasEdges) {
+    return 'Remove the selected connection from the canvas?';
+  }
+  return 'Do you really want to remove this element from the canvas?';
+}
 
 export interface EdgeDistributionSlot {
   edgeId: string;
@@ -172,7 +202,7 @@ export function computeConnectionLinePositions(
 }
 
 export function applyPendingCanvasDelete(
-  pendingDelete: { nodeIds: string[]; edgeIds: string[]; fileId: string | null },
+  pendingDelete: PendingDeleteState,
   removeEdge: (id: string) => void,
   removeNode: (id: string) => void,
   onEcoreFileDelete: ((id: string) => void) | undefined,

--- a/src/components/flow/flowCanvasSnapshot.ts
+++ b/src/components/flow/flowCanvasSnapshot.ts
@@ -1,0 +1,37 @@
+import { Edge, Node } from 'reactflow';
+import { MetaModelRelationRequest } from '../../services/api';
+import { WorkspaceSnapshot } from '../../types/workspace';
+import { getMetaModelSourceId } from './flowCanvasNodeLookup';
+
+/**
+ * Reduces the canvas to what the backend persists: the set of metamodels on it
+ * and the reaction relations between them. Relations whose endpoints have no
+ * resolvable metamodel id are dropped rather than sent as partial records.
+ */
+export function buildWorkspaceSnapshot(nodes: Node[], edges: Edge[]): WorkspaceSnapshot {
+  const metaModelIds = Array.from(
+    new Set(
+      nodes
+        .filter(node => node.type === 'ecoreFile')
+        .map(node => getMetaModelSourceId(nodes, node.id))
+        .filter((value): value is number => typeof value === 'number'),
+    ),
+  );
+
+  const metaModelRelationRequests: MetaModelRelationRequest[] = edges
+    .filter(edge => edge.type === 'reactions')
+    .map(edge => {
+      const sourceId = getMetaModelSourceId(nodes, edge.source);
+      const targetId = getMetaModelSourceId(nodes, edge.target);
+      const reactionFileId = typeof edge.data?.reactionFileId === 'number' ? edge.data.reactionFileId : 0;
+
+      if (typeof sourceId !== 'number' || typeof targetId !== 'number') {
+        return null;
+      }
+
+      return { sourceId, targetId, reactionFileId };
+    })
+    .filter((req): req is MetaModelRelationRequest => req !== null);
+
+  return { metaModelIds, metaModelRelationRequests };
+}

--- a/src/components/flow/flowCanvasToolLabels.ts
+++ b/src/components/flow/flowCanvasToolLabels.ts
@@ -1,0 +1,37 @@
+/** Default label placed on a node created from a palette tool. */
+const TOOL_LABELS: Record<string, Record<string, string>> = {
+  element: {
+    'class': 'Class',
+    'abstract-class': 'AbstractClass',
+    'interface': 'Interface',
+    'enumeration': 'Enumeration',
+    'package': 'Package',
+  },
+  member: {
+    'attribute': '+ attribute: Type',
+    'method': '+ method(): ReturnType',
+    'private-attribute': '- privateAttribute: Type',
+    'protected-attribute': '# protectedAttribute: Type',
+    'private-method': '- privateMethod(): ReturnType',
+    'protected-method': '# protectedMethod(): ReturnType',
+  },
+  relationship: {
+    'association': 'Association',
+    'aggregation': 'Aggregation',
+    'composition': 'Composition',
+    'inheritance': 'Inheritance',
+    'realization': 'Realization',
+    'dependency': 'Dependency',
+  },
+  multiplicity: {
+    'one': '1',
+    'many': '*',
+    'optional': '0..1',
+    'range': '1..*',
+  },
+};
+
+/** Falls back to the raw tool name for tools without a friendly label. */
+export function getToolLabel(toolType: string, toolName: string): string {
+  return TOOL_LABELS[toolType]?.[toolName] || toolName;
+}

--- a/src/components/flow/flowCanvasTypes.ts
+++ b/src/components/flow/flowCanvasTypes.ts
@@ -1,9 +1,22 @@
+/** Side of an EcoreFileBox a reaction edge attaches to. */
+export type HandlePosition = 'top' | 'bottom' | 'left' | 'right';
+
+/** Top-level canvas mode selected via the floating toggle. */
+export type CanvasMode = 'modeling' | 'constraints' | 'views';
+
 export interface ConnectionDragState {
   isActive: boolean;
   sourceNodeId: string | null;
-  sourceHandle: 'top' | 'bottom' | 'left' | 'right' | null;
+  sourceHandle: HandlePosition | null;
   currentPosition: { x: number; y: number } | null;
   sourceTipPosition: { x: number; y: number } | null;
+}
+
+/** Elements queued for removal, pending confirmation in the ConfirmDialog. */
+export interface PendingDeleteState {
+  nodeIds: string[];
+  edgeIds: string[];
+  fileId: string | null;
 }
 
 export interface CodeEditorState {

--- a/src/components/flow/flowCanvasUmlMerge.ts
+++ b/src/components/flow/flowCanvasUmlMerge.ts
@@ -1,0 +1,110 @@
+import { Edge, Node } from 'reactflow';
+import { NODE_DIMENSIONS } from './flowCanvasConstants';
+
+export interface UmlMergeData {
+  mergePointsMap: Map<string, { x: number; y: number; mergeGroupId: string }>;
+  firstInGroupMap: Map<string, string>;
+  mergeGroupSourceNodesMap: Map<string, string[]>;
+}
+
+function hasRelationshipType(data: unknown): data is { relationshipType?: string } {
+  return typeof data === 'object' && data !== null && 'relationshipType' in data;
+}
+
+/** Centre of mass of the source boxes feeding a merge group. */
+export function calculateAverageSourcePosition(
+  eligibleEdges: Edge[],
+  nodes: Node[],
+): { x: number; y: number } {
+  let sumX = 0;
+  let sumY = 0;
+  let count = 0;
+
+  eligibleEdges.forEach(edge => {
+    const sourceNode = nodes.find(n => n.id === edge.source);
+    if (sourceNode) {
+      sumX += sourceNode.position.x + NODE_DIMENSIONS.width / 2;
+      sumY += sourceNode.position.y + NODE_DIMENSIONS.height / 2;
+      count++;
+    }
+  });
+
+  return count > 0 ? { x: sumX / count, y: sumY / count } : { x: 0, y: 0 };
+}
+
+/**
+ * Places the merge point directly above/below the superclass centre so the last
+ * segment enters the box straight on rather than clipping a corner.
+ */
+export function calculateMergePoint(
+  avgSource: { x: number; y: number },
+  targetNode: Node,
+): { x: number; y: number } {
+  const targetCenterX = targetNode.position.x + NODE_DIMENSIONS.width / 2;
+  const targetCenterY = targetNode.position.y + NODE_DIMENSIONS.height / 2;
+
+  return {
+    x: targetCenterX,
+    y: avgSource.y + (targetCenterY - avgSource.y) * 0.4,
+  };
+}
+
+/**
+ * Computes fan-in merge points for UML inheritance edges sharing a superclass.
+ *
+ * Merging is deliberately limited to inheritance — several subclasses pointing
+ * at one superclass read well as a fan, whereas merging compositions and
+ * associations would obscure which class each line belongs to. A subclass that
+ * reaches the same superclass more than once is skipped, since its edges would
+ * collapse onto each other.
+ */
+export function computeUmlMergeData(edges: Edge[], nodes: Node[]): UmlMergeData {
+  const mergePointsMap: UmlMergeData['mergePointsMap'] = new Map();
+  const firstInGroupMap: UmlMergeData['firstInGroupMap'] = new Map();
+  const mergeGroupSourceNodesMap: UmlMergeData['mergeGroupSourceNodesMap'] = new Map();
+
+  const umlInheritanceEdges = edges.filter(
+    e => e.type === 'uml' && hasRelationshipType(e.data) && e.data.relationshipType === 'inheritance',
+  );
+
+  if (umlInheritanceEdges.length === 0) {
+    return { mergePointsMap, firstInGroupMap, mergeGroupSourceNodesMap };
+  }
+
+  const edgesPerSource = new Map<string, number>();
+  umlInheritanceEdges.forEach(edge => {
+    edgesPerSource.set(edge.source, (edgesPerSource.get(edge.source) || 0) + 1);
+  });
+
+  const edgesByTarget = new Map<string, Edge[]>();
+  umlInheritanceEdges.forEach(edge => {
+    const existing = edgesByTarget.get(edge.target) || [];
+    existing.push(edge);
+    edgesByTarget.set(edge.target, existing);
+  });
+
+  edgesByTarget.forEach((edgesGroup, targetId) => {
+    if (edgesGroup.length < 2) return;
+
+    const eligibleEdges = edgesGroup.filter(edge => (edgesPerSource.get(edge.source) || 0) === 1);
+    if (eligibleEdges.length < 2) return;
+
+    eligibleEdges.sort((a, b) => a.source.localeCompare(b.source));
+
+    const targetNode = nodes.find(n => n.id === targetId);
+    if (!targetNode) return;
+
+    const avgSourcePos = calculateAverageSourcePosition(eligibleEdges, nodes);
+    const mergePoint = calculateMergePoint(avgSourcePos, targetNode);
+    const mergeGroupId = `merge-${targetId}`;
+
+    mergeGroupSourceNodesMap.set(mergeGroupId, eligibleEdges.map(e => e.source));
+    eligibleEdges.forEach(edge => {
+      mergePointsMap.set(edge.id, { ...mergePoint, mergeGroupId });
+    });
+
+    firstInGroupMap.set(mergeGroupId, eligibleEdges[0].id);
+  });
+
+  return { mergePointsMap, firstInGroupMap, mergeGroupSourceNodesMap };
+}

--- a/src/components/flow/useEdgeColorMap.ts
+++ b/src/components/flow/useEdgeColorMap.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { EDGE_COLOR_LIST } from './flowCanvasConstants';
+
+/**
+ * Colours are keyed by unordered node pair, so an edge keeps its colour no
+ * matter which end it was drawn from.
+ */
+export function pairKey(a: string, b: string): string {
+  return a < b ? `${a}::${b}` : `${b}::${a}`;
+}
+
+/** Colour maps are per user *and* per project; anonymous callers share one key. */
+export function getEdgeColorStorageKey(userId?: string, vsumId?: string): string {
+  if (userId && vsumId) {
+    return `flow_edge_color_map_v1_user_${userId}_vsum_${vsumId}`;
+  }
+  return 'flow_edge_color_map_v1';
+}
+
+/**
+ * Resumes the palette after the highest-numbered colour already in use, so a
+ * reloaded session keeps handing out fresh colours instead of repeating.
+ */
+export function resolveNextColorIndex(usedColors: Iterable<string>): number {
+  const used = new Set(usedColors);
+  let maxIndex = 0;
+  EDGE_COLOR_LIST.forEach((color, i) => {
+    if (used.has(color)) maxIndex = Math.max(maxIndex, i + 1);
+  });
+  return maxIndex % EDGE_COLOR_LIST.length;
+}
+
+/**
+ * Assigns and persists a stable colour per connected metamodel pair.
+ *
+ * The map lives in a ref rather than state: colours are read during render of
+ * edges that were just created, and a re-render on assignment would be both
+ * unnecessary and a source of loops.
+ */
+export function useEdgeColorMap(userId?: string, vsumId?: string) {
+  const storageKey = getEdgeColorStorageKey(userId, vsumId);
+  const edgeColorMapRef = useRef<Map<string, string>>(new Map());
+  const nextColorIndexRef = useRef<number>(0);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (raw) {
+        const parsed = JSON.parse(raw) as Record<string, string>;
+        edgeColorMapRef.current = new Map(Object.entries(parsed));
+        nextColorIndexRef.current = resolveNextColorIndex(Object.values(parsed));
+        return;
+      }
+      edgeColorMapRef.current = new Map();
+      nextColorIndexRef.current = 0;
+    } catch (e) {
+      console.warn('Failed to load edge color map', e);
+      edgeColorMapRef.current = new Map();
+      nextColorIndexRef.current = 0;
+    }
+  }, [storageKey]);
+
+  const persistEdgeColorMap = useCallback(() => {
+    try {
+      const obj: Record<string, string> = {};
+      edgeColorMapRef.current.forEach((v, k) => {
+        obj[k] = v;
+      });
+      localStorage.setItem(storageKey, JSON.stringify(obj));
+    } catch (e) {
+      console.error('Failed to persist edge color map', e);
+    }
+  }, [storageKey]);
+
+  const getColorForPair = useCallback((idA: string, idB: string): string => {
+    const key = pairKey(idA, idB);
+    const existing = edgeColorMapRef.current.get(key);
+    if (existing) return existing;
+
+    const color = EDGE_COLOR_LIST[nextColorIndexRef.current % EDGE_COLOR_LIST.length];
+    edgeColorMapRef.current.set(key, color);
+    nextColorIndexRef.current += 1;
+    persistEdgeColorMap();
+    return color;
+  }, [persistEdgeColorMap]);
+
+  return { getColorForPair };
+}

--- a/src/components/flow/useFlowCanvasEvents.ts
+++ b/src/components/flow/useFlowCanvasEvents.ts
@@ -12,6 +12,19 @@ interface EdgeSelectionEventOptions {
   setSelectedFileId: (id: string | null) => void;
 }
 
+/** Toggles the named edge's selection and clears every other edge. */
+export function selectOnlyEdge(edges: Edge[], edgeId: string, currentlySelected: boolean): Edge[] {
+  return edges.map(edge => ({
+    ...edge,
+    selected: edge.id === edgeId ? !currentlySelected : false,
+  }));
+}
+
+/** Clears the selection flag on every node. */
+export function deselectAllNodes(nodes: Node[]): Node[] {
+  return nodes.map(node => ({ ...node, selected: false }));
+}
+
 /**
  * Selecting an edge is exclusive: it clears every other edge, all nodes, and
  * the selected-file highlight.
@@ -28,11 +41,8 @@ export function useEdgeSelectionEvents({
         currentlySelected: boolean;
       }>).detail;
 
-      setEdges(prev => prev.map(edge => ({
-        ...edge,
-        selected: edge.id === edgeId ? !currentlySelected : false,
-      })));
-      setNodes(prev => prev.map(node => ({ ...node, selected: false })));
+      setEdges(prev => selectOnlyEdge(prev, edgeId, currentlySelected));
+      setNodes(deselectAllNodes);
       setSelectedFileId(null);
     };
 

--- a/src/components/flow/useFlowCanvasEvents.ts
+++ b/src/components/flow/useFlowCanvasEvents.ts
@@ -1,0 +1,189 @@
+import { Dispatch, SetStateAction, useEffect } from 'react';
+import { Edge, Node, ReactFlowInstance } from 'reactflow';
+
+/**
+ * Child components communicate upward through window events rather than props
+ * because ReactFlow renders nodes and edges outside this component's tree.
+ */
+
+interface EdgeSelectionEventOptions {
+  setEdges: Dispatch<SetStateAction<Edge[]>>;
+  setNodes: Dispatch<SetStateAction<Node[]>>;
+  setSelectedFileId: (id: string | null) => void;
+}
+
+/**
+ * Selecting an edge is exclusive: it clears every other edge, all nodes, and
+ * the selected-file highlight.
+ */
+export function useEdgeSelectionEvents({
+  setEdges,
+  setNodes,
+  setSelectedFileId,
+}: EdgeSelectionEventOptions): void {
+  useEffect(() => {
+    const handleEdgeClick = (e: Event) => {
+      const { edgeId, currentlySelected } = (e as CustomEvent<{
+        edgeId: string;
+        currentlySelected: boolean;
+      }>).detail;
+
+      setEdges(prev => prev.map(edge => ({
+        ...edge,
+        selected: edge.id === edgeId ? !currentlySelected : false,
+      })));
+      setNodes(prev => prev.map(node => ({ ...node, selected: false })));
+      setSelectedFileId(null);
+    };
+
+    globalThis.addEventListener('edge-clicked', handleEdgeClick as EventListener);
+    return () => {
+      globalThis.removeEventListener('edge-clicked', handleEdgeClick as EventListener);
+    };
+  }, [setEdges, setNodes, setSelectedFileId]);
+}
+
+interface EdgeControlPointEventOptions {
+  reactFlowInstance: ReactFlowInstance | null;
+  updateEdgeControlPoint: (edgeId: string, controlPoint: { x: number; y: number } | null) => void;
+}
+
+/**
+ * Dragging a UML edge's control handle. The drag event carries screen
+ * coordinates and has to be projected into flow space; the drop event already
+ * carries a flow-space point (or `null` to reset to the default curve).
+ */
+export function useEdgeControlPointEvents({
+  reactFlowInstance,
+  updateEdgeControlPoint,
+}: EdgeControlPointEventOptions): void {
+  useEffect(() => {
+    const handleControlDrag = (e: Event) => {
+      const { edgeId, x, y } = (e as CustomEvent<{ edgeId: string; x: number; y: number }>).detail;
+      if (!reactFlowInstance) return;
+      updateEdgeControlPoint(edgeId, reactFlowInstance.screenToFlowPosition({ x, y }));
+    };
+
+    const handleControlDrop = (e: Event) => {
+      const { edgeId, point } = (e as CustomEvent<{
+        edgeId: string;
+        point: { x: number; y: number } | null;
+      }>).detail;
+      updateEdgeControlPoint(edgeId, point);
+    };
+
+    globalThis.addEventListener('uml-edge-control-drag', handleControlDrag as EventListener);
+    globalThis.addEventListener('uml-edge-control-drop', handleControlDrop as EventListener);
+    return () => {
+      globalThis.removeEventListener('uml-edge-control-drag', handleControlDrag as EventListener);
+      globalThis.removeEventListener('uml-edge-control-drop', handleControlDrop as EventListener);
+    };
+  }, [reactFlowInstance, updateEdgeControlPoint]);
+}
+
+interface WorkspaceLayoutEventOptions {
+  autoLayoutEcoreBoxes: () => void;
+  fitEcoreWorkspace: () => void;
+}
+
+/** Toolbar buttons outside this subtree trigger layout via window events. */
+export function useWorkspaceLayoutEvents({
+  autoLayoutEcoreBoxes,
+  fitEcoreWorkspace,
+}: WorkspaceLayoutEventOptions): void {
+  useEffect(() => {
+    const handleAutoLayout = () => autoLayoutEcoreBoxes();
+    const handleFitEcore = () => fitEcoreWorkspace();
+
+    globalThis.addEventListener('vitruv.autoLayoutWorkspace', handleAutoLayout as EventListener);
+    globalThis.addEventListener('vitruv.fitEcoreWorkspace', handleFitEcore as EventListener);
+    return () => {
+      globalThis.removeEventListener('vitruv.autoLayoutWorkspace', handleAutoLayout as EventListener);
+      globalThis.removeEventListener('vitruv.fitEcoreWorkspace', handleFitEcore as EventListener);
+    };
+  }, [autoLayoutEcoreBoxes, fitEcoreWorkspace]);
+}
+
+interface ReactionEdgeCreationEventOptions {
+  readOnly: boolean;
+  createReactionEdgeFromEvent: (detail: {
+    sourceNodeId: string;
+    targetNodeId: string;
+    code: string;
+    originalEdgeId: number;
+  }) => void;
+}
+
+/** `vitruv.createReactionEdge` — raised when a reaction is authored elsewhere. */
+export function useReactionEdgeCreationEvents({
+  readOnly,
+  createReactionEdgeFromEvent,
+}: ReactionEdgeCreationEventOptions): void {
+  useEffect(() => {
+    const handleCreateReactionEdge = (e: Event) => {
+      if (readOnly) return;
+      const custom = e as CustomEvent<{
+        sourceNodeId: string;
+        targetNodeId: string;
+        code: string;
+        originalEdgeId: number;
+      }>;
+      createReactionEdgeFromEvent(custom.detail);
+    };
+
+    globalThis.addEventListener('vitruv.createReactionEdge', handleCreateReactionEdge as EventListener);
+    return () => {
+      globalThis.removeEventListener('vitruv.createReactionEdge', handleCreateReactionEdge as EventListener);
+    };
+  }, [readOnly, createReactionEdgeFromEvent]);
+}
+
+export interface MetaModelRelation {
+  id: number;
+  sourceId: number;
+  targetId: number;
+  reactionFileId: number | null;
+}
+
+/** Normalises the several field spellings the backend has used over time. */
+export function normalizeMetaModelRelations(
+  raw: Array<Record<string, unknown>> | undefined,
+): MetaModelRelation[] {
+  return (raw ?? [])
+    .map(rel => ({
+      id: typeof rel.id === 'number' ? rel.id : 0,
+      sourceId: (rel.sourceId ?? rel.sourceMetaModelId) as number,
+      targetId: (rel.targetId ?? rel.targetMetaModelId) as number,
+      reactionFileId: (rel.reactionFileId ?? rel.reactionFileStorageId ?? null) as number | null,
+    }))
+    .filter(rel => typeof rel.sourceId === 'number' && typeof rel.targetId === 'number');
+}
+
+interface MetaModelRelationEventOptions {
+  processRelation: (relation: MetaModelRelation, preserveExisting: boolean) => void;
+}
+
+/** `vitruv.loadMetaModelRelations` / `vitruv.loadRelations` — both carry the same payload. */
+export function useMetaModelRelationEvents({
+  processRelation,
+}: MetaModelRelationEventOptions): void {
+  useEffect(() => {
+    const handleLoadMetaModelRelations = (e: Event) => {
+      const custom = e as CustomEvent<{
+        relations?: Array<Record<string, unknown>>;
+        preserveExisting?: boolean;
+      }>;
+
+      const preserveExisting = custom.detail?.preserveExisting ?? false;
+      normalizeMetaModelRelations(custom.detail?.relations)
+        .forEach(relation => processRelation(relation, preserveExisting));
+    };
+
+    globalThis.addEventListener('vitruv.loadMetaModelRelations', handleLoadMetaModelRelations);
+    globalThis.addEventListener('vitruv.loadRelations', handleLoadMetaModelRelations);
+    return () => {
+      globalThis.removeEventListener('vitruv.loadMetaModelRelations', handleLoadMetaModelRelations);
+      globalThis.removeEventListener('vitruv.loadRelations', handleLoadMetaModelRelations);
+    };
+  }, [processRelation]);
+}


### PR DESCRIPTION
Closes #422.

`FlowCanvas.tsx` had grown to 2740 lines, mixing layout maths, edge construction, window-event plumbing, and presentational chrome into a single component. This splits those responsibilities out and leaves `FlowCanvas` holding canvas state, the ReactFlow wiring, and the imperative handle.

**`FlowCanvas.tsx`: 2740 → 1355 lines.**

## What moved where

**Pure utilities** — `src/components/flow/`

| Module | Responsibility |
|---|---|
| `flowCanvasHandleUtils` | Which handles face each other, and re-pointing edges after a move |
| `flowCanvasEdgeDistribution` | Slot metadata that fans parallel edges along a box side |
| `flowCanvasAutoLayout` | Force-directed workspace layout (config, forces, components) |
| `flowCanvasUmlMerge` | Fan-in merge points for inheritance edges |
| `flowCanvasEdgeReorder` | Reordering edges that share a handle |
| `flowCanvasEdgeHygiene` | Orphan removal and the three id de-duplication passes |
| `flowCanvasEdgeFactory` | One construction point for reaction edges |
| `flowCanvasNodeLookup` | Metamodel id resolution and drop-target hit testing |
| `flowCanvasSnapshot` | Workspace snapshot for persistence |
| `flowCanvasReactionCode` | Initial `.reactions` skeleton |
| `flowCanvasToolLabels` | Palette tool labels |
| `flowCanvasConstants` | Shared node/box dimensions and the edge palette |

