### PR TITLE
Move the OTP verification page onto the new auth UI

### DIFF
--- a/src/__tests__/pages/OtpVerificationPage.test.tsx
+++ b/src/__tests__/pages/OtpVerificationPage.test.tsx
@@ -94,7 +94,7 @@ describe('OtpVerificationPage', () => {
   it('displays the countdown timer starting at 5:00', () => {
     render(<OtpVerificationPage />);
 
-    expect(screen.getByText(/Time Remaining/i)).toBeInTheDocument();
+    expect(screen.getByText(/Code expires in/i)).toBeInTheDocument();
     expect(screen.getByText('5:00')).toBeInTheDocument();
   });
 
@@ -106,7 +106,7 @@ describe('OtpVerificationPage', () => {
     });
 
     expect(
-      screen.getByRole('button', { name: /Resend Verification Code/i })
+      screen.getByRole('button', { name: /Resend code/i })
     ).toBeInTheDocument();
   });
 
@@ -119,7 +119,7 @@ describe('OtpVerificationPage', () => {
       jest.advanceTimersByTime(5 * 60 * 1000);
     });
 
-    const resendButton = screen.getByRole('button', { name: /Resend Verification Code/i });
+    const resendButton = screen.getByRole('button', { name: /Resend code/i });
     await userEvent.click(resendButton);
 
     expect(mockResendOtp).toHaveBeenCalled();
@@ -128,10 +128,10 @@ describe('OtpVerificationPage', () => {
     ).toBeInTheDocument();
   });
 
