### PR TITLE
Allow viewers to move shapes in the VSUM canvas

### DIFF
--- a/src/__tests__/components/flow/flowCanvasNodeChangeUtils.test.ts
+++ b/src/__tests__/components/flow/flowCanvasNodeChangeUtils.test.ts
@@ -1,0 +1,51 @@
+import {
+  getNodeDragFlags,
+  isReadOnlyBlockedEdgeChange,
+  isReadOnlyBlockedNodeChange,
+} from '../../../components/flow/flowCanvasNodeChangeUtils';
+
+describe('isReadOnlyBlockedNodeChange', () => {
+  it('blocks removing a node', () => {
+    expect(isReadOnlyBlockedNodeChange({ type: 'remove' })).toBe(true);
+  });
+
+  it('allows a node to be dragged', () => {
+    expect(isReadOnlyBlockedNodeChange({ type: 'position', dragging: true })).toBe(false);
+  });
+
+  it('allows the settling position when a drag ends', () => {
+    expect(isReadOnlyBlockedNodeChange({ type: 'position', dragging: false })).toBe(false);
+  });
+
+  it('allows selection and dimension changes', () => {
+    expect(isReadOnlyBlockedNodeChange({ type: 'select' })).toBe(false);
+    expect(isReadOnlyBlockedNodeChange({ type: 'dimensions' })).toBe(false);
+  });
+});
+
+describe('isReadOnlyBlockedEdgeChange', () => {
+  it('blocks removing an edge', () => {
+    expect(isReadOnlyBlockedEdgeChange({ type: 'remove' })).toBe(true);
+  });
+
+  it('allows selecting an edge', () => {
+    expect(isReadOnlyBlockedEdgeChange({ type: 'select' })).toBe(false);
+  });
+});
+
+describe('getNodeDragFlags', () => {
+  it('reports an in-flight drag', () => {
+    expect(getNodeDragFlags([{ type: 'position', dragging: true }]))
+      .toEqual({ isDragging: true, dragEnded: false });
+  });
+
+  it('reports a finished drag', () => {
+    expect(getNodeDragFlags([{ type: 'position', dragging: false }]))
+      .toEqual({ isDragging: false, dragEnded: true });
+  });
+
+  it('reports neither for unrelated changes', () => {
+    expect(getNodeDragFlags([{ type: 'select' }]))
+      .toEqual({ isDragging: false, dragEnded: false });
+  });
+});

--- a/src/__tests__/components/flow/flowCanvasRenderUtils.test.ts
+++ b/src/__tests__/components/flow/flowCanvasRenderUtils.test.ts
@@ -1,0 +1,105 @@
+import { Node } from 'reactflow';
+import {
+  mapEcoreFlowNode,
+  mapEditableFlowNode,
+} from '../../../components/flow/flowCanvasRenderUtils';
+
+const ecoreNode = (id = 'ecore-1'): Node =>
+  ({ id, position: { x: 0, y: 0 }, data: { fileName: 'A.ecore' }, type: 'ecoreFile' } as Node);
+
+const editableNode = (id = 'uml-1'): Node =>
+  ({ id, position: { x: 0, y: 0 }, data: { label: 'Class' }, type: 'editable' } as Node);
+
+const ecoreOptions = (overrides: Record<string, unknown> = {}) => ({
+  readOnly: false,
+  expandedFileId: null,
+  selectedFileId: null,
+  connectionDragState: null,
+  addReactionMode: false,
+  reactionSourceId: null,
+  constraintHighlightNodeId: null,
+  constraintFilterNodeId: null,
+  edgeDistribution: undefined,
+  handleEcoreFileExpand: jest.fn(),
+  handleEcoreFileSelect: jest.fn(),
+  onEcoreFileDelete: jest.fn(),
+  handleRequestDelete: jest.fn(),
+  onEcoreFileRename: jest.fn(),
+  handleShowDetails: jest.fn(),
+  handleConnectionStart: jest.fn(),
+  ...overrides,
+});
+
+describe('mapEcoreFlowNode', () => {
+  it('is draggable for an editor', () => {
+    expect(mapEcoreFlowNode(ecoreNode(), ecoreOptions()).draggable).toBe(true);
+  });
+
+  it('is draggable for a viewer, so large models can be rearranged locally', () => {
+    expect(mapEcoreFlowNode(ecoreNode(), ecoreOptions({ readOnly: true })).draggable).toBe(true);
+  });
+
+  it('freezes while a connection is being dragged', () => {
+    const options = ecoreOptions({ connectionDragState: { isActive: true } });
+
+    expect(mapEcoreFlowNode(ecoreNode(), options).draggable).toBe(false);
+  });
+
+  it('freezes in add-reaction mode, where a drag would fight the click gesture', () => {
+    const options = ecoreOptions({ addReactionMode: true });
+
+    expect(mapEcoreFlowNode(ecoreNode(), options).draggable).toBe(false);
+  });
+
+  it('still withholds delete and rename from a viewer', () => {
+    const mapped = mapEcoreFlowNode(ecoreNode(), ecoreOptions({ readOnly: true }));
+
+    expect(mapped.data.onDelete).toBeUndefined();
+    expect(mapped.data.onRequestDelete).toBeUndefined();
+    expect(mapped.data.onRename).toBeUndefined();
+    expect(mapped.data.readOnly).toBe(true);
+  });
+
+  it('still withholds connection starting from a viewer', () => {
+    const mapped = mapEcoreFlowNode(
+      ecoreNode(),
+      ecoreOptions({ readOnly: true, handleConnectionStart: jest.fn() }),
+    );
+
+    expect(mapped.data.onConnectionStart).toBeUndefined();
+  });
+
+  it('keeps delete and rename available to an editor', () => {
+    const mapped = mapEcoreFlowNode(ecoreNode(), ecoreOptions());
+
+    expect(mapped.data.onDelete).toBeDefined();
+    expect(mapped.data.onRename).toBeDefined();
+  });
+});
+
+describe('mapEditableFlowNode', () => {
+  const labelChange = jest.fn();
+  const removeNode = jest.fn();
+
+  it('is draggable for an editor', () => {
+    expect(mapEditableFlowNode(editableNode(), false, labelChange, removeNode).draggable).toBe(true);
+  });
+
+  it('is draggable for a viewer', () => {
+    expect(mapEditableFlowNode(editableNode(), true, labelChange, removeNode).draggable).toBe(true);
+  });
+
+  it('still withholds label editing and deletion from a viewer', () => {
+    const mapped = mapEditableFlowNode(editableNode(), true, labelChange, removeNode);
+
+    expect(mapped.data.onLabelChange).toBeUndefined();
+    expect(mapped.data.onDelete).toBeUndefined();
+  });
+
+  it('keeps label editing and deletion available to an editor', () => {
+    const mapped = mapEditableFlowNode(editableNode(), false, labelChange, removeNode);
+
+    expect(mapped.data.onLabelChange).toBe(labelChange);
+    expect(mapped.data.onDelete).toBe(removeNode);
+  });
+});

