### PR TITLE
added the download functionality for the new easy-deploy-package

### DIFF
--- a/src/__tests__/components/canvas/CanvasSidebarToolbar.test.tsx
+++ b/src/__tests__/components/canvas/CanvasSidebarToolbar.test.tsx
@@ -4,7 +4,7 @@ import { CanvasSidebarToolbar } from '../../../components/canvas/CanvasSidebarTo
 
 const labels = {
   select: 'Select. Move and select elements on the canvas',
-  download: 'Download. Export this project as a ZIP file',
+  download: 'Download. Export this project',
   save: 'Save. Save changes to this project',
   checkBuild: 'Check build. Verify the project compiles successfully',
   addReaction: 'Add reaction. Click two meta-models to connect them',
@@ -23,6 +23,7 @@ const createProps = () => ({
   onOpenReactionEditor: jest.fn(),
   onToggleModelDrawer: jest.fn(),
   onDownloadArtifact: jest.fn(),
+  onDownloadBundle: jest.fn(),
   onSaveChanges: jest.fn(),
   onCheckBuild: jest.fn(),
   onUndo: jest.fn(),
@@ -30,6 +31,7 @@ const createProps = () => ({
   canUndo: true,
   canRedo: true,
   downloadingArtifact: false,
+  downloadingBundle: false,
   savingChanges: false,
   checkingBuild: false,
 });
@@ -55,6 +57,7 @@ describe('CanvasSidebarToolbar', () => {
     ]);
 
     fireEvent.click(screen.getByRole('button', { name: labels.download }));
+    fireEvent.click(screen.getByRole('button', { name: /Project export/ }));
     fireEvent.click(screen.getByRole('button', { name: labels.save }));
     fireEvent.click(screen.getByRole('button', { name: labels.checkBuild }));
     fireEvent.click(screen.getByRole('button', { name: labels.addReaction }));
@@ -137,6 +140,38 @@ describe('CanvasSidebarToolbar', () => {
     expect(redoButton).toHaveStyle({ cursor: 'not-allowed' });
     expect(props.onUndo).not.toHaveBeenCalled();
     expect(props.onRedo).not.toHaveBeenCalled();
+  });
+
+  it('opens a menu offering project export or the easy deploy package', () => {
+    const props = createProps();
+    render(<CanvasSidebarToolbar {...props} />);
+
+    expect(screen.queryByText(/Easy deploy package/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: labels.download }));
+
+    expect(screen.getByText('Project export')).toBeInTheDocument();
+    expect(screen.getByText('Easy deploy package')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Easy deploy package/ }));
+
+    expect(props.onDownloadBundle).toHaveBeenCalledTimes(1);
+    expect(props.onDownloadArtifact).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Easy deploy package/)).not.toBeInTheDocument();
+  });
+
+  it('closes the download menu on outside click without triggering a download', () => {
+    const props = createProps();
+    render(<CanvasSidebarToolbar {...props} />);
+
+    fireEvent.click(screen.getByRole('button', { name: labels.download }));
+    expect(screen.getByText('Project export')).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+
+    expect(screen.queryByText('Project export')).not.toBeInTheDocument();
+    expect(props.onDownloadArtifact).not.toHaveBeenCalled();
+    expect(props.onDownloadBundle).not.toHaveBeenCalled();
   });
 
   it('forwards available undo and redo actions', () => {

--- a/src/__tests__/pages/CanvasPage.test.tsx
+++ b/src/__tests__/pages/CanvasPage.test.tsx
@@ -69,6 +69,7 @@ jest.mock('../../services/api', () => ({
     removeVsumMember: jest.fn(),
     buildVsum: jest.fn(),
     downloadVsumArtifact: jest.fn(),
+    downloadVsumBundle: jest.fn(),
     renameVsum: jest.fn(),
     deleteMetaModel: jest.fn(),
   },

--- a/src/__tests__/services/api.test.ts
+++ b/src/__tests__/services/api.test.ts
@@ -348,6 +348,78 @@ describe('ApiService – downloadVsumArtifact', () => {
   });
 });
 
+// ── downloadVsumBundle ────────────────────────────────────────────────────────
+
+describe('ApiService – downloadVsumBundle', () => {
+  const { AuthService } = require('../../services/auth') as {
+    AuthService: { ensureValidToken: jest.Mock; refreshToken: jest.Mock };
+  };
+
+  const zipBytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x00]);
+
+  const mockZipFetch = (status = 200) => {
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? 'OK' : 'Error',
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === 'content-type' ? 'application/zip' : null,
+      },
+      text: async () => '',
+      blob: async () => new Blob([zipBytes], { type: 'application/zip' }),
+    } as unknown as Response);
+  };
+
+  beforeEach(() => {
+    AuthService.ensureValidToken.mockResolvedValue('mock-token');
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('requests the build/bundle endpoint and returns a ZIP blob on success', async () => {
+    mockZipFetch();
+    const blob = await apiService.downloadVsumBundle(42);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/vsums/42/build/bundle'),
+      expect.any(Object),
+    );
+    expect(blob.size).toBeGreaterThan(0);
+    const header = new Uint8Array(await new Response(blob.slice(0, 2)).arrayBuffer());
+    expect(header[0]).toBe(0x50);
+    expect(header[1]).toBe(0x4b);
+  });
+
+  it('throws when the response body is JSON instead of a ZIP', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === 'content-type' ? 'application/json' : null,
+      },
+      text: async () => '{"message":"Bundle failed"}',
+      blob: async () => new Blob(['{"message":"Bundle failed"}'], { type: 'application/json' }),
+    } as unknown as Response);
+
+    await expect(apiService.downloadVsumBundle(42)).rejects.toThrow('Bundle failed');
+  });
+
+  it('throws on non-ok status', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Error',
+      headers: { get: () => null },
+      text: async () => '{"message":"Server error"}',
+      blob: async () => new Blob([]),
+    } as unknown as Response);
+
+    await expect(apiService.downloadVsumBundle(42)).rejects.toThrow('Server error');
+  });
+});
+
 // ── updateUserName ────────────────────────────────────────────────────────────
 
 describe('ApiService – updateUserName', () => {

--- a/src/components/canvas/CanvasSidebarToolbar.tsx
+++ b/src/components/canvas/CanvasSidebarToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { HoverTooltip } from '../ui/HoverTooltip';
 
 interface CanvasSidebarToolbarProps {
@@ -8,6 +8,7 @@ interface CanvasSidebarToolbarProps {
   onOpenReactionEditor?: () => void;
   onToggleModelDrawer: () => void;
   onDownloadArtifact: () => void;
+  onDownloadBundle: () => void;
   onSaveChanges: () => void;
   onCheckBuild: () => void;
   onUndo: () => void;
@@ -15,6 +16,7 @@ interface CanvasSidebarToolbarProps {
   canUndo: boolean;
   canRedo: boolean;
   downloadingArtifact: boolean;
+  downloadingBundle: boolean;
   savingChanges: boolean;
   checkingBuild: boolean;
 }
@@ -175,6 +177,66 @@ const DownloadIcon = () => (
   </svg>
 );
 
+const PackageIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 8v8a2 2 0 0 1-1 1.73l-7 4a2 2 0 0 1-2 0l-7-4A2 2 0 0 1 3 16V8" />
+    <path d="M3.27 6.96 12 12l8.73-5.04" />
+    <path d="M12 22.08V12" />
+    <path d="M12 2 3 7l9 5 9-5-9-5Z" />
+  </svg>
+);
+
+const ZipIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M16 2H8a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2Z" />
+    <path d="M12 2v20" strokeDasharray="2 2" />
+  </svg>
+);
+
+function getDownloadMenuItemBackground(hovered: boolean, disabled?: boolean): string {
+  if (disabled) return 'transparent';
+  return hovered ? '#f1f5f9' : 'transparent';
+}
+
+const DownloadMenuItem: React.FC<{
+  label: string;
+  sublabel: string;
+  icon: React.ReactNode;
+  disabled?: boolean;
+  loading?: boolean;
+  onClick: () => void;
+}> = ({ label, sublabel, icon, disabled, loading, onClick }) => {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={disabled ? undefined : onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        display: 'flex', alignItems: 'center', gap: 10,
+        width: '100%', padding: '8px 10px', border: 'none', borderRadius: 6,
+        background: getDownloadMenuItemBackground(hovered, disabled),
+        color: disabled ? '#94a3b8' : '#0f172a',
+        cursor: disabled ? 'not-allowed' : 'pointer', textAlign: 'left',
+        transition: 'background 0.1s',
+      }}
+    >
+      <span style={{
+        display: 'flex', flexShrink: 0, color: disabled ? '#c8d3dd' : '#049484',
+        animation: loading ? 'spin 0.9s linear infinite' : undefined,
+      }}
+      >
+        {icon}
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 13, fontWeight: 600 }}>{label}</div>
+        <div style={{ fontSize: 11, color: '#64748b', fontWeight: 400, marginTop: 1 }}>{sublabel}</div>
+      </div>
+    </button>
+  );
+};
+
 const SaveIcon = () => (
   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
     <rect x="3" y="3" width="18" height="18" rx="2" />
@@ -190,6 +252,7 @@ export const CanvasSidebarToolbar: React.FC<CanvasSidebarToolbarProps> = ({
   onOpenReactionEditor,
   onToggleModelDrawer,
   onDownloadArtifact,
+  onDownloadBundle,
   onSaveChanges,
   onCheckBuild,
   onUndo,
@@ -197,10 +260,24 @@ export const CanvasSidebarToolbar: React.FC<CanvasSidebarToolbarProps> = ({
   canUndo,
   canRedo,
   downloadingArtifact,
+  downloadingBundle,
   savingChanges,
   checkingBuild,
 }) => {
-  const busy = downloadingArtifact || savingChanges || checkingBuild;
+  const busy = downloadingArtifact || downloadingBundle || savingChanges || checkingBuild;
+  const [showDownloadMenu, setShowDownloadMenu] = useState(false);
+  const downloadMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!showDownloadMenu) return;
+    const handler = (event: MouseEvent) => {
+      if (downloadMenuRef.current && !downloadMenuRef.current.contains(event.target as unknown as HTMLElement)) {
+        setShowDownloadMenu(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showDownloadMenu]);
 
   return (
     <div style={sidebarStackStyle}>
@@ -216,15 +293,50 @@ export const CanvasSidebarToolbar: React.FC<CanvasSidebarToolbarProps> = ({
 
         <SidebarDivider />
 
-        <SidebarButton
-          label="Download"
-          description="Export this project as a ZIP file"
-          onClick={onDownloadArtifact}
-          loading={downloadingArtifact}
-          disabled={busy}
-        >
-          <DownloadIcon />
-        </SidebarButton>
+        <div ref={downloadMenuRef} style={{ position: 'relative' }}>
+          <SidebarButton
+            label="Download"
+            description="Export this project"
+            onClick={() => setShowDownloadMenu(current => !current)}
+            loading={downloadingArtifact || downloadingBundle}
+            disabled={busy}
+            active={showDownloadMenu}
+          >
+            <DownloadIcon />
+          </SidebarButton>
+
+          {showDownloadMenu && (
+            <div style={{
+              position: 'absolute',
+              left: 'calc(100% + 8px)',
+              top: 0,
+              background: '#ffffff',
+              borderRadius: 10,
+              boxShadow: '0 8px 32px rgba(0,0,0,0.16), 0 0 0 1px rgba(0,0,0,0.07)',
+              padding: '6px',
+              zIndex: 500,
+              minWidth: 240,
+            }}
+            >
+              <DownloadMenuItem
+                label="Project export"
+                sublabel="Download the project as a ZIP file"
+                icon={<ZipIcon />}
+                loading={downloadingArtifact}
+                disabled={busy}
+                onClick={() => { setShowDownloadMenu(false); onDownloadArtifact(); }}
+              />
+              <DownloadMenuItem
+                label="Easy deploy package"
+                sublabel="JAR, docs, and scripts ready to run"
+                icon={<PackageIcon />}
+                loading={downloadingBundle}
+                disabled={busy}
+                onClick={() => { setShowDownloadMenu(false); onDownloadBundle(); }}
+              />
+            </div>
+          )}
+        </div>
 
         {!readOnly && (
           <SidebarButton

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -336,6 +336,7 @@ export const CanvasPage: React.FC = () => {
   // check / download / save
   const [checkingBuild, setCheckingBuild] = useState(false);
   const [downloadingArtifact, setDownloadingArtifact] = useState(false);
+  const [downloadingBundle, setDownloadingBundle] = useState(false);
   const [savingChanges, setSavingChanges] = useState(false);
   const [popup, setPopup] = useState<{ message: string; type: CanvasPopupNotificationType } | null>(null);
   const notifyUmlPanelLoadError = useCallback((message: CanvasUmlPanelLoadErrorMessage) => {
@@ -1201,6 +1202,26 @@ export const CanvasPage: React.FC = () => {
     }
   }, [activeProjectId]);
 
+  const handleDownloadBundle = useCallback(async () => {
+    if (!activeProjectId) return;
+    setDownloadingBundle(true);
+    setPopup({ message: 'Downloading easy deploy package…', type: 'info' });
+    try {
+      const blob = await apiService.downloadVsumBundle(activeProjectId);
+      downloadBlobAsFile(blob, `vsum-${activeProjectId}-easy-deploy.zip`);
+      setPopup({ message: 'Easy deploy package downloaded successfully!', type: 'success' });
+    } catch (e: any) {
+      const data = e?.response?.data;
+      const detail = (typeof data?.message === 'string' && data.message) ||
+        (typeof data === 'string' && data) ||
+        e?.message || 'Download failed.';
+      setPopup({ message: detail, type: 'error' });
+    } finally {
+      setDownloadingBundle(false);
+      setTimeout(() => setPopup(null), 5000);
+    }
+  }, [activeProjectId]);
+
   // ── Save changes ──────────────────────────────────────────────────────────
 
   const handleSaveChanges = useCallback(async () => {
@@ -1394,6 +1415,7 @@ export const CanvasPage: React.FC = () => {
         onOpenReactionEditor={handleOpenReactionEditor}
         onToggleModelDrawer={() => setShowDrawer(d => !d)}
         onDownloadArtifact={handleDownloadArtifact}
+        onDownloadBundle={handleDownloadBundle}
         onSaveChanges={handleSaveChanges}
         onCheckBuild={handleCheckBuild}
         onUndo={() => flowCanvasRef.current?.undo?.()}
@@ -1401,6 +1423,7 @@ export const CanvasPage: React.FC = () => {
         canUndo={canUndo}
         canRedo={canRedo}
         downloadingArtifact={downloadingArtifact}
+        downloadingBundle={downloadingBundle}
         savingChanges={savingChanges}
         checkingBuild={checkingBuild}
       />}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -57,32 +57,82 @@ class ApiService {
   }
 
   /**
-   * Ensure a successful artifact response is a ZIP blob (not JSON error text).
+   * Ensure a successful download response is a ZIP blob (not JSON error text).
    */
-  private async parseArtifactBlob(response: Response): Promise<Blob> {
+  private async parseArtifactBlob(response: Response, label: string = 'Artifact'): Promise<Blob> {
     const contentType = response.headers.get('Content-Type')?.toLowerCase() ?? '';
     if (contentType.includes('json')) {
       const errorText = await response.text();
-      throw this.createApiError(errorText, 'Artifact download failed');
+      throw this.createApiError(errorText, `${label} download failed`);
     }
 
     const blob = await response.blob();
 
     if (blob.type?.toLowerCase().includes('json')) {
-      throw this.createApiError(await blob.text(), 'Artifact download failed');
+      throw this.createApiError(await blob.text(), `${label} download failed`);
     }
 
     if (!blob.size) {
-      throw this.createApiError('', 'Artifact download returned an empty file');
+      throw this.createApiError('', `${label} download returned an empty file`);
     }
 
     const header = new Uint8Array(await new Response(blob.slice(0, 4)).arrayBuffer());
     if (header[0] !== 0x50 || header[1] !== 0x4b) {
       const preview = await blob.slice(0, 512).text();
-      throw this.createApiError(preview, 'Artifact download did not return a valid ZIP file');
+      throw this.createApiError(preview, `${label} download did not return a valid ZIP file`);
     }
 
     return blob;
+  }
+
+  /**
+   * Fetch a ZIP blob from an authenticated vSUM build endpoint, retrying once
+   * on a 401 after a token refresh.
+   */
+  private async downloadVsumZip(path: string, label: string): Promise<Blob> {
+    const token = await AuthService.ensureValidToken();
+
+    if (!token) {
+      throw new Error('No valid authentication token available');
+    }
+
+    const url = `${this.baseURL}${path}`;
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/zip, application/octet-stream, */*',
+    };
+
+    let response = await fetch(url, {
+      method: 'GET',
+      headers,
+    });
+
+    if (response.status === 401) {
+      try {
+        await AuthService.refreshToken();
+      } catch {
+        console.error(`Token refresh failed during ${label.toLowerCase()} download`);
+      }
+
+      const newToken = await AuthService.ensureValidToken();
+      if (newToken) {
+        response = await fetch(url, {
+          method: 'GET',
+          headers: {
+            ...headers,
+            Authorization: `Bearer ${newToken}`,
+          },
+        });
+      }
+    }
+
+    if (!response.ok) {
+      const errorText = await this.getResponseText(response);
+      console.error(`${label} download failed`, { status: response.status });
+      throw this.createApiError(errorText, `${label} download failed`);
+    }
+
+    return this.parseArtifactBlob(response, label);
   }
 
   /**
@@ -612,49 +662,16 @@ class ApiService {
    * Returns a ZIP file blob containing the build artifact
    */
   async downloadVsumArtifact(id: number | string): Promise<Blob> {
-    const token = await AuthService.ensureValidToken();
+    return this.downloadVsumZip(`/api/v1/vsums/${id}/build/artifact`, 'Artifact');
+  }
 
-    if (!token) {
-      throw new Error('No valid authentication token available');
-    }
-
-    const url = `${this.baseURL}/api/v1/vsums/${id}/build/artifact`;
-    const headers: Record<string, string> = {
-      Authorization: `Bearer ${token}`,
-      Accept: 'application/zip, application/octet-stream, */*',
-    };
-
-    let response = await fetch(url, {
-      method: 'GET',
-      headers,
-    });
-
-    if (response.status === 401) {
-      try {
-        await AuthService.refreshToken();
-      } catch {
-        console.error('Token refresh failed during artifact download');
-      }
-
-      const newToken = await AuthService.ensureValidToken();
-      if (newToken) {
-        response = await fetch(url, {
-          method: 'GET',
-          headers: {
-            ...headers,
-            Authorization: `Bearer ${newToken}`,
-          },
-        });
-      }
-    }
-
-    if (!response.ok) {
-      const errorText = await this.getResponseText(response);
-      console.error('Artifact download failed', { status: response.status });
-      throw this.createApiError(errorText, 'Artifact download failed');
-    }
-
-    return this.parseArtifactBlob(response);
+  /**
+   * vSUMS: Download easy deploy package as ZIP file
+   * GET /api/v1/vsums/{id}/build/bundle
+   * Returns a ZIP file blob containing a JAR, documentation, and scripts
+   */
+  async downloadVsumBundle(id: number | string): Promise<Blob> {
+    return this.downloadVsumZip(`/api/v1/vsums/${id}/build/bundle`, 'Easy deploy package');
   }
 
   /**


### PR DESCRIPTION
Adds support for downloading the new "easy deploy" package (JAR + docs + scripts) from the Canvas sidebar, alongside the existing project export. Closes #444.

Previously the sidebar's Download button triggered a single action (project export as ZIP). It now opens a small menu with two options:

- **Project export*
- **Easy deploy package**