-  it('navigates back to login when Go to Sign In is clicked', async () => {
+  it('navigates back to login when Back to Sign In is clicked', async () => {
     render(<OtpVerificationPage />);
 
-    const goToLoginButton = screen.getByRole('button', { name: /Go to Sign In/i });
+    const goToLoginButton = screen.getByRole('button', { name: /Back to Sign In/i });
     await userEvent.click(goToLoginButton);
 
     expect(mockNavigate).toHaveBeenCalledWith('/login');

--- a/src/components/auth/AuthLayout.tsx
+++ b/src/components/auth/AuthLayout.tsx
@@ -443,6 +443,72 @@ const AUTH_STYLES = `
   .password-requirement.ok   { color: #1f9f92; }
   .password-requirement.fail { color: #94a3b8; }
   .password-requirement-icon { font-size: 10px; }
+
+  /* OTP verification */
+  /* Scoped under .mock-form-group so it outranks the shared input rule above,
+     which would otherwise keep the code at the standard 14px field size. */
+  .mock-form-group input.otp-code-input {
+    text-align: center;
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: 0.4em;
+    /* Offsets the trailing letter-spacing so the digits sit optically centred. */
+    text-indent: 0.4em;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .otp-status {
+    padding: 10px 12px;
+    border-radius: 8px;
+    margin-bottom: 16px;
+    font-size: 13px;
+    line-height: 1.45;
+    white-space: pre-line;
+  }
+  .otp-status-success { background: #ecfdf5; color: #065f46; }
+  .otp-status-warning { background: #fffbeb; color: #92400e; }
+
+  .otp-timer {
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    gap: 8px;
+    margin: 2px 0 18px;
+    font-size: 13px;
+    color: #64748b;
+  }
+  .otp-timer-value {
+    font-size: 18px;
+    font-weight: 700;
+    color: #1f9f92;
+    font-variant-numeric: tabular-nums;
+  }
+  .otp-timer-value.is-expiring { color: #dc2626; }
+
+  .otp-resend {
+    margin-top: 18px;
+    text-align: center;
+    font-size: 14px;
+    color: #475569;
+  }
+  .otp-resend-button {
+    background: none;
+    border: none;
+    color: #00876c;
+    font-weight: 700;
+    font-size: 14px;
+    cursor: pointer;
+    padding: 0;
+  }
+  .otp-resend-button:hover:not(:disabled) { color: #00755d; text-decoration: underline; }
+  .otp-resend-button:disabled { color: #94a3b8; cursor: not-allowed; }
+
+  .otp-help {
+    margin: 0 0 10px 0;
+    font-size: 12px;
+    color: #64748b;
+    line-height: 1.55;
+  }
 `;
 
 // ── AuthErrorBanner ────────────────────────────────────────────────────────────

--- a/src/pages/OtpVerificationPage.tsx
+++ b/src/pages/OtpVerificationPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { apiService } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
-import '../components/auth/Auth.css';
+import { AuthErrorBanner, AuthLayout } from '../components/auth/AuthLayout';
 
 const OTP_DURATION = 5 * 60; // 5 minutes in seconds
 
@@ -214,217 +214,95 @@ export function OtpVerificationPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.state, navigate]);
 
+  const verifyDisabled = isVerifying || !otpCode || failedAttempts >= MAX_ATTEMPTS;
+  const attemptsLeft = MAX_ATTEMPTS - failedAttempts;
+
   return (
-    <div 
-      className="auth-container"
-      style={{
-        backgroundImage: `url(${process.env.PUBLIC_URL}/assets/vitruvius1.png)`,
-        backgroundSize: 'contain',
-        backgroundPosition: 'center center',
-        backgroundRepeat: 'no-repeat',
-        backgroundColor: '#f0f0f0'
-      }}
-    >
-      <div className="auth-card" style={{ maxWidth: 480 }}>
-        <div className="auth-header">
-          <h1>Email Verification</h1>
-          <p>Please enter the latest verification code sent to your email</p>
-          <p style={{ marginTop: 6, fontSize: 12, color: '#6b7280' }}>
-            If a new code is sent, all previous codes become invalid.
-          </p>
-        </div>
+    <AuthLayout>
+      <div className="mock-auth-header">
+        <h1>Email Verification</h1>
+        <p>Enter the latest verification code sent to your email</p>
+      </div>
 
-        <form onSubmit={handleVerifyOtp} className="auth-form">
-          {error && (
-            <div className="error-message" style={{ display: 'block' }}>
-              <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
-                <span className="error-icon">⚠️</span>
-                <div style={{ flex: 1 }}>
-                  {error}
-                  {error.includes('session expired') && (
-                    <div style={{ marginTop: 12 }}>
-                      <button
-                        type="button"
-                        onClick={() => navigate('/login')}
-                        style={{
-                          padding: '8px 16px',
-                          background: '#049484',
-                          color: 'white',
-                          border: 'none',
-                          borderRadius: 6,
-                          fontWeight: 600,
-                          cursor: 'pointer',
-                          fontSize: 13,
-                        }}
-                      >
-                        Go to Sign In
-                      </button>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          )}
+      <form onSubmit={handleVerifyOtp} className="mock-auth-form">
+        <AuthErrorBanner message={error} />
 
-          {success && (
-            <div style={{
-              padding: '14px 16px',
-              background: '#d5f4e6',
-              border: '2px solid #a9dfbf',
-              borderRadius: 8,
-              color: '#166534',
-              fontSize: 14,
-              marginBottom: 20,
-              fontWeight: 500,
-              lineHeight: 1.5,
-            }}>
-              {success}
-            </div>
-          )}
-
-          {/* Show attempts warning after first failure */}
-          {failedAttempts > 0 && failedAttempts < MAX_ATTEMPTS && !error && (
-            <div style={{
-              padding: '12px 14px',
-              background: '#fff3cd',
-              border: '2px solid #ffc107',
-              borderRadius: 8,
-              color: '#856404',
-              fontSize: 13,
-              marginBottom: 16,
-              fontWeight: 500,
-              lineHeight: 1.5,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
-            }}>
-              <span style={{ fontSize: 16 }}>⚠️</span>
-              <div>
-                <strong>Verification attempts:</strong> {failedAttempts}/{MAX_ATTEMPTS} used
-                <br />
-                <span style={{ fontSize: 12 }}>
-                  {MAX_ATTEMPTS - failedAttempts} attempts remaining before requiring sign-in
-                </span>
-              </div>
-            </div>
-          )}
-
-          <div className="form-group">
-            <label htmlFor="otpCode">Verification Code</label>
-            <input
-              type="text"
-              id="otpCode"
-              name="otpCode"
-              value={otpCode}
-              onChange={(e) => {
-                setOtpCode(e.target.value);
-                setError(null);
-              }}
-              placeholder="Enter OTP code"
-              disabled={isVerifying}
-              required
-              style={{
-                fontSize: 18,
-                letterSpacing: '0.5em',
-                textAlign: 'center',
-                fontWeight: 600,
-              }}
-            />
-          </div>
-
-          {/* Timer Display */}
-          <div style={{
-            textAlign: 'center',
-            marginBottom: 20,
-            padding: '12px',
-            background: timeLeft <= 60 ? '#fef2f2' : '#f0f7ff',
-            border: `2px solid ${timeLeft <= 60 ? '#fecaca' : '#bfdbfe'}`,
-            borderRadius: 8,
-          }}>
-            <div style={{
-              fontSize: 13,
-              color: '#6b7280',
-              marginBottom: 4,
-              fontWeight: 500,
-            }}>
-              Time Remaining
-            </div>
-            <div style={{
-              fontSize: 28,
-              fontWeight: 700,
-              color: timeLeft <= 60 ? '#dc2626' : '#049484',
-              fontFamily: 'monospace',
-            }}>
-              {formatTime(timeLeft)}
-            </div>
-          </div>
-
-          <button
-            type="submit"
-            className="auth-button primary"
-            disabled={isVerifying || !otpCode || failedAttempts >= MAX_ATTEMPTS}
-            style={{
-              background: (isVerifying || !otpCode || failedAttempts >= MAX_ATTEMPTS) ? '#95a5a6' : 'linear-gradient(135deg, #049484 0%, #037368 100%)',
-              opacity: (isVerifying || !otpCode || failedAttempts >= MAX_ATTEMPTS) ? 0.6 : 1,
-            }}
-          >
-            {isVerifying ? (
-              <span className="loading-spinner">
-                <div className="spinner"></div>
-                Verifying...
-              </span>
-            ) : (
-              'Verify Email'
-            )}
-          </button>
-
-          {/* Resend OTP Link */}
-          {canResend && (
-            <div style={{
-              textAlign: 'center',
-              marginTop: 20,
-              padding: '12px',
-              background: '#f9fafb',
-              border: '1px solid #e5e7eb',
-              borderRadius: 8,
-            }}>
-              <p style={{ margin: '0 0 8px 0', fontSize: 13, color: '#6b7280' }}>
-                Didn't receive the code?
-              </p>
-              <button
-                type="button"
-                className="link-button"
-                onClick={handleResendOtp}
-                disabled={isResending}
-                style={{
-                  fontSize: 14,
-                  color: '#049484',
-                  fontWeight: 600,
-                  cursor: isResending ? 'not-allowed' : 'pointer',
-                  opacity: isResending ? 0.6 : 1,
-                }}
-              >
-                {isResending ? 'Sending...' : 'Resend Verification Code'}
-              </button>
-            </div>
-          )}
-        </form>
-
-        <div className="auth-footer">
-          <p style={{ fontSize: 12, color: '#6b7280', lineHeight: 1.5 }}>
-            Please check your inbox and spam folder for the verification code. 
-            The code is valid for 5 minutes.
-          </p>
+        {error?.includes('session expired') && (
           <button
             type="button"
-            className="link-button"
+            className="mock-action-button"
             onClick={() => navigate('/login')}
-            style={{ marginTop: 12 }}
+            style={{ marginBottom: 16 }}
           >
             Go to Sign In
           </button>
+        )}
+
+        {success && <div className="otp-status otp-status-success">{success}</div>}
+
+        {/* Attempts warning after the first failure, unless an error already says so */}
+        {failedAttempts > 0 && failedAttempts < MAX_ATTEMPTS && !error && (
+          <div className="otp-status otp-status-warning">
+            <strong>Verification attempts:</strong> {failedAttempts}/{MAX_ATTEMPTS} used —{' '}
+            {attemptsLeft} {attemptsLeft === 1 ? 'attempt' : 'attempts'} remaining.
+          </div>
+        )}
+
+        <div className="mock-form-group">
+          <label htmlFor="otpCode">Verification Code</label>
+          <input
+            className="otp-code-input"
+            type="text"
+            id="otpCode"
+            name="otpCode"
+            value={otpCode}
+            onChange={(e) => {
+              setOtpCode(e.target.value);
+              setError(null);
+            }}
+            placeholder="000000"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            disabled={isVerifying}
+            required
+          />
         </div>
+
+        <div className="otp-timer">
+          <span>Code expires in</span>
+          <span className={`otp-timer-value${timeLeft <= 60 ? ' is-expiring' : ''}`}>
+            {formatTime(timeLeft)}
+          </span>
+        </div>
+
+        <button type="submit" className="mock-action-button" disabled={verifyDisabled}>
+          {isVerifying ? 'Verifying...' : 'Verify Email'}
+        </button>
+
+        {canResend && (
+          <div className="otp-resend">
+            Didn&apos;t receive the code?{' '}
+            <button
+              type="button"
+              className="otp-resend-button"
+              onClick={handleResendOtp}
+              disabled={isResending}
+            >
+              {isResending ? 'Sending...' : 'Resend code'}
+            </button>
+          </div>
+        )}
+      </form>
+
+      <div className="mock-auth-footer">
+        <p className="otp-help">
+          Check your inbox and spam folder. The code is valid for 5 minutes, and sending a
+          new one invalidates any previous code.
+        </p>
+        <button type="button" className="mock-signup-link" onClick={() => navigate('/login')}>
+          Back to Sign In
+        </button>
       </div>
-    </div>
+    </AuthLayout>
   );
 }


### PR DESCRIPTION
Closes #432.

The OTP verification page was the last auth screen still on the old design — a flat grey backdrop with the logo tiled behind a plain card, ad-hoc inline styles throughout, and a large boxed countdown that dominated the form.

## Approach

Render it through `AuthLayout`, the same shell `SignIn` and `SignUp` already use, so it inherits the background video, the side illustration, the logo, and the white card. The inline styling is replaced with the shared `.mock-*` classes — header, form group, primary action button, footer — and errors go through `AuthErrorBanner` like the other screens.

The OTP-specific styles live in `AuthLayout`'s stylesheet next to the rest, following its stated *"all auth-page CSS lives here once so SignIn and SignUp stay DRY"* convention