--- a/src/components/flow/FlowCanvas.tsx
+++ b/src/components/flow/FlowCanvas.tsx
@@ -1187,6 +1187,9 @@ export const FlowCanvas = forwardRef<FlowCanvasHandle, FlowCanvasProps>(
     const connectionLinePositions = computeConnectionLinePositions(connectionDragState, reactFlowInstance);
     const umlViewActive = !!umlModalOpen;
     const interactionsAllowed = umlViewActive || readOnly || isInteractive;
+    // Viewers can reposition nodes to read a large model; they still cannot
+    // create, delete, connect, rename, or save anything.
+    const nodesMovable = umlViewActive || readOnly || (editable && !connectionDragState?.isActive);
 
     const handleSelectCanvasMode = useCallback((mode: CanvasMode) => {
       setActiveCanvasMode(mode);
@@ -1223,7 +1226,7 @@ export const FlowCanvas = forwardRef<FlowCanvasHandle, FlowCanvasProps>(
             setViewport(instance.getViewport());
           }}
           onMove={(_event, vp) => setViewport(vp)}
-          nodesDraggable={umlViewActive || (editable && !connectionDragState?.isActive)}
+          nodesDraggable={nodesMovable}
           nodesConnectable={!umlViewActive && editable}
           elementsSelectable={interactionsAllowed}
           edgesUpdatable={false}

--- a/src/components/flow/flowCanvasNodeChangeUtils.ts
+++ b/src/components/flow/flowCanvasNodeChangeUtils.ts
@@ -2,10 +2,14 @@ import { Node } from 'reactflow';
 import { Circle, clampToCircle } from '../../hooks/useCircleContainment';
 import { ecoreRectsOverlap } from './flowCanvasLayoutUtils';
 
-export function isReadOnlyBlockedNodeChange(change: { type?: string; dragging?: boolean }): boolean {
-  if (change.type === 'remove') return true;
-  if (change.type === 'position' && change.dragging) return true;
-  return false;
+/**
+ * Viewers may reposition nodes to read a large model, so `position` changes are
+ * allowed through; only structural edits are blocked. Positions are never part
+ * of the workspace snapshot, so moving a node cannot reach the backend or mark
+ * the project dirty.
+ */
+export function isReadOnlyBlockedNodeChange(change: { type?: string }): boolean {
+  return change.type === 'remove';
 }
 
 export function isReadOnlyBlockedEdgeChange(change: { type?: string }): boolean {

--- a/src/components/flow/flowCanvasRenderUtils.ts
+++ b/src/components/flow/flowCanvasRenderUtils.ts
@@ -225,7 +225,9 @@ export function mapEditableFlowNode(
 ): Node {
   return {
     ...node,
-    draggable: !readOnly,
+    // Draggable for viewers too, matching the ecore boxes — the label and
+    // delete affordances below stay gated on readOnly.
+    draggable: true,
     data: {
       ...node.data,
       onLabelChange: readOnly ? undefined : handleLabelChange,
@@ -298,6 +300,9 @@ export function mapEcoreFlowNode(
       isConstraintFilter: constraintFilterNodeId === node.id,
     },
     selected: selectedFileId === node.id,
-    draggable: !readOnly && !connectionDragState?.isActive && !addReactionMode,
+    // Draggable for viewers too — repositioning is local-only (see
+    // isReadOnlyBlockedNodeChange). Still frozen mid-connection and in
+    // add-reaction mode, where a drag would fight the click-to-target gesture.
+    draggable: !connectionDragState?.isActive && !addReactionMode,
   };
 }


### PR DESCRIPTION
Closes #433.

A shared project opened with the **Viewer** role rendered a canvas that panned and zoomed but whose nodes would not move, so larger models were awkward to inspect.

## Why it was frozen

Three independent guards all had to agree before a node could be dragged, and read-only failed every one of them:

