### PR TITLE
Stop downgrading a project owner to viewer on their own project

### DIFF
--- a/src/__tests__/utils/vsumMemberUtils.test.ts
+++ b/src/__tests__/utils/vsumMemberUtils.test.ts
@@ -9,6 +9,7 @@ import {
   readStoredProjectAccess,
   resolveProjectAccessRole,
   resolveVsumAccessRole,
+  sharedByFromOwner,
   sharedByFromVsum,
   sharedByToMember,
   uniqueVsumMembers,
@@ -25,6 +26,65 @@ describe('vsumMemberUtils', () => {
       { id: 2, vsumId: 9, firstName: 'Bob', lastName: 'Viewer', email: 'bob@example.com', role: 'VIEWER', createdAt: '' },
     ]);
     expect(owner?.email).toBe('ada@example.com');
+  });
+
+  describe('sharedByFromOwner', () => {
+    const owner = {
+      id: 1, vsumId: 9, firstName: 'Ada', lastName: 'Lovelace',
+      email: 'ada@example.com', role: 'OWNER' as const, createdAt: '',
+    };
+
+    it('returns the owner contact when someone else owns the project', () => {
+      expect(sharedByFromOwner(owner, 'bob@example.com')).toEqual({
+        firstName: 'Ada', lastName: 'Lovelace', email: 'ada@example.com',
+      });
+    });
+
+    it('returns null when the owner is the current user', () => {
+      expect(sharedByFromOwner(owner, 'ada@example.com')).toBeNull();
+    });
+
+    it('compares e-mail addresses case-insensitively', () => {
+      expect(sharedByFromOwner(owner, 'ADA@Example.COM')).toBeNull();
+    });
+
+    it('returns null without an owner', () => {
+      expect(sharedByFromOwner(null, 'ada@example.com')).toBeNull();
+    });
+
+    it('still returns the contact when the current user is unknown', () => {
+      expect(sharedByFromOwner(owner, undefined)?.email).toBe('ada@example.com');
+    });
+  });
+
+  it('keeps an owner as OWNER after their own member list loads', () => {
+    // Regression: the member list always contains an OWNER, and recording that
+    // owner as `sharedBy` made resolveProjectAccessRole infer shared access and
+    // downgrade the owner to VIEWER on their own project.
+    const members = [
+      { id: 1, vsumId: 5, firstName: 'Ada', lastName: 'L', email: 'ada@example.com', role: 'OWNER' as const, createdAt: '' },
+    ];
+    const me = 'ada@example.com';
+
+    mergeStoredProjectAccess(5, { accessRole: 'OWNER' });
+    const sharedBy = sharedByFromOwner(findVsumOwner(members), me);
+    if (sharedBy) mergeStoredProjectAccess(5, { sharedBy });
+
+    expect(sharedBy).toBeNull();
+    expect(readStoredProjectAccess(5)?.sharedBy ?? null).toBeNull();
+    expect(resolveProjectAccessRole(5, 'OWNER')).toBe('OWNER');
+  });
+
+  it('still downgrades to VIEWER when the project really was shared', () => {
+    const members = [
+      { id: 1, vsumId: 6, firstName: 'Ada', lastName: 'L', email: 'ada@example.com', role: 'OWNER' as const, createdAt: '' },
+    ];
+
+    const sharedBy = sharedByFromOwner(findVsumOwner(members), 'bob@example.com');
+    if (sharedBy) mergeStoredProjectAccess(6, { sharedBy });
+
+    expect(sharedBy?.email).toBe('ada@example.com');
+    expect(resolveProjectAccessRole(6, 'OWNER')).toBe('VIEWER');
   });
 
   it('normalizes access roles', () => {

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -35,6 +35,7 @@ import { createCanvasTabInstanceId } from '../utils/canvasTabId';
 import {
   findMembershipForEmail,
   findVsumOwner,
+  sharedByFromOwner,
   parseVsumMembersResponse,
   pickMostRestrictiveRole,
   readStoredProjectAccess,
@@ -442,14 +443,13 @@ export const CanvasPage: React.FC = () => {
     const owner = findVsumOwner(unique);
     if (owner) {
       setProjectSharer(owner);
-      if (options?.vsumId) {
-        mergeStoredProjectAccess(options.vsumId, {
-          sharedBy: {
-            firstName: owner.firstName,
-            lastName: owner.lastName,
-            email: owner.email,
-          },
-        });
+      const ownerSharedBy = sharedByFromOwner(owner, user?.email);
+      if (options?.vsumId && ownerSharedBy) {
+        mergeStoredProjectAccess(options.vsumId, { sharedBy: ownerSharedBy });
+      } else if (options?.vsumId) {
+        // We own this project. Record that explicitly and drop any stale
+        // shared-by, otherwise the owner is read back as a viewer.
+        mergeStoredProjectAccess(options.vsumId, { accessRole: 'OWNER', sharedBy: null });
       }
     } else if (sharedBy && options?.vsumId) {
       setProjectSharer(sharedByToMember(sharedBy, options.vsumId));

--- a/src/utils/vsumMemberUtils.ts
+++ b/src/utils/vsumMemberUtils.ts
@@ -132,6 +132,31 @@ export function findVsumOwner(members: VsumUserResponse[]): VsumUserResponse | n
   ) ?? null;
 }
 
+/**
+ * Contact for the person who shared a project with the current user, derived
+ * from the project's owner.
+ *
+ * Returns null when the owner *is* the current user. Nobody shared the project
+ * with you, and `resolveProjectAccessRole` reads a stored `sharedBy` as proof
+ * of shared access — so recording yourself here downgrades an owner to VIEWER.
+ */
+export function sharedByFromOwner(
+  owner: VsumUserResponse | null | undefined,
+  currentUserEmail?: string,
+): SharedByContact | null {
+  if (!owner) return null;
+
+  const ownerEmail = owner.email?.toLowerCase();
+  const selfEmail = currentUserEmail?.toLowerCase();
+  if (ownerEmail && selfEmail && ownerEmail === selfEmail) return null;
+
+  return {
+    firstName: owner.firstName,
+    lastName: owner.lastName,
+    email: owner.email,
+  };
+}
+
 export function findMembershipForEmail(
   members: VsumUserResponse[],
   email?: string,


### PR DESCRIPTION
Closes #439.

## Problem

A project owner gets a read-only canvas on a project they own — no edit, delete, rename, connect or save — and the header shows a "Shared by …" label naming themselves.

Verified on a freshly created project by reading the rendered node's props rather than inferring from the UI:

```
data.readOnly:      true
onDelete:           undefined
onRename:           undefined
onConnectionStart:  undefined
```
## Cause

`applyProjectMembers` recorded the project's owner as the person who shared it, with no check for whether that owner is the signed-in user:

Related, but separate: this branch is independent of #433 / PR #438 touch `FlowCanvas` and its render utils, while this touches `CanvasPage` and `vsumMemberUtils`. Both are based on `develop` and do not overlap.
