### PR TITLE
Implement theme toggle functionality and update styles for dark mode support across the application.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,19 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico?v=2" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#f7f8fa" />
+    <script>
+      (function () {
+        try {
+          var theme = localStorage.getItem('vitruv.theme');
+          if (theme !== 'dark' && theme !== 'light') theme = 'light';
+          document.documentElement.setAttribute('data-theme', theme);
+          document.documentElement.style.colorScheme = theme;
+        } catch (e) {
+          document.documentElement.setAttribute('data-theme', 'light');
+        }
+      })();
+    </script>
     <meta
       name="description"
       content="Vitruvius Methodologist - Methodological Dashboard for Meta Models and Projects"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ function ProtectedRoute({ children }: Readonly<{ children: React.ReactNode }>) {
         alignItems: 'center',
         height: '100vh',
         fontSize: '18px',
-        color: '#666'
+        color: 'var(--v-text-muted)',
       }}>
         Loading...
       </div>

--- a/src/__tests__/components/auth/SignIn.test.tsx
+++ b/src/__tests__/components/auth/SignIn.test.tsx
@@ -41,6 +41,20 @@ describe('SignIn component', () => {
     expect(screen.getByRole('button', { name: /Sign In/i })).toBeInTheDocument();
   });
 
+  it('places the theme toggle inside the sign-in card', () => {
+    const { container } = render(
+      <SignIn
+        onSignInSuccess={mockOnSignInSuccess}
+        onSwitchToSignUp={mockOnSwitchToSignUp}
+      />,
+    );
+
+    const card = container.querySelector('.mock-auth-card');
+    const toggle = screen.getByRole('button', { name: 'Switch to dark mode' });
+
+    expect(card).toContainElement(toggle);
+  });
+
   it('shows validation error when submitting with empty fields', async () => {
     render(
       <SignIn

--- a/src/__tests__/components/canvas/CanvasProjectAccessControls.test.tsx
+++ b/src/__tests__/components/canvas/CanvasProjectAccessControls.test.tsx
@@ -290,4 +290,9 @@ describe('CanvasProjectAccessControls', () => {
     expect(accountProps.dismissalBoundaryRef.current).toBeInstanceOf(HTMLDivElement);
     expect(accountProps.onCloseSiblingMenu).toEqual(expect.any(Function));
   });
+
+  it('renders a dark mode toggle next to the account menu', () => {
+    renderControls();
+    expect(screen.getByRole('button', { name: 'Switch to dark mode' })).toBeInTheDocument();
+  });
 });

--- a/src/__tests__/components/canvas/FloatingUMLPanel.test.tsx
+++ b/src/__tests__/components/canvas/FloatingUMLPanel.test.tsx
@@ -85,6 +85,7 @@ describe('FloatingUMLPanel', () => {
     expect(screen.getByTestId('uml-toolbar-badge')).toHaveTextContent('UML');
     expect(screen.getByText('My Ecore Model')).toBeInTheDocument();
     expect(screen.getByTestId('uml-toolbar-reload')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Switch to (dark|light) mode/ })).toBeInTheDocument();
   });
 
   it('renders as a fullscreen page overlay', () => {

--- a/src/__tests__/components/flow/UMLRelationship.test.tsx
+++ b/src/__tests__/components/flow/UMLRelationship.test.tsx
@@ -110,7 +110,7 @@ describe('UMLRelationship', () => {
     expect(marker).toBeInTheDocument();
     const path = marker.querySelector('path');
     expect(path).not.toBeNull();
-    expect(path?.getAttribute('fill')).toBe('#0c436e');
+    expect(path?.getAttribute('fill')).toBe('var(--v-uml-edge, #0c436e)');
   });
 
   it('renders a direction marker by default for composition edges', () => {
@@ -157,13 +157,13 @@ describe('UMLRelationship', () => {
     );
 
     const path = container.querySelector('path#edge-hover-mult') as SVGPathElement;
-    expect(path?.style.stroke).toBe('#0c436e');
+    expect(path?.style.stroke).toBe('var(--v-uml-edge, #0c436e)');
 
     fireEvent.mouseEnter(screen.getByText('1'));
     expect(path?.style.stroke).toBe('#ef4444');
 
     fireEvent.mouseLeave(screen.getByText('1'));
-    expect(path?.style.stroke).toBe('#0c436e');
+    expect(path?.style.stroke).toBe('var(--v-uml-edge, #0c436e)');
   });
 
   it('uses red stroke when selected', () => {

--- a/src/__tests__/components/flow/canvas/CircleOverlay.test.tsx
+++ b/src/__tests__/components/flow/canvas/CircleOverlay.test.tsx
@@ -138,6 +138,10 @@ describe('CircleOverlay', () => {
     it('renders the SVG overlay when circle.r > 0', () => {
         const { container } = render(<CircleOverlay {...defaultProps()} />);
         expect(container.querySelector('svg')).toBeInTheDocument();
+        const ring = [...container.querySelectorAll('circle')].find(
+            el => el.getAttribute('stroke') === 'var(--v-uml-circle, #0c436e)',
+        );
+        expect(ring).toBeTruthy();
     });
 
     it('renders a bubble for each viewType', () => {

--- a/src/__tests__/components/flow/canvas/ViewTypeArrow.test.tsx
+++ b/src/__tests__/components/flow/canvas/ViewTypeArrow.test.tsx
@@ -29,7 +29,7 @@ const getHitbox = (container: HTMLElement) =>
     container.querySelector('line[stroke="transparent"]')!;
 
 const getShaft = (container: HTMLElement) =>
-    container.querySelector('line[stroke="#000000"]')!;
+    container.querySelector('line[stroke="var(--v-uml-circle, #0c436e)"]')!;
 
 const getPolygons = (container: HTMLElement) =>
     container.querySelectorAll('polygon');
@@ -54,7 +54,7 @@ describe('ViewTypeArrow', () => {
     it('renders a visible shaft line', () => {
         const { container } = renderArrow();
         expect(getShaft(container)).toBeInTheDocument();
-        expect(getShaft(container).getAttribute('stroke')).toBe('#000000');
+        expect(getShaft(container).getAttribute('stroke')).toBe('var(--v-uml-circle, #0c436e)');
     });
 
     it('renders exactly one arrowhead polygon when not editable', () => {
@@ -174,7 +174,7 @@ describe('ViewTypeArrow', () => {
     it('polygons are filled black', () => {
         const { container } = renderArrow({ editable: true });
         getPolygons(container).forEach(polygon => {
-            expect(polygon.getAttribute('fill')).toBe('#000000');
+            expect(polygon.getAttribute('fill')).toBe('var(--v-uml-circle, #0c436e)');
         });
     });
 

--- a/src/__tests__/components/layout/AppSidebar.test.tsx
+++ b/src/__tests__/components/layout/AppSidebar.test.tsx
@@ -111,4 +111,21 @@ describe('AppSidebar', () => {
     // active nav item has fontWeight 600 — just check it renders without error
     expect(screen.getByText('Projects')).toBeInTheDocument();
   });
+
+  it('lets the user continue in dark mode or stay in the current light theme', () => {
+    render(<AppSidebar {...defaultProps} />);
+
+    const light = screen.getByRole('button', { name: 'Light theme' });
+    const dark = screen.getByRole('button', { name: 'Dark theme' });
+
+    expect(light).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(dark);
+
+    expect(dark).toHaveAttribute('aria-pressed', 'true');
+    expect(document.documentElement).toHaveAttribute('data-theme', 'dark');
+    expect(localStorage.getItem('vitruv.theme')).toBe('dark');
+
+    fireEvent.click(light);
+    expect(document.documentElement).toHaveAttribute('data-theme', 'light');
+  });
 });

--- a/src/__tests__/components/ui/ChangePasswordModal.test.tsx
+++ b/src/__tests__/components/ui/ChangePasswordModal.test.tsx
@@ -60,4 +60,32 @@ describe('ChangePasswordModal', () => {
     expect(confirmPasswordInput).toHaveAttribute('type', 'password');
     expect(screen.getByRole('button', { name: 'Hide password' })).toHaveAttribute('aria-pressed', 'true');
   });
+
+  it('places the theme toggle in the dialog and uses theme surfaces', () => {
+    render(
+      <ChangePasswordModal
+        isOpen
+        onClose={jest.fn()}
+        currentPassword=""
+        newPassword=""
+        confirmPassword=""
+        onCurrentPasswordChange={jest.fn()}
+        onNewPasswordChange={jest.fn()}
+        onConfirmPasswordChange={jest.fn()}
+        validation={validatePassword('')}
+        isConfirmValid
+        isChanging={false}
+        error=""
+        success=""
+        onSubmit={jest.fn()}
+        canSubmit={false}
+      />,
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Change Password' });
+    const toggle = screen.getByRole('button', { name: 'Switch to dark mode' });
+
+    expect(dialog).toContainElement(toggle);
+    expect(dialog).toHaveClass('change-password-dialog');
+  });
 });

--- a/src/__tests__/components/ui/CreateModelModal.test.tsx
+++ b/src/__tests__/components/ui/CreateModelModal.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { CreateModelModal } from '../../../components/ui/CreateModelModal';
+import { resetThemeStore, setTheme } from '../../../theme/theme';
 
 // ─── environment polyfills ────────────────────────────────────────────────────
 
@@ -119,6 +120,10 @@ describe('CreateModelModal', () => {
     delete (global as any).fetch;
   });
 
+  afterEach(() => {
+    resetThemeStore();
+  });
+
   // ── rendering ───────────────────────────────────────────────────────────────
 
   it('renders the modal title when open', () => {
@@ -146,6 +151,15 @@ describe('CreateModelModal', () => {
   it('shows drop-zones by default (file mode)', () => {
     render(<CreateModelModal isOpen onClose={jest.fn()} />);
     expect(screen.getAllByText(/Click to select file/i)).toHaveLength(2);
+  });
+
+  it('uses theme surfaces so file cards and the disabled submit button match dark mode', () => {
+    setTheme('dark');
+    render(<CreateModelModal isOpen onClose={jest.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Complete All Fields' })).toBeDisabled();
+    expect(screen.getAllByRole('button', { name: /Click to select file/i })).toHaveLength(2);
+    expect(screen.getByText('Required Meta Model Files')).toBeInTheDocument();
   });
 
   it('calls onClose when Cancel is clicked', async () => {

--- a/src/__tests__/components/ui/ModelLibraryTable.test.tsx
+++ b/src/__tests__/components/ui/ModelLibraryTable.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { ModelDetailModal, ModelLibraryTable } from '../../../components/ui/ModelLibraryTable';
+import { resetThemeStore, setTheme } from '../../../theme/theme';
 
 jest.mock('../../../services/api', () => ({
   apiService: {
@@ -46,6 +47,10 @@ describe('ModelLibraryTable', () => {
     apiService.findMetaModels.mockReset();
     apiService.deleteMetaModel.mockReset();
     apiService.findMetaModels.mockResolvedValue({ data: [existingModel] });
+  });
+
+  afterEach(() => {
+    resetThemeStore();
   });
 
   it('loads the list once on mount', async () => {
@@ -198,5 +203,25 @@ describe('ModelLibraryTable', () => {
       expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
     });
+  });
+});
+
+describe('ModelDetailModal', () => {
+  afterEach(() => {
+    resetThemeStore();
+  });
+
+  it('uses theme surfaces so the preview sidebar matches dark mode', () => {
+    setTheme('dark');
+    render(
+      <ModelDetailModal
+        model={{ id: 1, name: 'string', description: 'string', keyword: ['string'] }}
+        onClose={jest.fn()}
+        onUpdated={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('dialog', { name: 'Model Preview: string' })).toBeInTheDocument();
+    expect(screen.getByText('UML')).toBeInTheDocument();
   });
 });

--- a/src/__tests__/components/ui/ProfileModal.test.tsx
+++ b/src/__tests__/components/ui/ProfileModal.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ProfileModal } from '../../../components/ui/ProfileModal';
+import { setTheme } from '../../../theme/theme';
+
+jest.mock('../../../components/ui/ProfileView', () => ({
+  ProfileView: () => <div>Profile content</div>,
+}));
+
+const user = {
+  id: '1',
+  username: 'tm',
+  email: 'tm@example.com',
+  givenName: 'Tsotne',
+  familyName: 'Mikadze',
+  emailVerified: true,
+};
+
+describe('ProfileModal', () => {
+  it('uses theme surfaces so the dialog matches light or dark mode', () => {
+    setTheme('dark');
+    render(
+      <ProfileModal user={user} onClose={jest.fn()} onNameSaved={jest.fn()} />,
+    );
+
+    expect(screen.getByRole('dialog', { name: 'Profile' })).toBeInTheDocument();
+    expect(screen.getByText('Profile content')).toBeInTheDocument();
+    expect(screen.getByLabelText('Close')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/ui/ProfileView.test.tsx
+++ b/src/__tests__/components/ui/ProfileView.test.tsx
@@ -183,6 +183,14 @@ describe('ProfileView', () => {
     expect(screen.getByText(/Change password/i)).toBeInTheDocument();
   });
 
+  it('shows an appearance control to stay in light or continue in dark', async () => {
+    await renderProfileView();
+    expect(screen.getByText('Appearance')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Light theme' })).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(screen.getByRole('button', { name: 'Dark theme' }));
+    expect(document.documentElement).toHaveAttribute('data-theme', 'dark');
+  });
+
   it('returns null when user prop is null', async () => {
     const { container } = render(<ProfileView user={null} />);
     await settleUserInfo();

--- a/src/__tests__/components/ui/ProfileView.test.tsx
+++ b/src/__tests__/components/ui/ProfileView.test.tsx
@@ -107,6 +107,13 @@ describe('ProfileView', () => {
     expect(screen.getByText('User Profile')).toBeInTheDocument();
   });
 
+  it('centers the profile column in the page', async () => {
+    await renderProfileView();
+    const heading = screen.getByRole('heading', { name: 'User Profile' });
+    const column = heading.parentElement?.parentElement;
+    expect(column).toHaveStyle({ maxWidth: '680px', width: '100%', margin: '0px auto' });
+  });
+
   it('fetches profile from backend on mount', async () => {
     await renderProfileView();
     expect(apiService.getUserInfo).toHaveBeenCalledTimes(1);

--- a/src/__tests__/components/ui/VsumDetailsModal.test.tsx
+++ b/src/__tests__/components/ui/VsumDetailsModal.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { resetThemeStore, setTheme } from '../../../theme/theme';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -78,6 +79,10 @@ describe('VsumDetailsModal – real component tests', () => {
     apiService.getVsumVersions.mockResolvedValue({ data: [] });
   });
 
+  afterEach(() => {
+    resetThemeStore();
+  });
+
   it('returns null when not open', () => {
     const { container } = render(
       <RealModal isOpen={false} vsumId={1} onClose={jest.fn()} />,
@@ -125,5 +130,14 @@ describe('VsumDetailsModal – real component tests', () => {
     await waitFor(() => {
       expect(apiService.renameVsum).toHaveBeenCalledWith(1, { name: 'Test VSUM' });
     });
+  });
+
+  it('uses theme surfaces so the dialog matches dark mode', async () => {
+    setTheme('dark');
+    render(<RealModal isOpen vsumId={1} onClose={jest.fn()} />);
+    const title = await screen.findByText('Test VSUM');
+    expect(title).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Manage Users' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+ Link Meta Models' })).toBeInTheDocument();
   });
 });

--- a/src/__tests__/theme/theme.test.tsx
+++ b/src/__tests__/theme/theme.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  getTheme,
+  readStoredTheme,
+  resetThemeStore,
+  setTheme,
+  THEME_STORAGE_KEY,
+  toggleTheme,
+} from '../../theme/theme';
+import { ThemeToggle } from '../../components/ui/ThemeToggle';
+
+describe('theme store', () => {
+  afterEach(() => {
+    resetThemeStore();
+  });
+
+  it('defaults to light so the current look is preserved', () => {
+    expect(readStoredTheme()).toBe('light');
+    expect(getTheme()).toBe('light');
+    expect(document.documentElement).toHaveAttribute('data-theme', 'light');
+  });
+
+  it('persists a manual dark-mode choice', () => {
+    setTheme('dark');
+
+    expect(getTheme()).toBe('dark');
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+    expect(document.documentElement).toHaveAttribute('data-theme', 'dark');
+    expect(document.documentElement.style.colorScheme).toBe('dark');
+  });
+
+  it('toggles back to light mode', () => {
+    setTheme('dark');
+    toggleTheme();
+
+    expect(getTheme()).toBe('light');
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
+    expect(document.documentElement).toHaveAttribute('data-theme', 'light');
+  });
+});
+
+describe('ThemeToggle', () => {
+  it('switches between dark and light from the icon button', () => {
+    render(<ThemeToggle />);
+
+    const toggle = screen.getByRole('button', { name: 'Switch to dark mode' });
+    fireEvent.click(toggle);
+
+    expect(document.documentElement).toHaveAttribute('data-theme', 'dark');
+    expect(screen.getByRole('button', { name: 'Switch to light mode' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to light mode' }));
+    expect(document.documentElement).toHaveAttribute('data-theme', 'light');
+  });
+
+  it('lets the user keep light or continue in dark from the segmented control', () => {
+    render(<ThemeToggle variant="segmented" />);
+
+    const light = screen.getByRole('button', { name: 'Light theme' });
+    const dark = screen.getByRole('button', { name: 'Dark theme' });
+
+    expect(light).toHaveAttribute('aria-pressed', 'true');
+    expect(dark).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(dark);
+    expect(dark).toHaveAttribute('aria-pressed', 'true');
+    expect(getTheme()).toBe('dark');
+
+    fireEvent.click(light);
+    expect(light).toHaveAttribute('aria-pressed', 'true');
+    expect(getTheme()).toBe('light');
+  });
+});

--- a/src/components/auth/Auth.css
+++ b/src/components/auth/Auth.css
@@ -426,59 +426,57 @@
 }
 
 /* Dark mode support - Keep same design */
-@media (prefers-color-scheme: dark) {
-  .auth-card {
-    background: rgba(40, 40, 40, 0.65);
-    backdrop-filter: blur(25px);
-    color: #ffffff;
-  }
-  
-  .auth-header h1 {
-    background: linear-gradient(135deg, #06b5a0 0%, #05a896 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-  }
-  
-  .auth-header p {
-    color: #f0f0f0;
-  }
-  
-  .form-group label {
-    color: #ffffff;
-  }
-  
-  .form-group input {
-    background: rgba(255, 255, 255, 0.95);
-    border-color: rgba(255, 255, 255, 0.4);
-    color: #1a202c;
-  }
-  
-  .form-group input:focus {
-    background: rgba(255, 255, 255, 1);
-    border-color: #06b5a0;
-  }
-  
-  .form-group input::placeholder {
-    color: rgba(0, 0, 0, 0.4);
-  }
-  
-  .demo-credentials {
-    background: rgba(0, 0, 0, 0.3);
-    border-color: rgba(255, 255, 255, 0.25);
-  }
-  
-  .demo-title {
-    color: #ffffff;
-  }
-  
-  .demo-info p {
-    color: #e0e0e0;
-  }
-  
-  .demo-info strong {
-    color: #ffffff;
-  }
+[data-theme="dark"] .auth-card {
+  background: rgba(40, 40, 40, 0.65);
+  backdrop-filter: blur(25px);
+  color: #ffffff;
+}
+
+[data-theme="dark"] .auth-header h1 {
+  background: linear-gradient(135deg, #06b5a0 0%, #05a896 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+[data-theme="dark"] .auth-header p {
+  color: #f0f0f0;
+}
+
+[data-theme="dark"] .form-group label {
+  color: #ffffff;
+}
+
+[data-theme="dark"] .form-group input {
+  background: rgba(255, 255, 255, 0.95);
+  border-color: rgba(255, 255, 255, 0.4);
+  color: #1a202c;
+}
+
+[data-theme="dark"] .form-group input:focus {
+  background: rgba(255, 255, 255, 1);
+  border-color: #06b5a0;
+}
+
+[data-theme="dark"] .form-group input::placeholder {
+  color: rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] .demo-credentials {
+  background: rgba(0, 0, 0, 0.3);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+[data-theme="dark"] .demo-title {
+  color: #ffffff;
+}
+
+[data-theme="dark"] .demo-info p {
+  color: #e0e0e0;
+}
+
+[data-theme="dark"] .demo-info strong {
+  color: #ffffff;
 }
 
 /* Success message animation */

--- a/src/components/auth/AuthLayout.tsx
+++ b/src/components/auth/AuthLayout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ThemeToggle } from '../ui/ThemeToggle';
 
 // ── Shared styles ─────────────────────────────────────────────────────────────
 // All auth-page CSS lives here once so SignIn and SignUp stay DRY.
@@ -73,6 +74,7 @@ const AUTH_STYLES = `
   }
 
   .mock-auth-card {
+    position: relative;
     background: #ffffff;
     width: 100%;
     max-width: 460px;
@@ -509,6 +511,67 @@ const AUTH_STYLES = `
     color: #64748b;
     line-height: 1.55;
   }
+
+  .auth-theme-toggle {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    z-index: 2;
+    background: var(--v-surface-muted);
+    border: 1px solid var(--v-border);
+    border-radius: 10px;
+    padding: 2px;
+  }
+
+  [data-theme="dark"] .mock-auth-card {
+    background: rgba(15, 23, 42, 0.88);
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
+    color: #f1f5f9;
+  }
+  [data-theme="dark"] .mock-auth-header h1 { color: #f8fafc; }
+  [data-theme="dark"] .mock-auth-header p,
+  [data-theme="dark"] .mock-auth-footer,
+  [data-theme="dark"] .otp-help,
+  [data-theme="dark"] .otp-timer { color: #94a3b8; }
+  [data-theme="dark"] .mock-form-group label { color: #e2e8f0; }
+  [data-theme="dark"] .mock-form-group input {
+    background-color: #0f172a;
+    border-color: #334155;
+    color: #f1f5f9;
+  }
+  [data-theme="dark"] .mock-form-group input:disabled {
+    background-color: #162032;
+    color: #64748b;
+  }
+  [data-theme="dark"] .mock-checkbox-container { color: #cbd5e1; }
+  [data-theme="dark"] .mock-forgot-link,
+  [data-theme="dark"] .mock-signup-link { color: #e2e8f0; }
+  [data-theme="dark"] .mock-auth-divider::before,
+  [data-theme="dark"] .mock-auth-divider::after { background: #334155; }
+  [data-theme="dark"] .modal-dialog {
+    background: #1e293b;
+    color: #f1f5f9;
+  }
+  [data-theme="dark"] .modal-header h2 { color: #f8fafc; }
+  [data-theme="dark"] .modal-header p { color: #94a3b8; }
+  [data-theme="dark"] .modal-input {
+    background: #0f172a;
+    border-color: #334155;
+    color: #f1f5f9;
+  }
+  [data-theme="dark"] .btn-secondary {
+    background: #334155;
+    color: #e2e8f0;
+  }
+  [data-theme="dark"] .password-requirements {
+    background-color: #0f172a;
+    border-color: #334155;
+  }
+  [data-theme="dark"] .password-requirements-title { color: #cbd5e1; }
+  [data-theme="dark"] .auth-theme-toggle {
+    background: var(--v-chrome-hover);
+    border-color: var(--v-border);
+  }
 `;
 
 // ── AuthErrorBanner ────────────────────────────────────────────────────────────
@@ -566,6 +629,9 @@ export function AuthLayout({ children }: Readonly<AuthLayoutProps>) {
       {/* Right form card */}
       <div className="auth-right-form-area">
         <div className="mock-auth-card">
+          <div className="auth-theme-toggle">
+            <ThemeToggle />
+          </div>
 
           {/* Logo */}
           <div className="mock-logo-container">

--- a/src/components/canvas/CanvasAccountMenu.tsx
+++ b/src/components/canvas/CanvasAccountMenu.tsx
@@ -22,7 +22,7 @@ interface CanvasAccountMenuProps {
 function getProfileMenuItemBackground(hovered: boolean, danger?: boolean): string {
   if (!hovered) return 'transparent';
   if (danger) return '#fef2f2';
-  return '#f8fafc';
+  return 'var(--v-chrome-hover)';
 }
 
 const ProfileMenuItem: React.FC<{
@@ -43,16 +43,16 @@ const ProfileMenuItem: React.FC<{
         display: 'flex', alignItems: 'center', gap: 8,
         width: '100%', padding: '8px 10px', border: 'none', borderRadius: 6,
         background: getProfileMenuItemBackground(hov, danger),
-        color: danger ? '#dc2626' : '#0f172a',
+        color: danger ? '#dc2626' : 'var(--v-text)',
         fontSize: 13, fontWeight: 500, cursor: 'pointer', textAlign: 'left',
         transition: 'background 0.1s',
       }}
     >
-      <span style={{ display: 'flex', flexShrink: 0, color: danger ? 'inherit' : '#475569' }}>{icon}</span>
+      <span style={{ display: 'flex', flexShrink: 0, color: danger ? 'inherit' : 'var(--v-chrome-icon)' }}>{icon}</span>
       <div style={{ flex: 1, minWidth: 0 }}>
         <div>{label}</div>
         {sublabel && (
-          <div style={{ fontSize: 11, color: '#64748b', fontWeight: 400, marginTop: 1 }}>{sublabel}</div>
+          <div style={{ fontSize: 11, color: 'var(--v-text-muted)', fontWeight: 400, marginTop: 1 }}>{sublabel}</div>
         )}
       </div>
     </button>
@@ -126,7 +126,7 @@ export const CanvasAccountMenu: React.FC<CanvasAccountMenuProps> = ({
             position: 'absolute',
             top: 'calc(100% + 8px)',
             right: 0,
-            background: '#ffffff',
+            background: 'var(--v-chrome-bg)',
             borderRadius: 10,
             boxShadow: '0 8px 32px rgba(0,0,0,0.16), 0 0 0 1px rgba(0,0,0,0.07)',
             padding: '6px',
@@ -136,7 +136,7 @@ export const CanvasAccountMenu: React.FC<CanvasAccountMenuProps> = ({
             <div style={{
               display: 'flex', alignItems: 'center', gap: 10,
               padding: '8px 10px 12px',
-              borderBottom: '1px solid #f1f5f9',
+              borderBottom: '1px solid var(--v-border)',
               marginBottom: 4,
             }}>
               <CanvasUserAvatar
@@ -146,7 +146,7 @@ export const CanvasAccountMenu: React.FC<CanvasAccountMenuProps> = ({
                 ring={account.ringColor}
               />
               <div>
-                <div style={{ fontSize: 13, fontWeight: 600, color: '#0f172a', whiteSpace: 'nowrap' }}>
+                <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--v-text)', whiteSpace: 'nowrap' }}>
                   {account.displayName}
                 </div>
                 <div style={{ fontSize: 11, color: '#049484', fontWeight: 600, marginTop: 1 }}>Methodologist</div>

--- a/src/components/canvas/CanvasPeopleAccessPanel.tsx
+++ b/src/components/canvas/CanvasPeopleAccessPanel.tsx
@@ -67,7 +67,7 @@ const PeoplePanelMemberRow: React.FC<PeoplePanelMemberRowProps> = ({
           style={{
             fontSize: 13,
             fontWeight: 600,
-            color: '#0f172a',
+            color: 'var(--v-text)',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
@@ -79,7 +79,7 @@ const PeoplePanelMemberRow: React.FC<PeoplePanelMemberRowProps> = ({
           title={member.email}
           style={{
             fontSize: 11,
-            color: '#64748b',
+            color: 'var(--v-text-muted)',
             marginTop: 1,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
@@ -177,18 +177,18 @@ export const CanvasPeopleAccessPanel: React.FC<CanvasPeopleAccessPanelProps> = (
     right: 0,
     width: 340,
     maxWidth: '92vw',
-    background: '#ffffff',
+    background: 'var(--v-chrome-bg)',
     borderRadius: 12,
     boxShadow: '0 12px 40px rgba(0,0,0,0.14), 0 0 0 1px rgba(0,0,0,0.06)',
-    border: '1px solid #e2e8f0',
+    border: '1px solid var(--v-border)',
     overflow: 'hidden',
     zIndex: 500,
   }}>
     <div style={{ padding: '14px 16px 12px', borderBottom: '1px solid #f1f5f9' }}>
-      <div style={{ fontSize: 15, fontWeight: 700, color: '#0f172a' }}>
+      <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--v-text)' }}>
         {isSharedAccess ? 'Shared with you' : 'People with access'}
       </div>
-      <div style={{ fontSize: 12, color: '#64748b', marginTop: 3, lineHeight: 1.4 }}>
+      <div style={{ fontSize: 12, color: 'var(--v-text-muted)', marginTop: 3, lineHeight: 1.4 }}>
         {getCanvasMembersPanelSubtitle({
           isSharedAccess,
           projectSharer,
@@ -219,7 +219,7 @@ export const CanvasPeopleAccessPanel: React.FC<CanvasPeopleAccessPanelProps> = (
       scrollbarWidth: 'thin',
     }}>
       {membersLoading && panelMembers.length === 0 && (
-        <div style={{ padding: '12px 8px', fontSize: 13, color: '#64748b', fontStyle: 'italic' }}>
+        <div style={{ padding: '12px 8px', fontSize: 13, color: 'var(--v-text-muted)', fontStyle: 'italic' }}>
           Loading…
         </div>
       )}
@@ -239,7 +239,7 @@ export const CanvasPeopleAccessPanel: React.FC<CanvasPeopleAccessPanelProps> = (
       ))}
       {!membersLoading && panelMembers.length === 0 && (
         <div style={{ padding: '12px 8px', display: 'grid', gap: 8 }}>
-          <div style={{ fontSize: 13, color: '#64748b' }}>
+          <div style={{ fontSize: 13, color: 'var(--v-text-muted)' }}>
             {isSharedAccess
               ? 'Member list is not available for viewers. You can still view this project.'
               : 'Could not load project members.'}
@@ -251,9 +251,9 @@ export const CanvasPeopleAccessPanel: React.FC<CanvasPeopleAccessPanelProps> = (
               justifySelf: 'start',
               padding: '6px 12px',
               borderRadius: 8,
-              border: '1px solid #e2e8f0',
-              background: '#fff',
-              color: '#334155',
+              border: '1px solid var(--v-border)',
+              background: 'var(--v-surface)',
+              color: 'var(--v-text-secondary)',
               fontSize: 12,
               fontWeight: 600,
               cursor: 'pointer',

--- a/src/components/canvas/CanvasProjectAccessControls.tsx
+++ b/src/components/canvas/CanvasProjectAccessControls.tsx
@@ -6,6 +6,7 @@ import {
   mergeSharerWithMembers,
 } from '../../utils/vsumMemberUtils';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
+import { ThemeToggle } from '../ui/ThemeToggle';
 import {
   CanvasAccountMenu,
   type CanvasAccountDisplay,
@@ -50,7 +51,7 @@ const CollaboratorStackButton: React.FC<CollaboratorStackButtonProps> = ({
       padding: '4px 10px 4px 6px',
       border: 'none',
       borderRadius: 8,
-      background: open ? '#f1f5f9' : 'transparent',
+      background: open ? 'var(--v-chrome-hover)' : 'transparent',
       transition: 'background 0.15s',
     }}
   >
@@ -69,7 +70,7 @@ const CollaboratorStackButton: React.FC<CollaboratorStackButtonProps> = ({
         </span>
       ))}
     </span>
-    <span style={{ fontSize: 12, fontWeight: 600, color: '#334155', whiteSpace: 'nowrap' }}>
+    <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--v-text-secondary)', whiteSpace: 'nowrap' }}>
       {stackLabel}
     </span>
     <svg
@@ -77,7 +78,7 @@ const CollaboratorStackButton: React.FC<CollaboratorStackButtonProps> = ({
       height="12"
       viewBox="0 0 24 24"
       fill="none"
-      stroke="#64748b"
+      stroke="var(--v-chrome-icon)"
       strokeWidth="2.5"
       strokeLinecap="round"
       strokeLinejoin="round"
@@ -183,6 +184,10 @@ export const CanvasProjectAccessControls: React.FC<CanvasProjectAccessControlsPr
 
       <Divider />
 
+      <ThemeToggle />
+
+      <Divider />
+
       <CanvasAccountMenu
         account={accountDisplay}
         dismissalBoundaryRef={wrapRef}
@@ -268,7 +273,7 @@ const rightPillStyle: React.CSSProperties = {
   right: 14,
   borderRadius: 8,
   zIndex: 400,
-  background: '#ffffff',
+  background: 'var(--v-chrome-bg)',
   boxShadow: '0 4px 16px rgba(0,0,0,0.13), 0 0 0 1px rgba(0,0,0,0.07)',
   display: 'flex',
   alignItems: 'center',
@@ -278,7 +283,7 @@ const rightPillStyle: React.CSSProperties = {
 };
 
 const Divider = () => (
-  <div style={{ width: 1, height: 22, background: '#e2e8f0', margin: '0 5px', flexShrink: 0 }} />
+  <div style={{ width: 1, height: 22, background: 'var(--v-chrome-divider)', margin: '0 5px', flexShrink: 0 }} />
 );
 
 const ShareIcon = () => (

--- a/src/components/canvas/CanvasProjectControls.tsx
+++ b/src/components/canvas/CanvasProjectControls.tsx
@@ -26,7 +26,7 @@ const projectControlsStyle: React.CSSProperties = {
   left: 14,
   borderRadius: 8,
   zIndex: 400,
-  background: '#ffffff',
+  background: 'var(--v-chrome-bg)',
   boxShadow: '0 4px 16px rgba(0,0,0,0.13), 0 0 0 1px rgba(0,0,0,0.07)',
   display: 'flex',
   alignItems: 'center',
@@ -36,7 +36,7 @@ const projectControlsStyle: React.CSSProperties = {
 };
 
 const ProjectControlsDivider = () => (
-  <div style={{ width: 1, height: 22, background: '#e2e8f0', margin: '0 5px', flexShrink: 0 }} />
+  <div style={{ width: 1, height: 22, background: 'var(--v-chrome-divider)', margin: '0 5px', flexShrink: 0 }} />
 );
 
 interface ProjectControlButtonProps {
@@ -52,7 +52,7 @@ function getProjectControlButtonBackground(
   hovered: boolean,
 ): string {
   if (active) return '#049484';
-  if (hovered) return '#f1f5f9';
+  if (hovered) return 'var(--v-chrome-hover)';
   return 'transparent';
 }
 
@@ -61,8 +61,8 @@ function getProjectControlButtonColor(
   hovered: boolean,
 ): string {
   if (active) return '#ffffff';
-  if (hovered) return '#1e293b';
-  return '#475569';
+  if (hovered) return 'var(--v-chrome-icon-hover)';
+  return 'var(--v-chrome-icon)';
 }
 
 const ProjectControlButton: React.FC<ProjectControlButtonProps> = ({
@@ -188,10 +188,10 @@ export const CanvasProjectControls: React.FC<CanvasProjectControlsProps> = ({
           }}
           disabled={savingName}
           style={{
-            fontSize: 13, fontWeight: 600, color: '#0f172a',
+            fontSize: 13, fontWeight: 600, color: 'var(--v-text)',
             border: '1.5px solid #93c5fd', borderRadius: 6,
             padding: '2px 8px', outline: 'none', width: 170,
-            background: '#fff',
+            background: 'var(--v-input-bg)',
           }}
         />
         <ProjectControlButton onClick={onConfirmRename} title="Save" active spinning={savingName}>

--- a/src/components/canvas/CanvasProjectLoadStateOverlay.tsx
+++ b/src/components/canvas/CanvasProjectLoadStateOverlay.tsx
@@ -40,7 +40,7 @@ export const CanvasProjectLoadStateOverlay: React.FC<CanvasProjectLoadStateOverl
     zIndex: 5000,
     display: 'grid',
     placeItems: 'center',
-    background: '#f8fafc',
+    background: 'var(--v-page-bg)',
     fontFamily: 'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
   };
 
@@ -48,8 +48,8 @@ export const CanvasProjectLoadStateOverlay: React.FC<CanvasProjectLoadStateOverl
       <div style={{
         width: 'min(420px, calc(100vw - 32px))',
         padding: '28px 30px',
-        background: '#ffffff',
-        border: '1px solid #e2e8f0',
+        background: 'var(--v-surface)',
+        border: '1px solid var(--v-border)',
         borderRadius: 14,
         boxShadow: '0 20px 60px rgba(15, 23, 42, 0.12)',
         textAlign: 'center',
@@ -79,7 +79,7 @@ export const CanvasProjectLoadStateOverlay: React.FC<CanvasProjectLoadStateOverl
         </div>
         <h1 style={{
           margin: '0 0 8px',
-          color: '#0f172a',
+          color: 'var(--v-text)',
           fontSize: 22,
           lineHeight: 1.2,
         }}>
@@ -87,7 +87,7 @@ export const CanvasProjectLoadStateOverlay: React.FC<CanvasProjectLoadStateOverl
         </h1>
         <p style={{
           margin: 0,
-          color: '#64748b',
+          color: 'var(--v-text-muted)',
           fontSize: 14,
           lineHeight: 1.6,
         }}>
@@ -105,9 +105,9 @@ export const CanvasProjectLoadStateOverlay: React.FC<CanvasProjectLoadStateOverl
               type="button"
               onClick={onBack}
               style={{
-                border: '1px solid #cbd5e1',
-                background: '#ffffff',
-                color: '#334155',
+                border: '1px solid var(--v-border)',
+                background: 'var(--v-surface)',
+                color: 'var(--v-text-secondary)',
                 borderRadius: 8,
                 padding: '10px 16px',
                 fontSize: 14,

--- a/src/components/canvas/CanvasProjectTabs.tsx
+++ b/src/components/canvas/CanvasProjectTabs.tsx
@@ -11,7 +11,7 @@ const TRACKPAD_SCROLL_HINT = 'Scroll with two fingers on your trackpad to see mo
 const pillShellBase: React.CSSProperties = {
   display: 'flex',
   alignItems: 'center',
-  background: '#ffffff',
+  background: 'var(--v-chrome-bg)',
   borderRadius: 6,
   boxShadow: '0 2px 10px rgba(0,0,0,0.10), 0 0 0 1px rgba(0,0,0,0.06)',
   height: 38,
@@ -119,16 +119,16 @@ export const CanvasProjectTabs: React.FC<CanvasProjectTabsProps> = ({
                   padding: useCompactTabs ? '0 7px' : '0 10px',
                   height: useCompactTabs ? 26 : 28,
                   borderRadius: 5,
-                  border: isActive ? '1px solid #049484' : '1px solid #e5e7eb',
-                  background: isActive ? '#f0fdfc' : '#fafafa',
+                  border: isActive ? '1px solid #049484' : '1px solid var(--v-border)',
+                  background: isActive ? 'var(--v-uml-primary-soft)' : 'var(--v-surface-hover)',
                   cursor: 'pointer',
                   flexShrink: 0,
                 }}
                 onMouseEnter={e => {
-                  if (!isActive) e.currentTarget.style.background = '#f1f5f9';
+                  if (!isActive) e.currentTarget.style.background = 'var(--v-chrome-hover)';
                 }}
                 onMouseLeave={e => {
-                  if (!isActive) e.currentTarget.style.background = '#fafafa';
+                  if (!isActive) e.currentTarget.style.background = 'var(--v-surface-hover)';
                 }}
               >
                 {isDirty && (
@@ -147,7 +147,7 @@ export const CanvasProjectTabs: React.FC<CanvasProjectTabsProps> = ({
                   style={{
                     fontSize: useCompactTabs ? 11 : 12,
                     fontWeight: isActive ? 700 : 500,
-                    color: isActive ? '#049484' : '#64748b',
+                    color: isActive ? '#049484' : 'var(--v-text-muted)',
                     whiteSpace: 'nowrap',
                     maxWidth: useCompactTabs ? 80 : 120,
                     overflow: 'hidden',
@@ -157,7 +157,7 @@ export const CanvasProjectTabs: React.FC<CanvasProjectTabsProps> = ({
                 >
                   {label}
                   {duplicateCount > 1 && (
-                    <span style={{ marginLeft: 3, fontSize: useCompactTabs ? 8 : 9, color: '#94a3b8' }}>
+                      <span style={{ marginLeft: 3, fontSize: useCompactTabs ? 8 : 9, color: 'var(--v-text-faint)' }}>
                       #{tab.projectId}
                     </span>
                   )}
@@ -172,7 +172,7 @@ export const CanvasProjectTabs: React.FC<CanvasProjectTabsProps> = ({
                   style={{
                     border: 'none',
                     background: 'transparent',
-                    color: '#94a3b8',
+                    color: 'var(--v-text-muted)',
                     cursor: 'pointer',
                     fontSize: useCompactTabs ? 12 : 13,
                     lineHeight: 1,
@@ -185,7 +185,7 @@ export const CanvasProjectTabs: React.FC<CanvasProjectTabsProps> = ({
                     flexShrink: 0,
                   }}
                   onMouseEnter={e => { e.currentTarget.style.color = '#dc2626'; }}
-                  onMouseLeave={e => { e.currentTarget.style.color = '#94a3b8'; }}
+                  onMouseLeave={e => { e.currentTarget.style.color = 'var(--v-text-muted)'; }}
                 >
                   ×
                 </button>
@@ -204,7 +204,7 @@ export const CanvasProjectTabs: React.FC<CanvasProjectTabsProps> = ({
               bottom: 0,
               width: 14,
               pointerEvents: 'none',
-              background: 'linear-gradient(to right, transparent, #ffffff)',
+              background: 'linear-gradient(to right, transparent, var(--v-chrome-bg))',
             }}
           />
         )}
@@ -219,7 +219,7 @@ export const CanvasProjectTabs: React.FC<CanvasProjectTabsProps> = ({
         .canvas-project-tabs-scroll::-webkit-scrollbar-thumb:hover { background: #94a3b8; }
       `}</style>
 
-      <div style={{ width: 1, height: 22, background: '#e2e8f0', flexShrink: 0 }} />
+      <div style={{ width: 1, height: 22, background: 'var(--v-chrome-divider)', flexShrink: 0 }} />
 
       <ProjectPickerMenu
         variant="compact"

--- a/src/components/canvas/CanvasSidebarToolbar.tsx
+++ b/src/components/canvas/CanvasSidebarToolbar.tsx
@@ -38,7 +38,7 @@ const sidebarCardStyle: React.CSSProperties = {
   left: 'auto',
   top: 'auto',
   zIndex: 'auto',
-  background: '#ffffff',
+  background: 'var(--v-chrome-bg)',
   borderRadius: 8,
   boxShadow: '0 4px 16px rgba(0,0,0,0.13), 0 0 0 1px rgba(0,0,0,0.07)',
   display: 'flex',
@@ -68,7 +68,7 @@ function getSidebarButtonBackground(
   disabled?: boolean,
 ): string {
   if (isFilled) return activeColor;
-  if (hovered && !disabled) return '#f1f5f9';
+  if (hovered && !disabled) return 'var(--v-chrome-hover)';
   return 'transparent';
 }
 
@@ -79,8 +79,8 @@ function getSidebarButtonIconColor(
 ): string {
   if (disabled) return '#c8d3dd';
   if (isFilled) return '#ffffff';
-  if (hovered) return '#1e293b';
-  return '#475569';
+  if (hovered) return 'var(--v-chrome-icon-hover)';
+  return 'var(--v-chrome-icon)';
 }
 
 const SidebarButton: React.FC<SidebarButtonProps> = ({
@@ -195,7 +195,7 @@ const ZipIcon = () => (
 
 function getDownloadMenuItemBackground(hovered: boolean, disabled?: boolean): string {
   if (disabled) return 'transparent';
-  return hovered ? '#f1f5f9' : 'transparent';
+  return hovered ? 'var(--v-chrome-hover)' : 'transparent';
 }
 
 const DownloadMenuItem: React.FC<{
@@ -217,7 +217,7 @@ const DownloadMenuItem: React.FC<{
         display: 'flex', alignItems: 'center', gap: 10,
         width: '100%', padding: '8px 10px', border: 'none', borderRadius: 6,
         background: getDownloadMenuItemBackground(hovered, disabled),
-        color: disabled ? '#94a3b8' : '#0f172a',
+        color: disabled ? 'var(--v-text-faint)' : 'var(--v-text)',
         cursor: disabled ? 'not-allowed' : 'pointer', textAlign: 'left',
         transition: 'background 0.1s',
       }}
@@ -231,7 +231,7 @@ const DownloadMenuItem: React.FC<{
       </span>
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ fontSize: 13, fontWeight: 600 }}>{label}</div>
-        <div style={{ fontSize: 11, color: '#64748b', fontWeight: 400, marginTop: 1 }}>{sublabel}</div>
+        <div style={{ fontSize: 11, color: 'var(--v-text-muted)', fontWeight: 400, marginTop: 1 }}>{sublabel}</div>
       </div>
     </button>
   );
@@ -310,7 +310,7 @@ export const CanvasSidebarToolbar: React.FC<CanvasSidebarToolbarProps> = ({
               position: 'absolute',
               left: 'calc(100% + 8px)',
               top: 0,
-              background: '#ffffff',
+              background: 'var(--v-chrome-bg)',
               borderRadius: 10,
               boxShadow: '0 8px 32px rgba(0,0,0,0.16), 0 0 0 1px rgba(0,0,0,0.07)',
               padding: '6px',

--- a/src/components/canvas/FloatingUMLPanel.tsx
+++ b/src/components/canvas/FloatingUMLPanel.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { MODAL_Z_INDEX, getAppPortalRoot, useModalBodyLock } from '../ui/modalUtils';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
+import { ThemeToggle } from '../ui/ThemeToggle';
 import { UMLDiagram, UMLDiagramHandle, UmlDiagramSaveContext, WORKSPACE_DOT_BACKGROUND } from './UMLDiagram';
 
 interface FloatingUMLPanelProps {
@@ -37,15 +38,15 @@ interface FloatingUMLPanelProps {
 /** Vitruv toolbar tokens — aligned with UMLDiagram / canvas */
 const V = {
   primary: '#049484',
-  primarySoft: '#ecfdf5',
-  primaryBorder: '#a7f3d0',
+  primarySoft: 'var(--v-uml-primary-soft)',
+  primaryBorder: 'var(--v-uml-primary-border)',
   primaryRing: 'rgba(4,148,132,0.15)',
-  ink: '#0c436e',
-  text: '#374151',
-  textMuted: '#64748b',
-  border: '#e2e8f0',
-  surface: '#ffffff',
-  surfaceHover: '#f0fdfa',
+  ink: 'var(--v-text)',
+  text: 'var(--v-text-secondary)',
+  textMuted: 'var(--v-text-muted)',
+  border: 'var(--v-border)',
+  surface: 'var(--v-surface)',
+  surfaceHover: 'var(--v-surface-hover)',
 } as const;
 
 const ToolbarDivider = () => (
@@ -228,7 +229,7 @@ export const FloatingUMLPanel: React.FC<FloatingUMLPanelProps> = ({
           top: 12,
           left: 12,
           zIndex: 40,
-          background: V.surface,
+          background: 'var(--v-chrome-bg)',
           border: `1px solid ${V.primaryBorder}`,
           boxShadow: `0 4px 14px ${V.primaryRing}, 0 0 0 1px rgba(4,148,132,0.05)`,
           display: 'flex',
@@ -403,6 +404,9 @@ export const FloatingUMLPanel: React.FC<FloatingUMLPanelProps> = ({
             {refreshMessage}
           </span>
         )}
+
+        <ToolbarDivider />
+        <ThemeToggle />
       </div>
 
       <div style={{ flex: 1, overflow: 'hidden', position: 'relative', minHeight: 0 }}>
@@ -482,7 +486,7 @@ const getToolbarBtnStyle = (
 
   let background: string = V.surface;
   if (disabled) {
-    background = '#f8fafc';
+    background = 'var(--v-surface-muted)';
   } else if (hov) {
     background = V.surfaceHover;
   }
@@ -526,7 +530,7 @@ const renderToolbarBtnContent = (
       <span style={{
         width: 14,
         height: 14,
-        border: '2px solid #e2e8f0',
+        border: '2px solid var(--v-border)',
         borderTopColor: V.primary,
         borderRadius: '50%',
         animation: 'uml-spin 0.7s linear infinite',
@@ -582,10 +586,10 @@ const ZoomButton: React.FC<{ title: string; onClick: () => void; children: React
       onMouseLeave={() => setHov(false)}
       style={{
         width: 32, height: 32,
-        border: '1px solid #e2e8f0',
+        border: '1px solid var(--v-border)',
         borderRadius: 8,
-        background: hov ? '#f8fafc' : '#ffffff',
-        color: hov ? '#0f172a' : '#64748b',
+        background: hov ? 'var(--v-chrome-hover)' : 'var(--v-chrome-bg)',
+        color: hov ? 'var(--v-chrome-icon-hover)' : 'var(--v-chrome-icon)',
         boxShadow: '0 1px 4px rgba(0,0,0,0.08)',
         cursor: 'pointer',
         display: 'flex', alignItems: 'center', justifyContent: 'center',

--- a/src/components/canvas/ModelDrawer.tsx
+++ b/src/components/canvas/ModelDrawer.tsx
@@ -514,8 +514,8 @@ const DetailView: React.FC<DetailViewProps> = ({ model, onFetchFile, onAddModel,
             {isOnCanvas ? (
               <div style={{
                 padding: '9px 0', borderRadius: 8,
-                background: '#f0fdf4', border: '1px solid #bbf7d0',
-                color: '#15803d', fontSize: 12, fontWeight: 600,
+                background: 'var(--v-success-bg)', border: '1px solid var(--v-success-border)',
+                color: 'var(--v-success-text)', fontSize: 12, fontWeight: 600,
                 display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
               }}>
                 <svg width="13" height="13" viewBox="0 0 16 16" fill="none">

--- a/src/components/canvas/ModelDrawer.tsx
+++ b/src/components/canvas/ModelDrawer.tsx
@@ -10,6 +10,19 @@ import {
 
 const FONT = 'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif';
 const DARK = '#1e293b';
+const T = {
+  text: 'var(--v-text)',
+  secondary: 'var(--v-text-secondary)',
+  muted: 'var(--v-text-muted)',
+  faint: 'var(--v-text-faint)',
+  surface: 'var(--v-surface)',
+  mutedBg: 'var(--v-surface-muted)',
+  hover: 'var(--v-chrome-hover)',
+  border: 'var(--v-border)',
+  borderSubtle: 'var(--v-border-subtle)',
+  inputBg: 'var(--v-input-bg)',
+  workspace: 'var(--v-workspace-bg)',
+};
 
 export interface DrawerModel {
   id: number;
@@ -130,12 +143,12 @@ export const ModelDrawer: React.FC<ModelDrawerProps> = ({
   };
 
   return (
-    <div style={{ width: '100%', height: '100%', background: '#ffffff', display: 'flex', flexDirection: 'column', fontFamily: FONT }}>
+    <div style={{ width: '100%', height: '100%', background: T.surface, display: 'flex', flexDirection: 'column', fontFamily: FONT }}>
 
       {/* ── Header ── */}
       <div style={{
         padding: '12px 14px',
-        borderBottom: '1px solid #f1f5f9',
+        borderBottom: `1px solid ${T.border}`,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
@@ -148,7 +161,7 @@ export const ModelDrawer: React.FC<ModelDrawerProps> = ({
             style={{
               display: 'flex', alignItems: 'center', gap: 5,
               border: 'none', background: 'none', cursor: 'pointer',
-              color: DARK, fontSize: 13, fontWeight: 600, padding: '2px 0',
+              color: T.text, fontSize: 13, fontWeight: 600, padding: '2px 0',
             }}
           >
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
@@ -157,7 +170,7 @@ export const ModelDrawer: React.FC<ModelDrawerProps> = ({
             Back
           </button>
         ) : (
-          <span style={{ fontSize: 13, fontWeight: 700, color: '#0f172a', letterSpacing: '-0.01em' }}>
+          <span style={{ fontSize: 13, fontWeight: 700, color: T.text, letterSpacing: '-0.01em' }}>
             Model Library
           </span>
         )}
@@ -166,18 +179,18 @@ export const ModelDrawer: React.FC<ModelDrawerProps> = ({
           onClick={onClose}
           style={{
             border: 'none', background: 'transparent', cursor: 'pointer',
-            color: '#94a3b8', fontSize: 14, lineHeight: 1, padding: '3px 5px',
+            color: T.muted, fontSize: 14, lineHeight: 1, padding: '3px 5px',
             borderRadius: 5, transition: 'all 0.1s', marginLeft: 'auto',
           }}
           onMouseEnter={e => {
             const button = e.currentTarget;
-            button.style.background = '#f1f5f9';
-            button.style.color = '#475569';
+            button.style.background = T.hover;
+            button.style.color = T.secondary;
           }}
           onMouseLeave={e => {
             const button = e.currentTarget;
             button.style.background = 'transparent';
-            button.style.color = '#94a3b8';
+            button.style.color = T.muted;
           }}
           title="Close"
         >
@@ -250,7 +263,7 @@ const LibraryView: React.FC<LibraryViewProps> = ({
 }) => (
   <div style={{ flex: 1, overflowY: 'auto', display: 'flex', flexDirection: 'column' }}>
     {loading ? (
-      <div style={{ padding: '32px 0', textAlign: 'center', color: '#94a3b8' }}>
+      <div style={{ padding: '32px 0', textAlign: 'center', color: T.muted }}>
         <div style={{ width: 22, height: 22, border: '2.5px solid #e2e8f0', borderTop: `2.5px solid ${DARK}`, borderRadius: '50%', animation: 'spin 0.8s linear infinite', margin: '0 auto 10px' }} />
         <span style={{ fontSize: 12 }}>Loading...</span>
       </div>
@@ -261,7 +274,7 @@ const LibraryView: React.FC<LibraryViewProps> = ({
           <SectionLabel>On canvas</SectionLabel>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 5, marginBottom: 12 }}>
             {onCanvas.length === 0 ? (
-              <div style={{ padding: '8px 4px', textAlign: 'center', color: '#cbd5e1', fontSize: 11 }}>
+              <div style={{ padding: '8px 4px', textAlign: 'center', color: T.faint, fontSize: 11 }}>
                 No models on canvas
               </div>
             ) : (
@@ -273,16 +286,16 @@ const LibraryView: React.FC<LibraryViewProps> = ({
         </div>
 
         {/* Library */}
-        <div style={{ borderTop: '1px solid #f1f5f9', display: 'flex', flexDirection: 'column', flex: 1 }}>
+        <div style={{ borderTop: `1px solid ${T.border}`, display: 'flex', flexDirection: 'column', flex: 1 }}>
           <div style={{ padding: '10px 14px 0', flexShrink: 0 }}>
             {/* Tab strip */}
-            <div style={{ display: 'flex', borderRadius: 8, overflow: 'hidden', border: '1px solid #e2e8f0', marginBottom: 10 }}>
+            <div style={{ display: 'flex', borderRadius: 8, overflow: 'hidden', border: `1px solid ${T.border}`, marginBottom: 10 }}>
               {(['my', 'public'] as const).map(tab => (
                 <button type="button" key={tab} onClick={() => switchTab(tab)} style={{
                   flex: 1, padding: '7px 0', border: 'none', fontSize: 11, fontWeight: 600,
                   cursor: 'pointer', letterSpacing: '0.04em', textTransform: 'uppercase',
-                  background: libTab === tab ? DARK : '#f8fafc',
-                  color: libTab === tab ? '#fff' : '#94a3b8',
+                  background: libTab === tab ? DARK : T.mutedBg,
+                  color: libTab === tab ? '#fff' : T.muted,
                   transition: 'all 0.15s',
                 }}>
                   {tab === 'my' ? 'My Library' : 'Public Library'}
@@ -292,7 +305,7 @@ const LibraryView: React.FC<LibraryViewProps> = ({
 
             {/* Search */}
             <div style={{ position: 'relative', marginBottom: 8 }}>
-              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--v-text-muted)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
                 style={{ position: 'absolute', left: 10, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}>
                 <circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" />
               </svg>
@@ -304,18 +317,18 @@ const LibraryView: React.FC<LibraryViewProps> = ({
                 style={{
                   width: '100%', boxSizing: 'border-box',
                   padding: '8px 28px 8px 30px',
-                  border: '1.5px solid #e2e8f0', borderRadius: 8,
-                  fontSize: 12, color: '#0f172a', background: '#f8fafc',
+                  border: `1.5px solid ${T.border}`, borderRadius: 8,
+                  fontSize: 12, color: T.text, background: T.inputBg,
                   outline: 'none', fontFamily: FONT, transition: 'border-color 0.15s',
                 }}
                 onFocus={e => (e.currentTarget.style.borderColor = DARK)}
-                onBlur={e => (e.currentTarget.style.borderColor = '#e2e8f0')}
+                onBlur={e => (e.currentTarget.style.borderColor = T.border)}
               />
               {search && (
                 <button type="button" onClick={() => setSearch('')} style={{
                   position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)',
                   border: 'none', background: 'none', cursor: 'pointer',
-                  color: '#94a3b8', fontSize: 14, lineHeight: 1, padding: 2,
+                  color: T.muted, fontSize: 14, lineHeight: 1, padding: 2,
                 }}>✕</button>
               )}
             </div>
@@ -330,8 +343,8 @@ const LibraryView: React.FC<LibraryViewProps> = ({
                     <button type="button" key={domain} onClick={() => setDomainFilter(active ? null : domain)} style={{
                       padding: '3px 9px', border: 'none', borderRadius: 20,
                       fontSize: 10, fontWeight: 600, cursor: 'pointer', letterSpacing: '0.03em',
-                      background: active ? theme.badge : '#f1f5f9',
-                      color: active ? theme.badgeText : '#64748b',
+                      background: active ? theme.badge : T.hover,
+                      color: active ? theme.badgeText : T.muted,
                       transition: 'all 0.12s',
                       outline: active ? `1.5px solid ${theme.icon}40` : 'none',
                     }}>
@@ -346,7 +359,7 @@ const LibraryView: React.FC<LibraryViewProps> = ({
           {/* Results */}
           <div style={{ padding: '0 14px 14px', flex: 1 }}>
             {fromLibrary.length === 0 ? (
-              <div style={{ padding: '24px 4px', textAlign: 'center', color: '#cbd5e1', fontSize: 11 }}>
+              <div style={{ padding: '24px 4px', textAlign: 'center', color: T.faint, fontSize: 11 }}>
                 {search || domainFilter ? 'No models match your filter' : 'No models available'}
               </div>
             ) : (
@@ -422,15 +435,15 @@ const DetailView: React.FC<DetailViewProps> = ({ model, onFetchFile, onAddModel,
     <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
 
       {/* ── Banner ── */}
-      <div style={{ padding: '14px 16px', background: '#ffffff', borderBottom: '1px solid #f1f5f9', flexShrink: 0, display: 'flex', alignItems: 'center', gap: 10, minWidth: 0, overflow: 'hidden' }}>
+      <div style={{ padding: '14px 16px', background: T.surface, borderBottom: `1px solid ${T.border}`, flexShrink: 0, display: 'flex', alignItems: 'center', gap: 10, minWidth: 0, overflow: 'hidden' }}>
         <svg width="28" height="28" viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
           <path d="M16 5L27 11V21L16 27L5 21V11L16 5Z" stroke="#049484" strokeWidth="1.6" fill="#04948422" strokeLinejoin="round" />
           <path d="M16 5V27" stroke="#049484" strokeWidth="1.3" strokeLinecap="round" />
           <path d="M5 11L27 11" stroke="#049484" strokeWidth="1.3" strokeLinecap="round" />
           <path d="M16 5L5 11L16 17L27 11L16 5Z" stroke="#049484" strokeWidth="1.3" fill="#04948418" strokeLinejoin="round" />
         </svg>
-        <div style={{ fontSize: 15, fontWeight: 700, color: '#0f172a', letterSpacing: '-0.01em', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', minWidth: 0 }}>
-          Model Preview: <span style={{ color: '#374151', fontWeight: 600 }}>{model.name}</span>
+        <div style={{ fontSize: 15, fontWeight: 700, color: T.text, letterSpacing: '-0.01em', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', minWidth: 0 }}>
+          Model Preview: <span style={{ color: T.secondary, fontWeight: 600 }}>{model.name}</span>
         </div>
       </div>
 
@@ -440,7 +453,7 @@ const DetailView: React.FC<DetailViewProps> = ({ model, onFetchFile, onAddModel,
         {/* Left — fields */}
         <div style={{
           width: 280, flexShrink: 0,
-          borderRight: '1px solid #f1f5f9',
+          borderRight: `1px solid ${T.border}`,
           overflowY: 'auto',
           padding: '20px 22px',
           display: 'flex', flexDirection: 'column', gap: 20,
@@ -449,7 +462,7 @@ const DetailView: React.FC<DetailViewProps> = ({ model, onFetchFile, onAddModel,
           {/* Name */}
           <div>
             <FieldLabel>Name</FieldLabel>
-            <div style={{ fontSize: 14, fontWeight: 600, color: '#0f172a', fontFamily: FONT, lineHeight: 1.4 }}>
+            <div style={{ fontSize: 14, fontWeight: 600, color: T.text, fontFamily: FONT, lineHeight: 1.4 }}>
               {model.name}
             </div>
           </div>
@@ -473,8 +486,8 @@ const DetailView: React.FC<DetailViewProps> = ({ model, onFetchFile, onAddModel,
           {/* Description */}
           <div style={{ flex: 1 }}>
             <FieldLabel>Description</FieldLabel>
-            <div style={{ fontSize: 13, color: '#374151', fontFamily: FONT, lineHeight: 1.7 }}>
-              {model.description || <span style={{ color: '#cbd5e1' }}>—</span>}
+            <div style={{ fontSize: 13, color: T.secondary, fontFamily: FONT, lineHeight: 1.7 }}>
+              {model.description || <span style={{ color: T.faint }}>—</span>}
             </div>
           </div>
 
@@ -483,16 +496,16 @@ const DetailView: React.FC<DetailViewProps> = ({ model, onFetchFile, onAddModel,
             ecoreFileId={model.ecoreFileId}
             genModelFileId={model.genModelFileId}
             labelStyle={{
-              fontSize: 11, fontWeight: 700, color: '#374151',
+              fontSize: 11, fontWeight: 700, color: T.secondary,
               marginBottom: 5, letterSpacing: '0.01em', fontFamily: FONT,
             }}
           />
 
           {/* Created */}
           {model.createdAt && (
-            <div style={{ borderTop: '1px solid #f1f5f9', paddingTop: 12 }}>
+            <div style={{ borderTop: `1px solid ${T.border}`, paddingTop: 12 }}>
               <FieldLabel>Created</FieldLabel>
-              <div style={{ fontSize: 13, color: '#64748b' }}>{formatDate(model.createdAt)}</div>
+              <div style={{ fontSize: 13, color: T.muted }}>{formatDate(model.createdAt)}</div>
             </div>
           )}
 
@@ -535,12 +548,12 @@ const DetailView: React.FC<DetailViewProps> = ({ model, onFetchFile, onAddModel,
                 title="Delete meta-model"
                 style={{
                   width: '100%', padding: '9px 0', border: '1px solid #fecaca', borderRadius: 8,
-                  background: '#fff', color: '#dc2626', fontSize: 12, fontWeight: 600,
+                  background: T.surface, color: '#dc2626', fontSize: 12, fontWeight: 600,
                   cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
                   transition: 'background 0.15s', fontFamily: FONT,
                 }}
                 onMouseEnter={e => (e.currentTarget.style.background = '#fef2f2')}
-                onMouseLeave={e => (e.currentTarget.style.background = '#fff')}
+                onMouseLeave={e => (e.currentTarget.style.background = T.surface)}
               >
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <polyline points="3 6 5 6 21 6" />
@@ -554,10 +567,10 @@ const DetailView: React.FC<DetailViewProps> = ({ model, onFetchFile, onAddModel,
 
         {/* Right — UML preview */}
         {/* Right — UML preview */}
-        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', background: '#ffffff' }}>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', background: T.workspace }}>
           {/* Label + zoom controls */}
           <div style={{ padding: '14px 18px 10px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
-            <span style={{ fontSize: 13, fontWeight: 600, color: '#374151', fontFamily: FONT }}>UML</span>
+            <span style={{ fontSize: 13, fontWeight: 600, color: T.secondary, fontFamily: FONT }}>UML</span>
             {ecoreContent && (
               <div style={{ display: 'flex', gap: 4 }}>
                 <PreviewBtn title="Open full-screen UML editor" onClick={() => setUmlExpanded(true)}>
@@ -588,20 +601,20 @@ const DetailView: React.FC<DetailViewProps> = ({ model, onFetchFile, onAddModel,
 
           {/* Diagram card */}
           <div style={{ flex: 1, padding: '0 18px 18px', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-            <div style={{ flex: 1, position: 'relative', background: '#ffffff', borderRadius: 10, border: '1px solid #e2e8f0', overflow: 'hidden', boxShadow: '0 1px 4px rgba(0,0,0,0.04)' }}>
+            <div style={{ flex: 1, position: 'relative', background: T.workspace, borderRadius: 10, border: `1px solid ${T.border}`, overflow: 'hidden', boxShadow: 'var(--v-card-shadow)' }}>
               {fetchingUml && (
-                <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 10, color: '#94a3b8' }}>
-                  <div style={{ width: 24, height: 24, border: '2.5px solid #e2e8f0', borderTop: `2.5px solid ${theme.icon}`, borderRadius: '50%', animation: 'spin 0.8s linear infinite' }} />
+                <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 10, color: T.muted }}>
+                  <div style={{ width: 24, height: 24, border: `2.5px solid ${T.border}`, borderTop: `2.5px solid ${theme.icon}`, borderRadius: '50%', animation: 'spin 0.8s linear infinite' }} />
                   <span style={{ fontSize: 12, fontFamily: FONT }}>Loading preview…</span>
                 </div>
               )}
               {!fetchingUml && fetchError && (
-                <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#cbd5e1', fontSize: 12, fontFamily: FONT }}>
+                <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: T.faint, fontSize: 12, fontFamily: FONT }}>
                   Could not load UML preview
                 </div>
               )}
               {!fetchingUml && !fetchError && !ecoreContent && (
-                <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#cbd5e1', fontSize: 12, fontFamily: FONT }}>
+                <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: T.faint, fontSize: 12, fontFamily: FONT }}>
                   No diagram available
                 </div>
               )}
@@ -642,7 +655,7 @@ const DetailView: React.FC<DetailViewProps> = ({ model, onFetchFile, onAddModel,
 
 const FieldLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <div style={{
-    fontSize: 11, fontWeight: 700, color: '#374151',
+    fontSize: 11, fontWeight: 700, color: T.secondary,
     marginBottom: 5, letterSpacing: '0.01em', fontFamily: FONT,
   }}>
     {children}
@@ -656,8 +669,8 @@ const PreviewBtn: React.FC<{ title: string; onClick: () => void; children: React
       title={title} onClick={onClick}
       onMouseEnter={() => setHov(true)} onMouseLeave={() => setHov(false)}
       style={{
-        width: 24, height: 24, border: '1px solid #e2e8f0', borderRadius: 6,
-        background: hov ? '#f1f5f9' : '#fff', color: hov ? '#0f172a' : '#64748b',
+        width: 24, height: 24, border: `1px solid ${T.border}`, borderRadius: 6,
+        background: hov ? T.hover : T.surface, color: hov ? T.text : T.muted,
         cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
         transition: 'all 0.12s',
       }}
@@ -671,7 +684,7 @@ const PreviewBtn: React.FC<{ title: string; onClick: () => void; children: React
 
 const SectionLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <div style={{
-    fontSize: 10, fontWeight: 700, color: '#94a3b8',
+    fontSize: 10, fontWeight: 700, color: T.muted,
     letterSpacing: '0.06em', textTransform: 'uppercase',
     padding: '2px 2px 6px',
   }}>
@@ -715,7 +728,7 @@ const ModelCard: React.FC<ModelCardProps> = ({ model, onCanvas, onAdd, onOpenDet
         style={{
           display: 'flex', flexDirection: 'row', alignItems: 'center',
           gap: 10, padding: '7px 10px', borderRadius: 8,
-          background: '#f8fafc', border: '1.5px solid #e2e8f0',
+          background: T.mutedBg, border: `1.5px solid ${T.border}`,
           width: '100%', boxSizing: 'border-box', cursor: 'context-menu',
           fontFamily: 'inherit', textAlign: 'left',
         }}
@@ -726,7 +739,7 @@ const ModelCard: React.FC<ModelCardProps> = ({ model, onCanvas, onAdd, onOpenDet
         </div>
 
         {/* Name — fixed left column */}
-        <div style={{ flex: '0 0 30%', minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 12, fontWeight: 700, color: '#1e293b' }}>
+        <div style={{ flex: '0 0 30%', minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 12, fontWeight: 700, color: T.text }}>
           {model.name}
         </div>
 
@@ -738,16 +751,16 @@ const ModelCard: React.FC<ModelCardProps> = ({ model, onCanvas, onAdd, onOpenDet
               background: theme.badge, color: theme.badgeText,
               fontSize: 9, fontWeight: 700, letterSpacing: '0.03em', textTransform: 'uppercase',
             }}>{model.domain}</span>
-          ) : <span style={{ color: '#e2e8f0' }}>—</span>}
+          ) : <span style={{ color: T.faint }}>—</span>}
         </div>
 
         {/* Date */}
-        <div style={{ flex: '0 0 18%', minWidth: 0, fontSize: 10, color: '#94a3b8', whiteSpace: 'nowrap' }}>
+        <div style={{ flex: '0 0 18%', minWidth: 0, fontSize: 10, color: T.muted, whiteSpace: 'nowrap' }}>
           {formatDate(model.createdAt) ?? '—'}
         </div>
 
         {/* Keywords count */}
-        <div style={{ flex: '0 0 16%', minWidth: 0, fontSize: 10, color: '#94a3b8', whiteSpace: 'nowrap' }}>
+        <div style={{ flex: '0 0 16%', minWidth: 0, fontSize: 10, color: T.muted, whiteSpace: 'nowrap' }}>
           {model.keyword && model.keyword.length > 0 ? `${model.keyword.length} kw` : '—'}
         </div>
 
@@ -794,16 +807,16 @@ const ModelCard: React.FC<ModelCardProps> = ({ model, onCanvas, onAdd, onOpenDet
             background: theme.badge, color: theme.badgeText,
             fontSize: 9, fontWeight: 700, letterSpacing: '0.03em', textTransform: 'uppercase',
           }}>{model.domain}</span>
-        ) : <span style={{ color: '#e2e8f0', fontSize: 10 }}>—</span>}
+        ) : <span style={{ color: T.faint, fontSize: 10 }}>—</span>}
       </div>
 
       {/* Date */}
-      <div style={{ flex: '0 0 18%', minWidth: 0, fontSize: 10, color: '#94a3b8', whiteSpace: 'nowrap' }}>
+      <div style={{ flex: '0 0 18%', minWidth: 0, fontSize: 10, color: '#475569', whiteSpace: 'nowrap' }}>
         {formatDate(model.createdAt) ?? '—'}
       </div>
 
       {/* Keywords count */}
-      <div style={{ flex: '0 0 16%', minWidth: 0, fontSize: 10, color: '#94a3b8', whiteSpace: 'nowrap' }}>
+      <div style={{ flex: '0 0 16%', minWidth: 0, fontSize: 10, color: '#475569', whiteSpace: 'nowrap' }}>
         {model.keyword && model.keyword.length > 0 ? `${model.keyword.length} kw` : '—'}
       </div>
     </button>

--- a/src/components/canvas/ModelDrawerModal.tsx
+++ b/src/components/canvas/ModelDrawerModal.tsx
@@ -42,10 +42,10 @@ export const ModelDrawerModal: React.FC<ModelDrawerModalProps> = ({
       height: 'min(700px, 88vh)',
       zIndex: MODAL_Z_INDEX + 1,
       pointerEvents: 'auto',
-      background: '#ffffff',
+      background: 'var(--v-surface)',
       borderRadius: 10,
-      boxShadow: '0 24px 64px rgba(0,0,0,0.28), 0 4px 16px rgba(0,0,0,0.10)',
-      border: '1px solid #e2e8f0',
+      boxShadow: 'var(--v-card-shadow)',
+      border: '1px solid var(--v-border)',
       overflow: 'hidden',
     }}>
       <ModelDrawer

--- a/src/components/canvas/ProjectPickerMenu.tsx
+++ b/src/components/canvas/ProjectPickerMenu.tsx
@@ -204,16 +204,16 @@ export const ProjectPickerMenu: React.FC<ProjectPickerMenuProps> = ({
           overflow: 'hidden',
           display: 'flex',
           flexDirection: 'column',
-          background: '#ffffff',
-          border: '1px solid #e2e8f0',
+          background: 'var(--v-surface)',
+          border: '1px solid var(--v-border)',
           borderRadius: 10,
           boxShadow: '0 16px 40px rgba(0,0,0,0.16)',
           zIndex: MENU_Z_INDEX,
           boxSizing: 'border-box',
         }}
       >
-      <div style={{ flexShrink: 0, padding: '10px 12px', borderBottom: '1px solid #f1f5f9' }}>
-        <div style={{ fontSize: 11, fontWeight: 700, color: '#64748b', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 8 }}>
+      <div style={{ flexShrink: 0, padding: '10px 12px', borderBottom: '1px solid var(--v-border)' }}>
+        <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--v-text-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 8 }}>
           Your projects
         </div>
         <input
@@ -227,9 +227,11 @@ export const ProjectPickerMenu: React.FC<ProjectPickerMenuProps> = ({
             boxSizing: 'border-box',
             padding: '9px 11px',
             fontSize: 13,
-            border: '1px solid #e2e8f0',
+            border: '1px solid var(--v-border)',
             borderRadius: 8,
             outline: 'none',
+            background: 'var(--v-input-bg)',
+            color: 'var(--v-text)',
           }}
         />
       </div>
@@ -252,10 +254,10 @@ export const ProjectPickerMenu: React.FC<ProjectPickerMenuProps> = ({
         }}
       >
         {loading && (
-          <div style={{ padding: '14px 12px', fontSize: 13, color: '#64748b' }}>Loading projects…</div>
+          <div style={{ padding: '14px 12px', fontSize: 13, color: 'var(--v-text-muted)' }}>Loading projects…</div>
         )}
         {!loading && projects.length === 0 && (
-          <div style={{ padding: '14px 12px', fontSize: 13, color: '#64748b' }}>No projects found</div>
+          <div style={{ padding: '14px 12px', fontSize: 13, color: 'var(--v-text-muted)' }}>No projects found</div>
         )}
         {!loading && projects.map(project => {
           const isActive = project.id === activeProjectId;
@@ -301,7 +303,7 @@ export const ProjectPickerMenu: React.FC<ProjectPickerMenuProps> = ({
                 gap: 10,
               }}
               onMouseEnter={e => {
-                if (!isActive) e.currentTarget.style.background = '#f8fafc';
+                if (!isActive) e.currentTarget.style.background = 'var(--v-surface-hover)';
               }}
               onMouseLeave={e => {
                 if (!isActive) e.currentTarget.style.background = 'transparent';
@@ -321,14 +323,14 @@ export const ProjectPickerMenu: React.FC<ProjectPickerMenuProps> = ({
                   display: 'block',
                   fontSize: 13,
                   fontWeight: isActive ? 700 : 500,
-                  color: '#0f172a',
+                  color: 'var(--v-text)',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
                 }}>
                   {project.name}
                 </span>
-                <span style={{ fontSize: 11, color: '#64748b', marginTop: 2, display: 'block' }}>
+                <span style={{ fontSize: 11, color: 'var(--v-text-muted)', marginTop: 2, display: 'block' }}>
                   {statusLine}
                   {isCurrentInPill && !isActive && isOpen && ''}
                 </span>
@@ -403,24 +405,24 @@ export const ProjectPickerMenu: React.FC<ProjectPickerMenuProps> = ({
           height: 34,
           border: isCompact ? '1px solid transparent' : 'none',
           borderRadius: 6,
-          background: open ? '#f0fdfc' : 'transparent',
+          background: open ? 'var(--v-uml-primary-soft)' : 'transparent',
           cursor: disabled ? 'not-allowed' : 'pointer',
           fontSize: 13,
           fontWeight: 600,
-          color: isCompact ? '#64748b' : '#0f172a',
+          color: isCompact ? 'var(--v-text-muted)' : 'var(--v-text)',
           letterSpacing: '-0.01em',
           whiteSpace: 'nowrap',
         }}
         onMouseEnter={e => {
           if (!disabled) {
-            e.currentTarget.style.background = '#f1f5f9';
-            if (isCompact) e.currentTarget.style.color = '#1e293b';
+            e.currentTarget.style.background = 'var(--v-chrome-hover)';
+            if (isCompact) e.currentTarget.style.color = 'var(--v-text)';
           }
         }}
         onMouseLeave={e => {
           if (!open && !disabled) {
             e.currentTarget.style.background = 'transparent';
-            if (isCompact) e.currentTarget.style.color = '#64748b';
+            if (isCompact) e.currentTarget.style.color = 'var(--v-text-muted)';
           }
         }}
       >
@@ -438,7 +440,7 @@ export const ProjectPickerMenu: React.FC<ProjectPickerMenuProps> = ({
             }}>
               {currentProjectName}
             </span>
-            <span style={{ color: '#64748b', display: 'flex', flexShrink: 0 }}>
+            <span style={{ color: 'var(--v-text-muted)', display: 'flex', flexShrink: 0 }}>
               <ChevronIcon />
             </span>
           </>
@@ -447,9 +449,9 @@ export const ProjectPickerMenu: React.FC<ProjectPickerMenuProps> = ({
 
       <style>{`
         .project-picker-scroll::-webkit-scrollbar { width: 8px; }
-        .project-picker-scroll::-webkit-scrollbar-track { background: #f1f5f9; border-radius: 4px; }
+        .project-picker-scroll::-webkit-scrollbar-track { background: var(--v-scrollbar-track); border-radius: 4px; }
         .project-picker-scroll::-webkit-scrollbar-thumb {
-          background: #cbd5e1;
+          background: var(--v-scrollbar-thumb);
           border-radius: 4px;
         }
         .project-picker-scroll::-webkit-scrollbar-thumb:hover { background: #94a3b8; }

--- a/src/components/canvas/UMLClassBox.tsx
+++ b/src/components/canvas/UMLClassBox.tsx
@@ -69,7 +69,7 @@ function getClassBoxNameSectionHeight(
 
 function getClassBoxBorder(selected: boolean, connectSource: boolean): string {
   if (connectSource || selected) return `2.5px solid ${UML.primary}`;
-  return `1.5px solid ${UML.border}`;
+  return `1.5px solid ${UML.boxBorder}`;
 }
 
 function isClassBoxHighlighted(
@@ -114,7 +114,7 @@ function getClassBoxOuterStyle(params: {
     width: '100%',
     border: params.boxBorder,
     borderRadius: 8,
-    background: UML.surface,
+    background: UML.boxBg,
     boxShadow: params.boxShadow,
     userSelect: 'none',
     fontFamily: UML.fontMono,
@@ -229,7 +229,7 @@ function getClassBoxNameSectionBackground(
   selected: boolean,
 ): string {
   if (isEditingName || selected) return UML.primarySoft;
-  return UML.surfaceMuted;
+  return UML.boxMuted;
 }
 
 function getClassBoxNameSectionPadding(isEditingName: boolean): string {
@@ -245,7 +245,7 @@ function getClassBoxNameSectionStyle(
   return {
     height: nameSectionH,
     background: nameSectionBackground,
-    borderBottom: `1.5px solid ${UML.border}`,
+    borderBottom: `1.5px solid ${UML.boxBorder}`,
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
@@ -474,7 +474,7 @@ const ClassBoxNameSection = ({
     <span
       style={{
         fontSize: 10,
-        color: '#444444',
+        color: UML.boxTextMuted,
         fontStyle: 'italic',
         fontFamily: 'ui-sans-serif, system-ui, sans-serif',
       }}
@@ -519,8 +519,8 @@ const ClassBoxNameSection = ({
             fontSize: 14,
             fontWeight: 700,
             fontFamily: UML.fontSans,
-            color: UML.ink,
-            background: UML.surface,
+            color: UML.boxText,
+            background: UML.boxBg,
             outline: 'none',
             boxShadow: `0 0 0 3px ${UML.primaryRing}`,
           }}
@@ -551,7 +551,7 @@ const ClassBoxNameSection = ({
         style={{
           fontWeight: 700,
           fontSize: 13,
-          color: '#000000',
+          color: UML.boxText,
           fontFamily: 'ui-sans-serif, system-ui, sans-serif',
           fontStyle: nameFontStyle,
           textAlign: 'center',
@@ -723,9 +723,9 @@ export const UMLClassBox = ({
 
         <div
           style={{
-            borderBottom: `1px solid ${UML.border}`,
+            borderBottom: `1px solid ${UML.boxBorder}`,
             padding: sectionPadding,
-            background: UML.surface,
+            background: UML.boxBg,
             transition: 'padding 0.22s ease',
           }}
         >
@@ -764,7 +764,7 @@ export const UMLClassBox = ({
         <div
           style={{
             padding: sectionPadding,
-            background: '#ffffff',
+            background: UML.boxBg,
             minHeight: UML_CLASS_EMPTY_OPERATION_SECTION_HEIGHT,
             transition: 'padding 0.22s ease',
           }}

--- a/src/components/canvas/UMLClassMemberRows.tsx
+++ b/src/components/canvas/UMLClassMemberRows.tsx
@@ -33,8 +33,8 @@ const umlMemberEditFieldStyle: CSSProperties = {
   border: `1px solid ${UML.primaryBorder}`,
   borderRadius: 4,
   padding: '1px 4px',
-  background: UML.surface,
-  color: UML.ink,
+  background: UML.boxBg,
+  color: UML.boxText,
   fontFamily: UML.fontSans,
 };
 
@@ -78,7 +78,7 @@ function getUmlRowContainerStyle(hovered: boolean): CSSProperties {
     alignItems: 'center',
     padding: '0 6px',
     height: UML_CLASS_MEMBER_ROW_HEIGHT,
-    background: hovered ? '#f8fafc' : 'transparent',
+    background: hovered ? UML.boxHover : 'transparent',
     gap: 3,
   };
 }
@@ -279,7 +279,7 @@ const UmlAttributeRowEditor = ({
         )}
         style={{ ...editFieldStyle, flex: 1, minWidth: nameInputMinWidth }}
       />
-      <span style={{ color: UML.textMuted, flexShrink: 0 }}>:</span>
+      <span style={{ color: UML.boxTextMuted, flexShrink: 0 }}>:</span>
       <select
         value={selectValue}
         onMouseDown={event => event.preventDefault()}
@@ -364,9 +364,9 @@ export const UmlAttributeRow = ({
       onDoubleClick={onDoubleClick}
       onDelete={onDelete}
     >
-      <span style={{ color: '#64748b', flexShrink: 0 }}>{attr.visibility ?? '+'}</span>
+      <span style={{ color: UML.boxTextMuted, flexShrink: 0 }}>{attr.visibility ?? '+'}</span>
       <span style={{
-        color: '#1e293b',
+        color: UML.boxText,
         flex: 1,
         overflow: 'hidden',
         textOverflow: 'ellipsis',
@@ -374,7 +374,7 @@ export const UmlAttributeRow = ({
       }}>
         {attr.name}
       </span>
-      <span style={{ color: '#94a3b8', flexShrink: 0 }}>:</span>
+      <span style={{ color: UML.boxTextMuted, flexShrink: 0 }}>:</span>
       <span style={{ color: UML.primary, flexShrink: 0, fontWeight: 600 }}>
         {normalizeAttributeTypeDisplay(attr.type)}
       </span>
@@ -390,7 +390,7 @@ function getUmlAddMemberRowStyle(hovered: boolean): CSSProperties {
     padding: '0 8px',
     gap: 4,
     cursor: 'pointer',
-    color: hovered ? UML.primary : UML.textMuted,
+    color: hovered ? UML.primary : UML.boxTextMuted,
     transition: 'color 0.1s',
     fontFamily: UML.fontSans,
     border: 'none',
@@ -519,7 +519,7 @@ const UmlOperationRowEditor = ({
         )}
         style={{ ...editFieldStyle, flex: 1, minWidth: nameInputMinWidth }}
       />
-      <span style={{ color: UML.textMuted, flexShrink: 0 }}>() :</span>
+      <span style={{ color: UML.boxTextMuted, flexShrink: 0 }}>() :</span>
       <select
         value={selectValue}
         onMouseDown={event => event.preventDefault()}
@@ -603,9 +603,9 @@ export const UmlOperationRow = ({
       onDoubleClick={onDoubleClick}
       onDelete={onDelete}
     >
-      <span style={{ color: '#64748b', flexShrink: 0 }}>{op.visibility ?? '+'}</span>
+      <span style={{ color: UML.boxTextMuted, flexShrink: 0 }}>{op.visibility ?? '+'}</span>
       <span style={{
-        color: '#1e293b',
+        color: UML.boxText,
         flex: 1,
         overflow: 'hidden',
         textOverflow: 'ellipsis',
@@ -613,7 +613,7 @@ export const UmlOperationRow = ({
       }}>
         {op.name}()
       </span>
-      <span style={{ color: '#94a3b8', flexShrink: 0 }}>:</span>
+      <span style={{ color: UML.boxTextMuted, flexShrink: 0 }}>:</span>
       <span style={{ color: UML.primary, flexShrink: 0, fontWeight: 600 }}>
         {normalizeOperationReturnType(op.returnType)}
       </span>

--- a/src/components/canvas/UMLDiagramMinimap.tsx
+++ b/src/components/canvas/UMLDiagramMinimap.tsx
@@ -190,10 +190,10 @@ export const UMLDiagramMinimap: React.FC<UMLDiagramMinimapProps> = ({
         display: 'block',
         margin: 0,
         padding: 0,
-        background: 'rgba(255,255,255,0.96)',
-        border: '1px solid #e2e8f0',
+        background: 'var(--v-surface)',
+        border: '1px solid var(--v-border)',
         borderRadius: 8,
-        boxShadow: '0 2px 10px rgba(0,0,0,0.08)',
+        boxShadow: 'var(--v-card-shadow)',
         overflow: 'hidden',
         zIndex: 5,
         cursor: 'crosshair',
@@ -211,7 +211,7 @@ export const UMLDiagramMinimap: React.FC<UMLDiagramMinimapProps> = ({
               key={rel.id}
               x1={toX(src.x + offsetX + BW / 2)} y1={toY(src.y + offsetY + minimapBoxH(src) / 2)}
               x2={toX(tgt.x + offsetX + BW / 2)} y2={toY(tgt.y + offsetY + minimapBoxH(tgt) / 2)}
-              stroke="#94a3b8"
+              stroke="var(--v-text-muted)"
               strokeWidth={1}
             />
           );
@@ -231,8 +231,8 @@ export const UMLDiagramMinimap: React.FC<UMLDiagramMinimapProps> = ({
               y={y}
               width={Math.max(2, w)}
               height={Math.max(2, h)}
-              fill="#e0f2fe"
-              stroke="#0c436e"
+              fill="var(--v-uml-primary-soft)"
+              stroke="var(--v-uml-edge, #0c436e)"
               strokeWidth={0.75}
               rx={1}
             />
@@ -262,7 +262,7 @@ export const UMLDiagramMinimap: React.FC<UMLDiagramMinimapProps> = ({
             cy={ind.y}
             r={3.5}
             fill="#049484"
-            stroke="#ffffff"
+            stroke="var(--v-surface)"
             strokeWidth={1}
           />
         ))}

--- a/src/components/canvas/UMLDiagramToolbar.tsx
+++ b/src/components/canvas/UMLDiagramToolbar.tsx
@@ -27,20 +27,18 @@ function getDiagramToolButtonBackground(
   if (disabled) return UML.surfaceMuted;
   if (active) return UML.primarySoft;
   if (accent && hovered) return UML.primarySoft;
-  if (hovered) return '#f0fdfa';
-  return UML.surface;
+  if (hovered) return UML.surfaceHover;
+  return 'var(--v-chrome-hover)';
 }
 
 function getDiagramToolButtonColor(
   disabled: boolean,
   active: boolean,
   accent: boolean,
-  hovered: boolean,
 ): string {
-  if (disabled) return '#cbd5e1';
+  if (disabled) return UML.textFaint;
   if (active || accent) return UML.primary;
-  if (hovered) return UML.ink;
-  return UML.textMuted;
+  return UML.ink;
 }
 
 function getDiagramToolButtonBoxShadow(
@@ -70,7 +68,6 @@ function getDiagramToolButtonStyle(params: {
     params.disabled,
     params.active,
     params.accent,
-    params.hovered,
   );
   const boxShadow = getDiagramToolButtonBoxShadow(
     params.active,
@@ -212,7 +209,7 @@ export const UMLDiagramToolbar = ({
       zIndex: 30,
       padding: '5px 8px',
       borderRadius: 10,
-      background: UML.surface,
+      background: 'var(--v-chrome-bg)',
       border: `1px solid ${UML.primaryBorder}`,
       boxShadow: `0 4px 14px ${UML.primaryRing}, 0 0 0 1px rgba(4,148,132,0.05)`,
     }}

--- a/src/components/canvas/UMLRelationVisuals.tsx
+++ b/src/components/canvas/UMLRelationVisuals.tsx
@@ -52,7 +52,7 @@ function getDirectionMarkerSvg(
     return (
       <path
         d="M 0 0 L 12 6 L 0 12 z"
-        fill="#ffffff"
+        fill={UML.boxBg}
         stroke={color}
         strokeWidth="1.5"
       />

--- a/src/components/canvas/UMLRelationVisuals.tsx
+++ b/src/components/canvas/UMLRelationVisuals.tsx
@@ -6,6 +6,7 @@ import {
   type MultiplicityBadge,
   type Point,
 } from '../../utils/umlDiagramGeometry';
+import { UML } from './umlDiagramTheme';
 
 export type UmlRelationEdgeState = 'default' | 'hovered' | 'selected';
 
@@ -19,7 +20,7 @@ export function getUmlRelationEdgeState(
 }
 
 export const UML_RELATION_EDGE_COLORS: Record<UmlRelationEdgeState, string> = {
-  default: '#0c436e',
+  default: UML.edge,
   hovered: '#f87171',
   selected: '#ef4444',
 };
@@ -105,7 +106,7 @@ export const UMLRelationLine = ({
       <path
         d={haloPath}
         fill="none"
-        stroke="#ffffff"
+        stroke={UML.edgeHalo}
         strokeWidth={strokeWidth + 4}
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -125,7 +126,7 @@ export const UMLRelationLine = ({
           textAnchor="middle"
           fontSize="10"
           fill={strokeColor}
-          stroke="#ffffff"
+          stroke={UML.edgeHalo}
           strokeWidth={3}
           paintOrder="stroke fill"
           fontFamily="ui-sans-serif, system-ui, sans-serif"
@@ -195,7 +196,7 @@ export const UMLMultiplicityBadge = ({
       width={36}
       height={24}
       rx={4}
-      fill="#ffffff"
+      fill={UML.boxBg}
       stroke={strokeColor}
       strokeWidth={1.5}
     />
@@ -205,7 +206,7 @@ export const UMLMultiplicityBadge = ({
       textAnchor="middle"
       fontSize="13"
       fontWeight={700}
-      fill={strokeColor}
+      fill={UML.boxText}
       fontFamily="ui-monospace, Consolas, monospace"
     >
       {badge.text}

--- a/src/components/canvas/UnsavedTabCloseDialog.tsx
+++ b/src/components/canvas/UnsavedTabCloseDialog.tsx
@@ -47,19 +47,20 @@ export const UnsavedTabCloseDialog: React.FC<UnsavedTabCloseDialogProps> = ({
           aria-modal="true"
           style={{
             pointerEvents: 'auto',
-            background: '#ffffff',
+            background: 'var(--v-surface)',
             borderRadius: 12,
-            boxShadow: '0 20px 50px rgba(0,0,0,0.2)',
+            boxShadow: 'var(--v-card-shadow)',
             width: 400,
             maxWidth: '92vw',
             padding: '24px',
             borderTop: '4px solid #f59e0b',
+            color: 'var(--v-text)',
           }}
         >
-          <h3 style={{ margin: '0 0 8px', fontSize: 17, fontWeight: 700, color: '#111827' }}>
+          <h3 style={{ margin: '0 0 8px', fontSize: 17, fontWeight: 700, color: 'var(--v-text)' }}>
             Unsaved changes
           </h3>
-          <p style={{ margin: '0 0 20px', fontSize: 14, color: '#6b7280', lineHeight: 1.55 }}>
+          <p style={{ margin: '0 0 20px', fontSize: 14, color: 'var(--v-text-muted)', lineHeight: 1.55 }}>
             {projectName
               ? `"${projectName}" has unsaved changes. Save before closing, or close without saving.`
               : 'This project has unsaved changes. Save before closing, or close without saving.'}
@@ -89,9 +90,9 @@ export const UnsavedTabCloseDialog: React.FC<UnsavedTabCloseDialogProps> = ({
               style={{
                 padding: '10px 14px',
                 borderRadius: 8,
-                border: '1px solid #fecaca',
-                background: '#fff',
-                color: '#dc2626',
+                border: '1px solid var(--v-danger-border)',
+                background: 'var(--v-surface)',
+                color: 'var(--v-danger-text)',
                 fontWeight: 600,
                 fontSize: 14,
                 cursor: saving ? 'not-allowed' : 'pointer',
@@ -106,9 +107,9 @@ export const UnsavedTabCloseDialog: React.FC<UnsavedTabCloseDialogProps> = ({
               style={{
                 padding: '10px 14px',
                 borderRadius: 8,
-                border: '1px solid #e5e7eb',
-                background: '#fff',
-                color: '#374151',
+                border: '1px solid var(--v-border)',
+                background: 'var(--v-surface)',
+                color: 'var(--v-text-secondary)',
                 fontWeight: 600,
                 fontSize: 14,
                 cursor: saving ? 'not-allowed' : 'pointer',

--- a/src/components/canvas/umlDiagramTheme.ts
+++ b/src/components/canvas/umlDiagramTheme.ts
@@ -6,23 +6,34 @@ export const DIAGRAM_HINT_TOP = DIAGRAM_TOOLBAR_TOP + DIAGRAM_TOOLBAR_HEIGHT + 8
 
 /** Dotted workspace background — matches canvas / HomePage grid */
 export const WORKSPACE_DOT_BACKGROUND: CSSProperties = {
-  backgroundColor: '#f3f4f6',
-  backgroundImage: 'radial-gradient(circle, #d1d5db 0.75px, transparent 0.75px)',
+  backgroundColor: 'var(--v-workspace-bg)',
+  backgroundImage: 'radial-gradient(circle, var(--v-workspace-dot) 0.75px, transparent 0.75px)',
   backgroundSize: '24px 24px',
 };
 
 /** Vitruv design tokens — aligned with Model Library / canvas UI */
 export const UML = {
   primary: '#049484',
-  primarySoft: '#ecfdf5',
-  primaryBorder: '#a7f3d0',
+  primarySoft: 'var(--v-uml-primary-soft, #ecfdf5)',
+  primaryBorder: 'var(--v-uml-primary-border, #a7f3d0)',
   primaryRing: 'rgba(4,148,132,0.2)',
-  ink: '#0c436e',
-  text: '#374151',
-  textMuted: '#64748b',
-  border: '#e2e8f0',
-  surface: '#ffffff',
-  surfaceMuted: '#f8fafc',
+  ink: 'var(--v-text)',
+  text: 'var(--v-text-secondary)',
+  textMuted: 'var(--v-text-muted)',
+  border: 'var(--v-border)',
+  surface: 'var(--v-surface)',
+  surfaceMuted: 'var(--v-surface-muted)',
+  surfaceHover: 'var(--v-surface-hover)',
+  textFaint: 'var(--v-text-faint)',
+  edge: 'var(--v-uml-edge, #0c436e)',
+  edgeHalo: 'var(--v-uml-edge-halo, #ffffff)',
+  circle: 'var(--v-uml-circle, #0c436e)',
+  boxBg: 'var(--v-uml-box-bg, #ffffff)',
+  boxMuted: 'var(--v-uml-box-muted, #f8fafc)',
+  boxHover: 'var(--v-uml-box-hover, #f1f5f9)',
+  boxText: 'var(--v-uml-box-text, #0f172a)',
+  boxTextMuted: 'var(--v-uml-box-text-muted, #64748b)',
+  boxBorder: 'var(--v-uml-box-border, #cbd5e1)',
   fontSans: 'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
   fontMono: 'ui-monospace, SFMono-Regular, Menlo, monospace',
 } as const;

--- a/src/components/constraints/ConstraintsView.tsx
+++ b/src/components/constraints/ConstraintsView.tsx
@@ -15,6 +15,21 @@ import {
   vitruvOCLTheme,
 } from './VitruvOCLMonarchGrammar';
 
+const T = {
+  surface: 'var(--v-surface)',
+  mutedBg: 'var(--v-surface-muted)',
+  hover: 'var(--v-surface-hover)',
+  chromeHover: 'var(--v-chrome-hover)',
+  text: 'var(--v-text)',
+  secondary: 'var(--v-text-secondary)',
+  muted: 'var(--v-text-muted)',
+  faint: 'var(--v-text-faint)',
+  border: 'var(--v-border)',
+  borderSubtle: 'var(--v-border-subtle)',
+  inputBg: 'var(--v-input-bg)',
+  primarySoft: 'var(--v-uml-primary-soft)',
+};
+
 const handleVitruvOCLMount: OnMount = (_editor, monacoInstance) => {
   monacoInstance.languages.register({ id: vitruvOCLLanguageId, extensions: ['.ocl'], aliases: ['VitruvOCL'] });
   monacoInstance.languages.setLanguageConfiguration(vitruvOCLLanguageId, vitruvOCLLanguageConfig);
@@ -482,7 +497,7 @@ const ColumnResizeHandle: React.FC<{
     style={{
       width: 6, flexShrink: 0, cursor: 'ew-resize', zIndex: 5,
       display: 'flex', alignItems: 'center', justifyContent: 'center',
-      background: '#f1f5f9', transition: 'background 0.15s',
+      background: T.chromeHover, transition: 'background 0.15s',
     }}
     onMouseEnter={e => {
       e.currentTarget.style.background = '#ccfbf1';
@@ -490,7 +505,7 @@ const ColumnResizeHandle: React.FC<{
       if (grip) grip.style.background = '#049484';
     }}
     onMouseLeave={e => {
-      e.currentTarget.style.background = '#f1f5f9';
+      e.currentTarget.style.background = T.chromeHover;
       const grip = e.currentTarget.querySelector('[data-grip]') as HTMLElement | null;
       if (grip) grip.style.background = '#cbd5e1';
     }}
@@ -537,8 +552,8 @@ const RuleRow: React.FC<{ rule: ConstraintRule; selected: boolean; onClick: () =
   }, [menuOpen]);
 
   let rowBackground: string;
-  if (selected) { rowBackground = '#f0fdf9'; }
-  else if (hov) { rowBackground = '#f8fafc'; }
+  if (selected) { rowBackground = T.primarySoft; }
+  else if (hov) { rowBackground = T.hover; }
   else { rowBackground = 'transparent'; }
 
   return (
@@ -561,17 +576,17 @@ const RuleRow: React.FC<{ rule: ConstraintRule; selected: boolean; onClick: () =
           textAlign: 'left', borderRadius: 0,
         }}
       >
-        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={selected ? '#049484' : '#94a3b8'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={selected ? '#049484' : 'var(--v-text-muted)'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
           <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14,2 14,8 20,8"/>
         </svg>
-        <span style={{ fontSize: 12.5, color: selected ? '#049484' : '#334155', fontWeight: selected ? 600 : 400, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        <span style={{ fontSize: 12.5, color: selected ? '#049484' : T.secondary, fontWeight: selected ? 600 : 400, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
           {rule.name}
         </span>
       </button>
       <div ref={menuRef} style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)' }}>
         <button type="button"
           onClick={e => { e.stopPropagation(); setMenuOpen(o => !o); }}
-          style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 2, color: '#94a3b8', borderRadius: 4, display: 'flex', alignItems: 'center' }}
+          style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 2, color: T.muted, borderRadius: 4, display: 'flex', alignItems: 'center' }}
           title="Options"
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="12" cy="19" r="1.5"/></svg>
@@ -583,7 +598,7 @@ const RuleRow: React.FC<{ rule: ConstraintRule; selected: boolean; onClick: () =
             onKeyDown={e => e.stopPropagation()}
             style={{
               position: 'absolute', right: 0, top: '100%', zIndex: 50,
-              background: '#ffffff', border: '1px solid #e2e8f0',
+              background: T.surface, border: `1px solid ${T.border}`,
               borderRadius: 8, boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
               minWidth: 140, padding: '4px 0',
             }}
@@ -625,8 +640,8 @@ const RuleSetSection: React.FC<RuleSetSectionProps> = ({ ruleSet, selectedRuleId
   const [hov, setHov] = useState(false);
   const isSelected = selectedRuleSetId === ruleSet.id;
   let headerBackground: string;
-  if (isSelected) { headerBackground = '#f0fdf9'; }
-  else if (hov) { headerBackground = '#f8fafc'; }
+  if (isSelected) { headerBackground = T.primarySoft; }
+  else if (hov) { headerBackground = T.hover; }
   else { headerBackground = 'transparent'; }
   return (
     <div>
@@ -637,7 +652,7 @@ const RuleSetSection: React.FC<RuleSetSectionProps> = ({ ruleSet, selectedRuleId
           display: 'flex', alignItems: 'center',
           background: headerBackground,
           borderLeft: isSelected ? `2px solid ${ruleSet.color}` : '2px solid transparent',
-          borderBottom: '1px solid #f1f5f9',
+          borderBottom: `1px solid ${T.borderSubtle}`,
         }}
       >
         <button type="button"
@@ -649,15 +664,15 @@ const RuleSetSection: React.FC<RuleSetSectionProps> = ({ ruleSet, selectedRuleId
           }}
         >
           <div style={{ width: 10, height: 10, borderRadius: 2, background: ruleSet.color, flexShrink: 0 }} />
-          <span style={{ fontSize: 12.5, fontWeight: 600, color: '#1e293b', flex: 1 }}>{ruleSet.name}</span>
-          <span style={{ fontSize: 11, color: '#94a3b8', fontWeight: 500 }}>{ruleSet.rules.length} rules</span>
+          <span style={{ fontSize: 12.5, fontWeight: 600, color: T.text, flex: 1 }}>{ruleSet.name}</span>
+          <span style={{ fontSize: 11, color: T.muted, fontWeight: 500 }}>{ruleSet.rules.length} rules</span>
         </button>
         <button type="button"
           onClick={() => onToggleCollapse(ruleSet.id)}
           style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '8px 12px 8px 4px', display: 'flex', alignItems: 'center' }}
         >
           <svg
-            width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" strokeWidth="2.5" strokeLinecap="round"
+            width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--v-text-muted)" strokeWidth="2.5" strokeLinecap="round"
             style={{ transform: ruleSet.collapsed ? 'rotate(-90deg)' : 'rotate(0deg)', transition: 'transform 0.15s', flexShrink: 0 }}
           >
             <polyline points="6,9 12,15 18,9"/>
@@ -671,9 +686,9 @@ const RuleSetSection: React.FC<RuleSetSectionProps> = ({ ruleSet, selectedRuleId
           ))}
           <button type="button"
             onClick={() => onAddRule(ruleSet.id)}
-            style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px 6px 28px', cursor: 'pointer', color: '#94a3b8', fontSize: 12, background: 'none', border: 'none', width: '100%', textAlign: 'left' }}
+            style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px 6px 28px', cursor: 'pointer', color: T.muted, fontSize: 12, background: 'none', border: 'none', width: '100%', textAlign: 'left' }}
             onMouseEnter={e => (e.currentTarget.style.color = '#049484')}
-            onMouseLeave={e => (e.currentTarget.style.color = '#94a3b8')}
+            onMouseLeave={e => (e.currentTarget.style.color = T.muted)}
           >
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
             Add rule
@@ -690,11 +705,11 @@ const MetamodelBar: React.FC<{ label: string; count: number; max: number; colorM
   const bg = scopeBg(label, colorMap);
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
-      <span style={{ fontSize: 11.5, color: '#64748b', width: 90, flexShrink: 0 }}>{label}</span>
-      <div style={{ flex: 1, height: 6, background: '#f1f5f9', borderRadius: 3, overflow: 'hidden' }}>
+      <span style={{ fontSize: 11.5, color: T.muted, width: 90, flexShrink: 0 }}>{label}</span>
+      <div style={{ flex: 1, height: 6, background: T.hover, borderRadius: 3, overflow: 'hidden' }}>
         <div style={{ height: '100%', width: `${(count / max) * 100}%`, background: bg, borderRadius: 3 }} />
       </div>
-      <span style={{ fontSize: 11, color: '#94a3b8', width: 18, textAlign: 'right' }}>{count}</span>
+      <span style={{ fontSize: 11, color: T.muted, width: 18, textAlign: 'right' }}>{count}</span>
     </div>
   );
 };
@@ -703,14 +718,14 @@ const MetamodelBar: React.FC<{ label: string; count: number; max: number; colorM
 
 const InsightCard: React.FC<{ label: string; value: string | number; sub?: React.ReactNode; wide?: boolean }> = ({ label, value, sub, wide }) => (
   <div style={{
-    background: '#f8fafc', borderRadius: 8, border: '1px solid #f1f5f9',
+    background: T.mutedBg, borderRadius: 8, border: `1px solid ${T.borderSubtle}`,
     padding: '12px 14px',
     gridColumn: wide ? 'span 2' : undefined,
     minWidth: 0,
   }}>
-    <div style={{ fontSize: 11, color: '#94a3b8', fontWeight: 500, marginBottom: 4 }}>{label}</div>
-    <div style={{ fontSize: typeof value === 'number' ? 26 : 18, fontWeight: 700, color: '#0f172a', lineHeight: 1.1 }}>{value}</div>
-    {sub && <div style={{ fontSize: 11, color: '#94a3b8', marginTop: 2 }}>{sub}</div>}
+    <div style={{ fontSize: 11, color: T.muted, fontWeight: 500, marginBottom: 4 }}>{label}</div>
+    <div style={{ fontSize: typeof value === 'number' ? 26 : 18, fontWeight: 700, color: T.text, lineHeight: 1.1 }}>{value}</div>
+    {sub && <div style={{ fontSize: 11, color: T.muted, marginTop: 2 }}>{sub}</div>}
   </div>
 );
 
@@ -778,8 +793,8 @@ const ContextClassPicker: React.FC<{
   });
 
   const inputBase: React.CSSProperties = {
-    width: '100%', padding: '6px 10px', border: '1.5px solid #e2e8f0', borderRadius: 7,
-    fontSize: 12.5, background: '#f8fafc', color: '#0f172a', boxSizing: 'border-box',
+    width: '100%', padding: '6px 10px', border: `1.5px solid ${T.border}`, borderRadius: 7,
+    fontSize: 12.5, background: T.inputBg, color: T.text, boxSizing: 'border-box',
     outline: 'none', fontFamily: APP_FONT, cursor: 'pointer',
   };
 
@@ -789,7 +804,7 @@ const ContextClassPicker: React.FC<{
         style={{ ...inputBase, display: 'flex', alignItems: 'center', justifyContent: 'space-between', userSelect: 'none' }}
         onClick={() => { setOpen(o => !o); setQuery(''); }}
       >
-        <span style={{ color: value ? '#0f172a' : '#94a3b8' }}>{value || 'Select context class…'}</span>
+        <span style={{ color: value ? T.text : T.muted }}>{value || 'Select context class…'}</span>
         <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" strokeWidth="2.5" strokeLinecap="round" style={{ transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s', flexShrink: 0 }}>
           <polyline points="6,9 12,15 18,9" />
         </svg>
@@ -798,7 +813,7 @@ const ContextClassPicker: React.FC<{
       {open && (
         <div style={{
           position: 'absolute', top: '100%', left: 0, right: 0, zIndex: 999,
-          background: '#fff', border: '1.5px solid #e2e8f0', borderRadius: 8,
+          background: T.surface, border: `1.5px solid ${T.border}`, borderRadius: 8,
           boxShadow: '0 8px 24px rgba(0,0,0,0.12)', marginTop: 4, overflow: 'hidden',
         }}>
           {/* Search input */}
@@ -808,7 +823,7 @@ const ContextClassPicker: React.FC<{
               value={query}
               onChange={e => setQuery(e.target.value)}
               placeholder="Filter classes…"
-              style={{ ...inputBase, cursor: 'text', background: '#fff', border: '1px solid #e2e8f0' }}
+              style={{ ...inputBase, cursor: 'text', background: T.inputBg, border: `1px solid ${T.border}` }}
               onKeyDown={e => e.stopPropagation()}
             />
           </div>
@@ -1011,7 +1026,7 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
       />
 
       <div style={{
-        background: '#ffffff', borderTop: '1px solid #e2e8f0',
+        background: T.surface, borderTop: `1px solid ${T.border}`,
         boxShadow: '0 -4px 24px rgba(0,0,0,0.10)',
         zIndex: 50, display: 'flex', flexDirection: 'column',
         height, overflow: 'hidden', position: 'relative',
@@ -1039,11 +1054,11 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
           />
         </div>
         {/* Header — top-padding accounts for the 6px resize handle */}
-        <div style={{ display: 'flex', alignItems: 'center', padding: '10px 16px 10px 16px', paddingTop: 12, borderBottom: '1px solid #f1f5f9', flexShrink: 0 }}>
-          <span style={{ fontSize: 13, fontWeight: 600, color: '#0f172a', flex: 1 }}>
+        <div style={{ display: 'flex', alignItems: 'center', padding: '10px 16px 10px 16px', paddingTop: 12, borderBottom: `1px solid ${T.borderSubtle}`, flexShrink: 0 }}>
+          <span style={{ fontSize: 13, fontWeight: 600, color: T.text, flex: 1 }}>
             Editing: {draft.name}
           </span>
-          <button type="button" onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', padding: 4, borderRadius: 4, display: 'flex', alignItems: 'center' }}>
+          <button type="button" onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: T.muted, padding: 4, borderRadius: 4, display: 'flex', alignItems: 'center' }}>
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
           </button>
         </div>
@@ -1055,7 +1070,7 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
 
             {/* Context class */}
             <div>
-              <label htmlFor="ep-context-class" style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 4 }}>Context Class</label>
+              <label htmlFor="ep-context-class" style={{ fontSize: 11, fontWeight: 600, color: T.muted, display: 'block', marginBottom: 4 }}>Context Class</label>
               <div id="ep-context-class">
                 <ContextClassPicker
                   value={oclGetContextType(draft.oclDefinition)}
@@ -1067,26 +1082,26 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
 
             {/* Name — no spaces */}
             <div>
-              <label htmlFor="ep-inv-name" style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 4 }}>
-                Name <span style={{ fontWeight: 400, color: '#94a3b8' }}>(no spaces)</span>
+              <label htmlFor="ep-inv-name" style={{ fontSize: 11, fontWeight: 600, color: T.muted, display: 'block', marginBottom: 4 }}>
+                Name <span style={{ fontWeight: 400, color: T.muted }}>(no spaces)</span>
               </label>
               <input
                 id="ep-inv-name"
                 value={draft.name}
                 onChange={e => handleNameChange(e.target.value)}
                 placeholder="InvariantName"
-                style={{ width: '100%', border: '1px solid #e2e8f0', borderRadius: 6, padding: '6px 8px', fontSize: 12.5, outline: 'none', boxSizing: 'border-box', color: '#0f172a', fontFamily: 'monospace' }}
+                style={{ width: '100%', border: `1px solid ${T.border}`, borderRadius: 6, padding: '6px 8px', fontSize: 12.5, outline: 'none', boxSizing: 'border-box', color: T.text, fontFamily: 'monospace', background: T.inputBg }}
               />
             </div>
 
             {/* Severity */}
             <div>
-              <label htmlFor="ep-severity" style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 6 }}>Severity</label>
+              <label htmlFor="ep-severity" style={{ fontSize: 11, fontWeight: 600, color: T.muted, display: 'block', marginBottom: 6 }}>Severity</label>
               <div id="ep-severity" style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
                 {SEVERITY_OPTIONS.map(opt => {
                   const active = draft.severity === opt.value;
                   return (
-                    <button type="button" key={opt.value} onClick={() => handleSeverityChange(opt.value)} style={{ padding: '3px 10px', borderRadius: 12, fontSize: 11, fontWeight: 600, cursor: 'pointer', border: `1.5px solid ${active ? opt.color : '#e2e8f0'}`, background: active ? opt.bg : '#fff', color: active ? opt.color : '#94a3b8', transition: 'all 0.12s' }}>
+                    <button type="button" key={opt.value} onClick={() => handleSeverityChange(opt.value)} style={{ padding: '3px 10px', borderRadius: 12, fontSize: 11, fontWeight: 600, cursor: 'pointer', border: `1.5px solid ${active ? opt.color : T.border}`, background: active ? opt.bg : T.surface, color: active ? opt.color : T.muted, transition: 'all 0.12s' }}>
                       {opt.label}
                     </button>
                   );
@@ -1100,24 +1115,24 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
 
             {/* Message */}
             <div>
-              <label htmlFor="ep-message" style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 4 }}>Message</label>
-              <textarea id="ep-message" value={draft.description} onChange={e => handleDescriptionChange(e.target.value)} rows={3} style={{ width: '100%', border: '1px solid #e2e8f0', borderRadius: 6, padding: '6px 8px', fontSize: 12, resize: 'none', outline: 'none', boxSizing: 'border-box', color: '#334155', lineHeight: 1.5 }} />
+              <label htmlFor="ep-message" style={{ fontSize: 11, fontWeight: 600, color: T.muted, display: 'block', marginBottom: 4 }}>Message</label>
+              <textarea id="ep-message" value={draft.description} onChange={e => handleDescriptionChange(e.target.value)} rows={3} style={{ width: '100%', border: `1px solid ${T.border}`, borderRadius: 6, padding: '6px 8px', fontSize: 12, resize: 'none', outline: 'none', boxSizing: 'border-box', color: T.secondary, lineHeight: 1.5, background: T.inputBg }} />
             </div>
 
             {/* Rule Set */}
             <div>
-              <label htmlFor="ep-rule-set" style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 4 }}>Rule Set</label>
-              <select id="ep-rule-set" value={draft.ruleSetId} onChange={e => setDraft(d => ({ ...d, ruleSetId: e.target.value }))} style={{ width: '100%', border: '1px solid #e2e8f0', borderRadius: 6, padding: '6px 8px', fontSize: 12.5, background: '#fff', color: '#0f172a', outline: 'none', boxSizing: 'border-box' }}>
+              <label htmlFor="ep-rule-set" style={{ fontSize: 11, fontWeight: 600, color: T.muted, display: 'block', marginBottom: 4 }}>Rule Set</label>
+              <select id="ep-rule-set" value={draft.ruleSetId} onChange={e => setDraft(d => ({ ...d, ruleSetId: e.target.value }))} style={{ width: '100%', border: `1px solid ${T.border}`, borderRadius: 6, padding: '6px 8px', fontSize: 12.5, background: T.inputBg, color: T.text, outline: 'none', boxSizing: 'border-box' }}>
                 {ruleSets.map(rs => <option key={rs.id} value={rs.id}>{rs.name}</option>)}
               </select>
             </div>
 
             {/* Metamodels */}
             <div>
-              <label htmlFor="ep-metamodels" style={{ fontSize: 11, fontWeight: 600, color: '#64748b', display: 'block', marginBottom: 2 }}>
-                Metamodels <span style={{ fontWeight: 400, color: '#94a3b8', marginLeft: 4 }}>auto</span>
+              <label htmlFor="ep-metamodels" style={{ fontSize: 11, fontWeight: 600, color: T.muted, display: 'block', marginBottom: 2 }}>
+                Metamodels <span style={{ fontWeight: 400, color: T.muted, marginLeft: 4 }}>auto</span>
               </label>
-              <p style={{ fontSize: 10.5, color: '#94a3b8', margin: '0 0 6px' }}>
+              <p style={{ fontSize: 10.5, color: T.muted, margin: '0 0 6px' }}>
                 Derived from <code style={{ fontSize: 10 }}>MM::Class</code> patterns in the OCL
               </p>
               <div id="ep-metamodels" style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
@@ -1141,9 +1156,9 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
 
           {/* Center: OCL editor */}
           <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: EDITOR_CENTER_MIN_W }}>
-            <div style={{ display: 'flex', alignItems: 'center', padding: '6px 12px', background: '#f8fafc', borderBottom: '1px solid #f1f5f9', gap: 6, flexShrink: 0 }}>
-              <span style={{ fontSize: 11, fontWeight: 600, color: '#64748b', flex: 1 }}>OCL Definition</span>
-              <span style={{ fontSize: 10, padding: '2px 6px', borderRadius: 4, background: '#f1f5f9', color: '#64748b' }}>OCL</span>
+            <div style={{ display: 'flex', alignItems: 'center', padding: '6px 12px', background: T.mutedBg, borderBottom: `1px solid ${T.borderSubtle}`, gap: 6, flexShrink: 0 }}>
+              <span style={{ fontSize: 11, fontWeight: 600, color: T.muted, flex: 1 }}>OCL Definition</span>
+              <span style={{ fontSize: 10, padding: '2px 6px', borderRadius: 4, background: T.hover, color: T.muted }}>OCL</span>
             </div>
             <div style={{ flex: 1 }}>
               <Editor
@@ -1155,11 +1170,11 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
                 options={{ minimap: { enabled: false }, fontSize: 13, lineNumbers: 'on', scrollBeyondLastLine: false, wordWrap: 'on', automaticLayout: true, padding: { top: 8, bottom: 8 }, folding: false, lineDecorationsWidth: 0, renderLineHighlight: 'line', overviewRulerLanes: 0 }}
               />
             </div>
-            <div style={{ display: 'flex', alignItems: 'center', padding: '6px 12px', background: '#f8fafc', borderTop: '1px solid #f1f5f9', flexShrink: 0, gap: 8 }}>
+            <div style={{ display: 'flex', alignItems: 'center', padding: '6px 12px', background: T.mutedBg, borderTop: `1px solid ${T.borderSubtle}`, flexShrink: 0, gap: 8 }}>
               <svg width="12" height="12" viewBox="0 0 24 24" fill="#22c55e" stroke="none"><circle cx="12" cy="12" r="10"/><polyline points="9,12 11,14 15,10" fill="none" stroke="#fff" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
-              <span style={{ fontSize: 11, color: '#64748b', flex: 1 }}>No syntax errors</span>
-              <span style={{ fontSize: 10.5, color: '#94a3b8' }}>Spaces: 2</span>
-              <span style={{ fontSize: 10.5, color: '#94a3b8' }}>OCL</span>
+              <span style={{ fontSize: 11, color: T.muted, flex: 1 }}>No syntax errors</span>
+              <span style={{ fontSize: 10.5, color: T.muted }}>Spaces: 2</span>
+              <span style={{ fontSize: 10.5, color: T.muted }}>OCL</span>
             </div>
           </div>
 
@@ -1173,7 +1188,7 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
 
           {/* Right: overview */}
           <div style={{ width: rightWidth, flexShrink: 0, padding: '12px 16px', overflowY: 'auto' }}>
-            <div style={{ fontSize: 12, fontWeight: 700, color: '#0f172a', marginBottom: 12 }}>Rule Overview</div>
+            <div style={{ fontSize: 12, fontWeight: 700, color: T.text, marginBottom: 12 }}>Rule Overview</div>
             {([
               ['Type', draft.type],
               ['Severity', draft.severity],
@@ -1185,16 +1200,16 @@ const EditorPanel: React.FC<EditorPanelProps> = ({ rule, ruleSets, colorMap, met
               ['Last Modified', draft.modifiedAt],
             ] as [string, string][]).map(([k, v]) => (
               <div key={k} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 8, gap: 6 }}>
-                <span style={{ fontSize: 11, color: '#94a3b8', flexShrink: 0 }}>{k}</span>
+                <span style={{ fontSize: 11, color: T.muted, flexShrink: 0 }}>{k}</span>
                 {k === 'Severity'
                   ? <span style={{ fontSize: 11, fontWeight: 600, color: sev.color }}>{v}</span>
-                  : <span style={{ fontSize: 11, color: '#334155', textAlign: 'right', fontWeight: k === 'Type' ? 500 : 400 }}>{v || '—'}</span>
+                  : <span style={{ fontSize: 11, color: T.secondary, textAlign: 'right', fontWeight: k === 'Type' ? 500 : 400 }}>{v || '—'}</span>
                 }
               </div>
             ))}
-            <div style={{ marginTop: 8, display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 0', borderTop: '1px solid #f1f5f9' }}>
-              <span style={{ fontSize: 11, color: '#94a3b8' }}>Linked Reactions</span>
-              <span style={{ fontSize: 11, color: '#334155', fontWeight: 500 }}>{draft.linkedReactions ?? 0}</span>
+            <div style={{ marginTop: 8, display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 0', borderTop: `1px solid ${T.borderSubtle}` }}>
+              <span style={{ fontSize: 11, color: T.muted }}>Linked Reactions</span>
+              <span style={{ fontSize: 11, color: T.secondary, fontWeight: 500 }}>{draft.linkedReactions ?? 0}</span>
             </div>
             <SaveChangesButton onSave={() => onSave(draft)} />
             <button type="button" onClick={() => setFullEditorOpen(true)} style={{ width: '100%', marginTop: 6, padding: '7px 0', background: 'transparent', color: '#049484', border: '1px solid #049484', borderRadius: 6, fontSize: 12, fontWeight: 500, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
@@ -1242,14 +1257,14 @@ const MetricsPanel: React.FC<MetricsPanelProps> = ({ ruleSets, colorMap }) => {
   return (
     <div style={{
       width: 300, flexShrink: 0, height: '100%',
-      background: '#ffffff', borderLeft: '1px solid #e2e8f0',
+      background: T.surface, borderLeft: `1px solid ${T.border}`,
       borderTopLeftRadius: 10, borderTopRightRadius: 10,
       overflowY: 'auto', display: 'flex', flexDirection: 'column',
     }}>
       {/* Insight cards */}
       <div style={{ padding: '16px 16px 0' }}>
-        <div style={{ fontSize: 13, fontWeight: 700, color: '#0f172a', marginBottom: 2 }}>Constraint Insights</div>
-        <div style={{ fontSize: 11, color: '#94a3b8', marginBottom: 14 }}>Static metrics about your consistency definitions</div>
+        <div style={{ fontSize: 13, fontWeight: 700, color: T.text, marginBottom: 2 }}>Constraint Insights</div>
+        <div style={{ fontSize: 11, color: T.muted, marginBottom: 14 }}>Static metrics about your consistency definitions</div>
 
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginBottom: 16 }}>
           <InsightCard label="Total Rules" value={total} sub={`Across ${ruleSets.length} Sets`} />
@@ -1263,7 +1278,7 @@ const MetricsPanel: React.FC<MetricsPanelProps> = ({ ruleSets, colorMap }) => {
                 Ø {avgCCStr}{' '}
                 <span
                   title="McCabe's Cyclomatic Complexity — McCabe (1976), IEEE Trans. Softw. Eng."
-                  style={{ cursor: 'help', color: '#94a3b8', fontSize: 10, fontWeight: 400 }}
+                  style={{ cursor: 'help', color: T.muted, fontSize: 10, fontWeight: 400 }}
                 >
                   CC ⓘ
                 </span>
@@ -1274,9 +1289,9 @@ const MetricsPanel: React.FC<MetricsPanelProps> = ({ ruleSets, colorMap }) => {
       </div>
 
       {/* Metamodel involvement */}
-      <div style={{ padding: '0 16px 16px', borderBottom: '1px solid #f1f5f9' }}>
-        <div style={{ fontSize: 12, fontWeight: 700, color: '#0f172a', marginBottom: 2 }}>Metamodel Involvement</div>
-        <div style={{ fontSize: 11, color: '#94a3b8', marginBottom: 12 }}>How many rules reference each metamodel</div>
+      <div style={{ padding: '0 16px 16px', borderBottom: `1px solid ${T.borderSubtle}` }}>
+        <div style={{ fontSize: 12, fontWeight: 700, color: T.text, marginBottom: 2 }}>Metamodel Involvement</div>
+        <div style={{ fontSize: 11, color: T.muted, marginBottom: 12 }}>How many rules reference each metamodel</div>
         {sortedMeta.map(([name, count], i) => (
           <MetamodelBar key={name} label={name} count={count} max={maxMeta} colorMap={colorMap} />
         ))}
@@ -1284,15 +1299,15 @@ const MetricsPanel: React.FC<MetricsPanelProps> = ({ ruleSets, colorMap }) => {
 
       {/* Rule characteristics */}
       <div style={{ padding: '14px 16px' }}>
-        <div style={{ fontSize: 12, fontWeight: 700, color: '#0f172a', marginBottom: 12 }}>Rule Characteristics</div>
+        <div style={{ fontSize: 12, fontWeight: 700, color: T.text, marginBottom: 12 }}>Rule Characteristics</div>
         {([
           ['Total OCL Lines', String(totalLines)],
           ['Avg. Lines per Rule', avgLines],
           ['Max Lines in a Rule', String(maxLines)],
         ] as [string, string][]).map(([k, v]) => (
           <div key={k} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
-            <span style={{ fontSize: 11.5, color: '#64748b' }}>{k}</span>
-            <span style={{ fontSize: 12, color: '#0f172a', fontWeight: 500 }}>{v}</span>
+            <span style={{ fontSize: 11.5, color: T.muted }}>{k}</span>
+            <span style={{ fontSize: 12, color: T.text, fontWeight: 500 }}>{v}</span>
           </div>
         ))}
 
@@ -1331,18 +1346,18 @@ const DetailedMetricsModal: React.FC<{ ruleSets: RuleSet[]; colorMap: Record<str
       <button type="button" onClick={onClose} aria-label="Close" style={{ position: 'absolute', inset: 0, background: 'rgba(15,23,42,0.35)', border: 'none', cursor: 'default', padding: 0 }} />
       <div style={{
         position: 'relative', zIndex: 1,
-        background: '#fff', borderRadius: 14,
+        background: T.surface, borderRadius: 14,
         width: 'min(1040px, calc(100vw - 48px))',
         maxHeight: 'calc(100vh - 48px)',
         display: 'flex', flexDirection: 'column',
         boxShadow: '0 24px 64px rgba(0,0,0,0.20)',
-        border: '1px solid #e2e8f0', fontFamily: APP_FONT,
+        border: `1px solid ${T.border}`, fontFamily: APP_FONT,
         overflow: 'hidden', boxSizing: 'border-box',
       }}>
         {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '16px 22px', borderBottom: '1px solid #f1f5f9', flexShrink: 0 }}>
-          <span style={{ fontSize: 15, fontWeight: 700, color: '#0f172a' }}>Detailed Metrics</span>
-          <button type="button" onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', fontSize: 20, lineHeight: 1 }}>×</button>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '16px 22px', borderBottom: `1px solid ${T.borderSubtle}`, flexShrink: 0 }}>
+          <span style={{ fontSize: 15, fontWeight: 700, color: T.text }}>Detailed Metrics</span>
+          <button type="button" onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: T.muted, fontSize: 20, lineHeight: 1 }}>×</button>
         </div>
 
         {/* Body — grows with content, scrolls when it would exceed the viewport */}
@@ -1466,8 +1481,8 @@ const RuleSetPanel: React.FC<{
   };
 
   const inputBase: React.CSSProperties = {
-    width: '100%', padding: '6px 10px', border: '1.5px solid #e2e8f0', borderRadius: 7,
-    fontSize: 12.5, background: '#f8fafc', color: '#0f172a', boxSizing: 'border-box',
+    width: '100%', padding: '6px 10px', border: `1.5px solid ${T.border}`, borderRadius: 7,
+    fontSize: 12.5, background: T.inputBg, color: T.text, boxSizing: 'border-box',
     outline: 'none', fontFamily: APP_FONT,
   };
 
@@ -1478,15 +1493,15 @@ const RuleSetPanel: React.FC<{
 
   return (
     <div style={{
-      background: '#ffffff', borderTop: '1px solid #e2e8f0',
+      background: T.surface, borderTop: `1px solid ${T.border}`,
       boxShadow: '0 -4px 24px rgba(0,0,0,0.10)',
       display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0,
     }}>
       {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', padding: '10px 16px', borderBottom: '1px solid #f1f5f9', flexShrink: 0 }}>
+      <div style={{ display: 'flex', alignItems: 'center', padding: '10px 16px', borderBottom: `1px solid ${T.borderSubtle}`, flexShrink: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1 }}>
           <div style={{ width: 10, height: 10, borderRadius: 2, background: draft.color, flexShrink: 0 }} />
-          <span style={{ fontSize: 13, fontWeight: 600, color: '#0f172a' }}>Rule Set: {draft.name}</span>
+          <span style={{ fontSize: 13, fontWeight: 600, color: T.text }}>Rule Set: {draft.name}</span>
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
           {onDelete && (
@@ -1498,7 +1513,7 @@ const RuleSetPanel: React.FC<{
               title="Delete Rule Set"
             >Delete</button>
           )}
-          <button type="button" onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', fontSize: 18, lineHeight: 1 }}>×</button>
+          <button type="button" onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: T.muted, fontSize: 18, lineHeight: 1 }}>×</button>
         </div>
       </div>
 
@@ -1615,18 +1630,18 @@ const LeftPanel: React.FC<LeftPanelProps> = ({
   return (
     <div style={{
       width: 260, flexShrink: 0, height: '100%',
-      background: '#ffffff', borderRight: '1px solid #e2e8f0',
+      background: T.surface, borderRight: `1px solid ${T.border}`,
       borderTopLeftRadius: 10, borderTopRightRadius: 10,
       display: 'flex', flexDirection: 'column', overflow: 'hidden',
     }}>
       {/* Header */}
-      <div style={{ padding: '14px 14px 10px', borderBottom: '1px solid #f1f5f9', flexShrink: 0 }}>
+      <div style={{ padding: '14px 14px 10px', borderBottom: `1px solid ${T.borderSubtle}`, flexShrink: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
-          <span style={{ fontSize: 13, fontWeight: 700, color: '#0f172a' }}>Constraint Sets</span>
+          <span style={{ fontSize: 13, fontWeight: 700, color: T.text }}>Constraint Sets</span>
           <button type="button"
             onClick={onAddSet}
             style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 11.5, color: '#049484', background: 'none', border: 'none', cursor: 'pointer', fontWeight: 500, padding: '3px 6px', borderRadius: 5 }}
-            onMouseEnter={e => (e.currentTarget.style.background = '#f0fdf9')}
+            onMouseEnter={e => (e.currentTarget.style.background = T.primarySoft)}
             onMouseLeave={e => (e.currentTarget.style.background = 'none')}
           >
             <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
@@ -1634,14 +1649,14 @@ const LeftPanel: React.FC<LeftPanelProps> = ({
           </button>
         </div>
         <div style={{ position: 'relative' }}>
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" strokeWidth="2.5" strokeLinecap="round" style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)' }}>
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--v-text-muted)" strokeWidth="2.5" strokeLinecap="round" style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)' }}>
             <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
           </svg>
           <input
             value={searchQuery}
             onChange={e => onSearch(e.target.value)}
             placeholder="Search projects… (Ctrl+K)"
-            style={{ width: '100%', border: '1px solid #e2e8f0', borderRadius: 6, padding: '6px 8px 6px 28px', fontSize: 12, outline: 'none', boxSizing: 'border-box', color: '#334155' }}
+            style={{ width: '100%', border: `1px solid ${T.border}`, borderRadius: 6, padding: '6px 8px 6px 28px', fontSize: 12, outline: 'none', boxSizing: 'border-box', color: T.secondary, background: T.inputBg }}
           />
         </div>
       </div>

--- a/src/components/flow/ConnectionHandle.tsx
+++ b/src/components/flow/ConnectionHandle.tsx
@@ -11,7 +11,7 @@ function connectionHandleArrowSvg(
   isHovered: boolean,
   size = 24,
 ): React.ReactNode {
-  const color = isHovered ? '#2c3e50' : '#95a5a6';
+  const color = isHovered ? 'var(--v-chrome-icon-hover)' : 'var(--v-chrome-icon)';
   const svgStyle: React.CSSProperties = {
     transition: 'all 0.2s ease',
     filter: isHovered

--- a/src/components/flow/EditableNode.tsx
+++ b/src/components/flow/EditableNode.tsx
@@ -46,7 +46,7 @@ const typeSelectStyle: React.CSSProperties = {
   borderRadius: '3px',
   fontSize: '16px',
   fontFamily: `'Consolas', 'Courier New', monospace`,
-  color: '#0c436e',
+  color: 'var(--v-uml-edge, #0c436e)',
   background: '#f4f8fc',
   padding: '2px 5px',
   cursor: 'pointer',
@@ -574,7 +574,7 @@ export function EditableNode({ id, data, selected, isConnectable }: NodeProps<UM
           value={nodeData.className || ''}
           onSave={(newValue) => updateNodeData({ className: newValue })}
           placeholder="ClassName"
-          style={{ fontWeight: 600, fontSize: '13px', color: '#0c436e' }}
+          style={{ fontWeight: 600, fontSize: '13px', color: 'var(--v-uml-edge, #0c436e)' }}
         />
       </div>
       {nodeData.attributes && nodeData.attributes.length > 0 && (
@@ -595,7 +595,7 @@ export function EditableNode({ id, data, selected, isConnectable }: NodeProps<UM
           value={nodeData.className || ''}
           onSave={(newValue) => updateNodeData({ className: newValue })}
           placeholder="ClassName"
-          style={{ fontWeight: 600, fontSize: '13px', color: '#0c436e', fontStyle: 'italic' }}
+          style={{ fontWeight: 600, fontSize: '13px', color: 'var(--v-uml-edge, #0c436e)', fontStyle: 'italic' }}
         />
       </div>
       {nodeData.attributes && nodeData.attributes.length > 0 && (
@@ -616,7 +616,7 @@ export function EditableNode({ id, data, selected, isConnectable }: NodeProps<UM
           value={nodeData.className || ''}
           onSave={(newValue) => updateNodeData({ className: newValue })}
           placeholder="InterfaceName"
-          style={{ fontWeight: 600, fontSize: '13px', color: '#0c436e', fontStyle: 'italic' }}
+          style={{ fontWeight: 600, fontSize: '13px', color: 'var(--v-uml-edge, #0c436e)', fontStyle: 'italic' }}
         />
       </div>
       {nodeData.attributes && nodeData.attributes.length > 0 && (

--- a/src/components/flow/EditableNode.tsx
+++ b/src/components/flow/EditableNode.tsx
@@ -215,8 +215,8 @@ const MenuOverlay: React.FC<{
     position: 'absolute',
     top: '100%',
     left: '0',
-    background: '#fff',
-    border: '1px solid #ddd',
+    background: 'var(--v-surface)',
+    border: '1px solid var(--v-border)',
     borderRadius: '4px',
     padding: '4px',
     boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
@@ -515,11 +515,11 @@ export function EditableNode({ id, data, selected, isConnectable }: NodeProps<UM
       : '0 2px 8px rgba(0,0,0,0.08)';
 
     const elementStyles: Record<string, React.CSSProperties> = {
-      'class': { borderColor, background: '#ffffff' },
-      'abstract-class': { borderColor, background: '#ffffff' },
-      'interface': { borderColor, borderStyle: 'dashed', background: '#ffffff' },
-      'enumeration': { borderColor, background: '#ffffff' },
-      'package': { borderColor, background: '#ffffff' },
+      'class': { borderColor, background: 'var(--v-uml-box-bg)' },
+      'abstract-class': { borderColor, background: 'var(--v-uml-box-bg)' },
+      'interface': { borderColor, borderStyle: 'dashed', background: 'var(--v-uml-box-bg)' },
+      'enumeration': { borderColor, background: 'var(--v-uml-box-bg)' },
+      'package': { borderColor, background: 'var(--v-uml-box-bg)' },
     };
 
     if (nodeData.toolType === 'element' && nodeData.toolName) {

--- a/src/components/flow/FlowCanvas.tsx
+++ b/src/components/flow/FlowCanvas.tsx
@@ -1251,7 +1251,7 @@ export const FlowCanvas = forwardRef<FlowCanvasHandle, FlowCanvasProps>(
             }
           }}
         >
-          <Background />
+          <Background color="var(--v-workspace-dot)" gap={24} size={0.75} />
         </ReactFlow>
 
         {circleVisible && !umlModalOpen && (

--- a/src/components/flow/UMLRelationship.tsx
+++ b/src/components/flow/UMLRelationship.tsx
@@ -89,7 +89,7 @@ function calculateStraightPath(params: PathParams & { parallelIndex?: number; pa
 
 
 // jjodel-style navy blue as the default edge color
-const EDGE_DEFAULT = '#0c436e';
+const EDGE_DEFAULT = 'var(--v-uml-edge, #0c436e)';
 const EDGE_SELECT  = '#ef4444';
 const EDGE_SELECT_HOVER = '#f87171';
 // Shorten the drawn line so endpoint markers sit on the visible segment (not under HTML nodes).

--- a/src/components/flow/canvas/CanvasControls.tsx
+++ b/src/components/flow/canvas/CanvasControls.tsx
@@ -14,8 +14,9 @@ export const CanvasControlButton: React.FC<CanvasControlButtonProps> = ({ onClic
       width: 36,
       height: 36,
       borderRadius: 10,
-      border: '1px solid #e5e7eb',
-      background: '#ffffff',
+      border: '1px solid var(--v-border)',
+      background: 'var(--v-chrome-bg)',
+      color: 'var(--v-chrome-icon)',
       cursor: 'pointer',
       display: 'flex',
       alignItems: 'center',
@@ -25,8 +26,8 @@ export const CanvasControlButton: React.FC<CanvasControlButtonProps> = ({ onClic
       boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
     }}
     title={title}
-    onMouseEnter={e => (e.currentTarget.style.background = '#f0f0f0')}
-    onMouseLeave={e => (e.currentTarget.style.background = '#ffffff')}
+    onMouseEnter={e => (e.currentTarget.style.background = 'var(--v-chrome-hover)')}
+    onMouseLeave={e => (e.currentTarget.style.background = 'var(--v-chrome-bg)')}
   >
     {icon}
   </button>

--- a/src/components/flow/canvas/CanvasModeToggle.tsx
+++ b/src/components/flow/canvas/CanvasModeToggle.tsx
@@ -70,9 +70,9 @@ export const CanvasModeToggle: React.FC<CanvasModeToggleProps> = ({
         style={{
           display: 'flex',
           alignItems: 'center',
-          background: '#ffffff',
+          background: 'var(--v-chrome-bg)',
           borderRadius: 8,
-          boxShadow: '0 4px 16px rgba(0,0,0,0.13), 0 0 0 1px rgba(0,0,0,0.07)',
+          boxShadow: '0 4px 16px rgba(0,0,0,0.13), 0 0 0 1px var(--v-card-border)',
           height: 44,
           padding: '0 4px',
           gap: 2,
@@ -94,7 +94,7 @@ export const CanvasModeToggle: React.FC<CanvasModeToggleProps> = ({
                 border: isActive ? '1px solid #049484' : '1px solid transparent',
                 borderRadius: 6,
                 background: isActive ? '#049484' : 'transparent',
-                color: isActive ? '#ffffff' : '#64748b',
+                color: isActive ? '#ffffff' : 'var(--v-text-muted)',
                 fontSize: 12,
                 fontWeight: 600,
                 cursor: 'pointer',
@@ -104,13 +104,13 @@ export const CanvasModeToggle: React.FC<CanvasModeToggleProps> = ({
               }}
               onMouseEnter={e => {
                 if (isActive) return;
-                e.currentTarget.style.background = '#f1f5f9';
-                e.currentTarget.style.color = '#1e293b';
+                e.currentTarget.style.background = 'var(--v-chrome-hover)';
+                e.currentTarget.style.color = 'var(--v-text)';
               }}
               onMouseLeave={e => {
                 if (isActive) return;
                 e.currentTarget.style.background = 'transparent';
-                e.currentTarget.style.color = '#64748b';
+                e.currentTarget.style.color = 'var(--v-text-muted)';
               }}
             >
               {icon}

--- a/src/components/flow/canvas/CircleOverlay.tsx
+++ b/src/components/flow/canvas/CircleOverlay.tsx
@@ -243,7 +243,7 @@ export const CircleOverlay: React.FC<CircleOverlayProps> = ({
                         markerHeight={8}
                         orient="auto-start-reverse"
                     >
-                        <path d="M0 0L10 5L0 10Z" fill="#000000" />
+                        <path d="M0 0L10 5L0 10Z" fill="var(--v-uml-circle, #0c436e)" />
                     </marker>
                 </defs>
 
@@ -252,7 +252,7 @@ export const CircleOverlay: React.FC<CircleOverlayProps> = ({
                     <circle
                         cx={screenCx} cy={screenCy}
                         r={previewR * viewport.zoom}
-                        fill="none" stroke="#000000" strokeWidth={2}
+                        fill="none" stroke="var(--v-uml-circle, #0c436e)" strokeWidth={2.5}
                         strokeDasharray="8 5" opacity={0.35}
                         pointerEvents="none"
                     />
@@ -286,8 +286,8 @@ export const CircleOverlay: React.FC<CircleOverlayProps> = ({
                 {/* Visible circle — no pointer events */}
                 <circle
                     cx={screenCx} cy={screenCy} r={screenR}
-                    fill="none" stroke="#000000"
-                    strokeWidth={selected ? 2 : 1.5}
+                    fill="none" stroke="var(--v-uml-circle, #0c436e)"
+                    strokeWidth={selected ? 3.5 : 2.5}
                     filter="url(#circle-shadow)"
                     pointerEvents="none"
                 />
@@ -350,7 +350,7 @@ export const CircleOverlay: React.FC<CircleOverlayProps> = ({
                         onPointerUp={handlePointerUp}
                     >
                         <circle cx={handleScreenX} cy={handleScreenY} r={HANDLE_RADIUS + 3} fill="rgba(0,0,0,0.12)" />
-                        <circle cx={handleScreenX} cy={handleScreenY} r={HANDLE_RADIUS} fill="white" stroke="#000000" strokeWidth={1.5} />
+                        <circle cx={handleScreenX} cy={handleScreenY} r={HANDLE_RADIUS} fill="white" stroke="var(--v-uml-circle, #0c436e)" strokeWidth={1.5} />
                         <text
                             x={handleScreenX} y={handleScreenY}
                             textAnchor="middle" dominantBaseline="central"

--- a/src/components/flow/canvas/ViewTypeArrow.tsx
+++ b/src/components/flow/canvas/ViewTypeArrow.tsx
@@ -199,19 +199,19 @@ export const ViewTypeArrow: React.FC<ViewTypeArrowProps> = ({
             <line
                 x1={start.x} y1={start.y}
                 x2={end.x} y2={end.y}
-                stroke="#000000"
+                stroke="var(--v-uml-circle, #0c436e)"
                 strokeWidth={1.5}
                 style={{ pointerEvents: 'none' }}
             />
             <polygon
                 points={startArrow}
-                fill="#000000"
+                fill="var(--v-uml-circle, #0c436e)"
                 style={{ pointerEvents: 'none' }}
             />
             {editable && (
                 <polygon
                     points={endArrow}
-                    fill="#000000"
+                    fill="var(--v-uml-circle, #0c436e)"
                     style={{ pointerEvents: 'none' }}
                 />
             )}

--- a/src/components/flow/umlNodeStyles.ts
+++ b/src/components/flow/umlNodeStyles.ts
@@ -5,12 +5,12 @@ const NAVY = 'var(--v-uml-edge, #0c436e)';
 const TEAL = '#087E8B';
 const MAROON = '#5F0F40';
 const GOLD = '#d4a017';
-const SEPARATOR = '#b8d0e2';
+const SEPARATOR = 'var(--v-uml-separator, #b8d0e2)';
 
 // Base node container
 export const getBaseNodeStyle = (selected: boolean): React.CSSProperties => ({
   padding: '0px',
-  background: '#ffffff',
+  background: 'var(--v-uml-box-bg, #ffffff)',
   border: selected ? `2px solid ${TEAL}` : `1.5px solid ${NAVY}`,
   borderRadius: '3px',
   minWidth: '380px',
@@ -32,7 +32,7 @@ export const headerBaseStyle: React.CSSProperties = {
   fontWeight: 700,
   fontSize: '18px',
   color: NAVY,
-  background: '#ffffff',
+  background: 'var(--v-uml-box-bg, #ffffff)',
   flexWrap: 'nowrap' as const,
   letterSpacing: '0.1px',
 };
@@ -68,15 +68,15 @@ export const borderedSectionBodyStyle: React.CSSProperties = {
   borderBottom: `1px solid ${SEPARATOR}`,
   padding: '5px 0',
   fontSize: '16px',
-  color: '#2d4a5e',
-  background: '#ffffff',
+  color: 'var(--v-uml-box-text-muted, #2d4a5e)',
+  background: 'var(--v-uml-box-bg, #ffffff)',
 };
 
 export const sectionBodyStyle: React.CSSProperties = {
   padding: '5px 0',
   fontSize: '16px',
-  color: '#2d4a5e',
-  background: '#ffffff',
+  color: 'var(--v-uml-box-text-muted, #2d4a5e)',
+  background: 'var(--v-uml-box-bg, #ffffff)',
 };
 
 // Monospace list item for attributes / methods / enum values
@@ -87,13 +87,13 @@ export const listItemStyle: React.CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   gap: '4px',
-  color: '#1e3a50',
+  color: 'var(--v-uml-box-text, #1e3a50)',
   lineHeight: '1.4',
 };
 
 // Package header (maroon theme)
 export const packageHeaderStyle: React.CSSProperties = {
-  background: '#f9f4f7',
+  background: 'var(--v-uml-package-bg, #f9f4f7)',
   borderBottom: `2px solid ${MAROON}`,
   padding: '12px 18px',
   textAlign: 'center',
@@ -111,7 +111,7 @@ export const packageHeaderStyle: React.CSSProperties = {
 export const packageContentStyle: React.CSSProperties = {
   padding: '8px 0',
   fontSize: '15px',
-  color: '#666',
+  color: 'var(--v-uml-box-text-muted, #666)',
   minHeight: '50px',
 };
 
@@ -119,7 +119,7 @@ export const packageContentTitleStyle: React.CSSProperties = {
   padding: '5px 10px',
   fontWeight: 'bold',
   color: MAROON,
-  background: '#f9f4f7',
+  background: 'var(--v-uml-package-bg, #f9f4f7)',
   fontSize: '14px',
 };
 
@@ -168,7 +168,7 @@ const handleBase: React.CSSProperties = {
   width: '8px',
   height: '8px',
   borderRadius: '50%',
-  border: '1.5px solid #ffffff',
+  border: '1.5px solid var(--v-uml-box-bg, #ffffff)',
   opacity: 0,
 };
 

--- a/src/components/flow/umlNodeStyles.ts
+++ b/src/components/flow/umlNodeStyles.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 
 // jjodel-inspired color palette
-const NAVY = '#0c436e';
+const NAVY = 'var(--v-uml-edge, #0c436e)';
 const TEAL = '#087E8B';
 const MAROON = '#5F0F40';
 const GOLD = '#d4a017';

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import { BoundChangePasswordModal } from '../ui/BoundChangePasswordModal';
+import { ThemeToggle } from '../ui/ThemeToggle';
 import { useChangePassword } from '../../hooks/useChangePassword';
 import { useDismissOnOutsideClick } from '../../hooks/useDismissOnOutsideClick';
 import { getUserInitials } from '../../utils/userInitials';
@@ -339,6 +340,9 @@ export const AppSidebar: React.FC<AppSidebarProps> = ({
 
         {/* Border above user card */}
         <div style={{ borderTop: '1px solid rgba(255,255,255,0.07)', padding: '10px 12px 12px' }}>
+          <div style={{ marginBottom: 10 }}>
+            <ThemeToggle variant="segmented" tone="onDark" />
+          </div>
           {/* User card */}
           <button type="button"
             onClick={() => setMenuOpen(v => !v)}

--- a/src/components/ui/ActionButton.tsx
+++ b/src/components/ui/ActionButton.tsx
@@ -23,9 +23,9 @@ const VARIANT_BASE: Record<ActionButtonVariant, React.CSSProperties> = {
     boxShadow: '0 2px 8px rgba(4, 148, 132, 0.22)',
   },
   secondary: {
-    background: '#ffffff',
-    color: '#374151',
-    border: '1.5px solid #e2e8f0',
+    background: 'var(--v-surface)',
+    color: 'var(--v-text-secondary)',
+    border: '1.5px solid var(--v-border)',
     boxShadow: 'none',
   },
   danger: {
@@ -35,33 +35,33 @@ const VARIANT_BASE: Record<ActionButtonVariant, React.CSSProperties> = {
     boxShadow: '0 2px 8px rgba(220, 38, 38, 0.2)',
   },
   dangerOutline: {
-    background: '#ffffff',
+    background: 'var(--v-surface)',
     color: DANGER_COLOR,
     border: `1.5px solid ${DANGER_COLOR}`,
     boxShadow: 'none',
   },
   ghost: {
-    background: '#ffffff',
-    color: '#475569',
-    border: '1.5px solid #e2e8f0',
+    background: 'var(--v-surface)',
+    color: 'var(--v-text-secondary)',
+    border: '1.5px solid var(--v-border)',
     boxShadow: 'none',
   },
 };
 
 const VARIANT_HOVER: Record<ActionButtonVariant, React.CSSProperties> = {
   primary: { background: BRAND_COLOR_HOVER, boxShadow: '0 4px 12px rgba(4, 148, 132, 0.3)' },
-  secondary: { background: '#f8fafc', borderColor: '#cbd5e1' },
+  secondary: { background: 'var(--v-surface-hover)', borderColor: 'var(--v-text-muted)' },
   danger: { background: DANGER_COLOR_HOVER, boxShadow: '0 4px 12px rgba(220, 38, 38, 0.28)' },
-  dangerOutline: { background: '#fef2f2', borderColor: DANGER_COLOR_HOVER },
-  ghost: { background: '#f8fafc', borderColor: '#cbd5e1', color: '#334155' },
+  dangerOutline: { background: 'var(--v-danger-bg)', borderColor: DANGER_COLOR_HOVER },
+  ghost: { background: 'var(--v-surface-hover)', borderColor: 'var(--v-text-muted)', color: 'var(--v-text)' },
 };
 
 const VARIANT_DISABLED: Record<ActionButtonVariant, React.CSSProperties> = {
-  primary: { background: '#94a3b8', boxShadow: 'none', cursor: 'not-allowed' },
-  secondary: { background: '#f1f5f9', color: '#94a3b8', borderColor: '#e2e8f0', cursor: 'not-allowed' },
-  danger: { background: '#fca5a5', boxShadow: 'none', cursor: 'not-allowed' },
-  dangerOutline: { background: '#f8fafc', color: '#94a3b8', borderColor: '#e2e8f0', cursor: 'not-allowed' },
-  ghost: { background: '#f8fafc', color: '#94a3b8', borderColor: '#e2e8f0', cursor: 'not-allowed' },
+  primary: { background: 'var(--v-disabled-bg)', boxShadow: 'none', cursor: 'not-allowed' },
+  secondary: { background: 'var(--v-surface-muted)', color: 'var(--v-disabled-text)', borderColor: 'var(--v-border)', cursor: 'not-allowed' },
+  danger: { background: 'var(--v-danger-bg)', color: 'var(--v-danger-text)', boxShadow: 'none', cursor: 'not-allowed' },
+  dangerOutline: { background: 'var(--v-surface-muted)', color: 'var(--v-disabled-text)', borderColor: 'var(--v-border)', cursor: 'not-allowed' },
+  ghost: { background: 'var(--v-surface-muted)', color: 'var(--v-disabled-text)', borderColor: 'var(--v-border)', cursor: 'not-allowed' },
 };
 
 export const ActionButton: React.FC<ActionButtonProps> = ({

--- a/src/components/ui/ChangePasswordModal.tsx
+++ b/src/components/ui/ChangePasswordModal.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
+import { useTheme } from '../../theme/theme';
 import { useModalBodyLock } from './modalUtils';
 import { EyeIcon, EyeOffIcon } from './PasswordVisibilityIcons';
+import { ThemeToggle } from './ThemeToggle';
 
 export interface PasswordValidation {
   hasMinLength: boolean;
@@ -34,8 +36,8 @@ const PasswordRequirements: React.FC<{ validation: PasswordValidation; showRequi
 }) => {
   if (!showRequirements) return null;
   return (
-    <div style={{ marginTop: 12, padding: 12, background: '#f9fafb', border: '1px solid #e5e7eb', borderRadius: 8 }}>
-      <div style={{ fontSize: 12, fontWeight: 600, color: '#374151', marginBottom: 8 }}>Password must:</div>
+    <div style={{ marginTop: 12, padding: 12, background: 'var(--v-surface-muted)', border: '1px solid var(--v-border)', borderRadius: 8 }}>
+      <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--v-text)', marginBottom: 8 }}>Password must:</div>
       <ul style={{ listStyle: 'none', padding: 0, margin: 0, fontSize: 12, display: 'flex', flexDirection: 'column', gap: 4 }}>
         <ValidationItem isValid={validation.hasMinLength} text="Be at least 8 characters long" />
         <ValidationItem isValid={validation.hasLowercase} text="Have at least one lowercase letter" />
@@ -64,7 +66,7 @@ const PasswordInput: React.FC<{
   const inputId = React.useId();
   return (
     <div style={{ marginBottom: 20 }}>
-      <label htmlFor={inputId} style={{ display: 'block', marginBottom: 10, fontSize: 14, fontWeight: 600, color: '#1f2937' }}>
+      <label htmlFor={inputId} style={{ display: 'block', marginBottom: 10, fontSize: 14, fontWeight: 600, color: 'var(--v-text)' }}>
         {label}
       </label>
       <div style={{ position: 'relative' }}>
@@ -77,9 +79,10 @@ const PasswordInput: React.FC<{
           disabled={disabled}
           style={{
             width: '100%', padding: '12px 48px 12px 14px',
-            border: showError ? '2px solid #dc2626' : '2px solid #e5e7eb',
+            border: showError ? '2px solid #dc2626' : '2px solid var(--v-border)',
             borderRadius: 8, fontSize: 14, boxSizing: 'border-box', outline: 'none',
-            background: isFocused ? '#ffffff' : '#f9fafb',
+            color: 'var(--v-text)',
+            background: isFocused ? 'var(--v-input-bg)' : 'var(--v-surface-muted)',
             boxShadow: isFocused ? '0 0 0 3px rgba(4, 148, 132, 0.1)' : 'none',
           }}
           onFocus={() => setIsFocused(true)}
@@ -103,8 +106,8 @@ const PasswordInput: React.FC<{
             height: 32,
             border: 'none',
             borderRadius: 6,
-            background: isToggleHovered && !disabled ? '#f0fdfa' : 'transparent',
-            color: isToggleHovered && !disabled ? '#1f9f92' : '#64748b',
+            background: isToggleHovered && !disabled ? 'var(--v-chrome-hover)' : 'transparent',
+            color: isToggleHovered && !disabled ? '#049484' : 'var(--v-chrome-icon)',
             cursor: disabled ? 'not-allowed' : 'pointer',
             display: 'flex',
             alignItems: 'center',
@@ -133,14 +136,27 @@ const PasswordInput: React.FC<{
 };
 
 const MessageBox: React.FC<{ message: string; type: 'error' | 'success' }> = ({ message, type }) => {
+  const { isDark } = useTheme();
   const isError = type === 'error';
+  let background: string;
+  let border: string;
+  let color: string;
+  if (isError) {
+    background = isDark ? '#3f1d1d' : '#fef2f2';
+    border = isDark ? '#7f1d1d' : '#fecaca';
+    color = isDark ? '#fecaca' : '#991b1b';
+  } else {
+    background = isDark ? '#14532d' : '#d5f4e6';
+    border = isDark ? '#166534' : '#a9dfbf';
+    color = isDark ? '#bbf7d0' : '#166534';
+  }
   return (
     <div style={{
       padding: '14px 16px',
-      background: isError ? '#fef2f2' : '#d5f4e6',
-      border: `2px solid ${isError ? '#fecaca' : '#a9dfbf'}`,
+      background,
+      border: `2px solid ${border}`,
       borderRadius: 8,
-      color: isError ? '#991b1b' : '#166534',
+      color,
       fontSize: 13,
       marginBottom: 20,
       fontWeight: 500,
@@ -163,7 +179,7 @@ const ModalButton: React.FC<{
   const isDisabled = Boolean(disabled || isLoading);
   let background: string;
   if (isCancel) {
-    background = '#fff';
+    background = 'var(--v-surface)';
   } else if (isDisabled) {
     background = '#95a5a6';
   } else {
@@ -186,9 +202,9 @@ const ModalButton: React.FC<{
       style={{
         padding: isCancel ? '12px 24px' : '12px 28px',
         borderRadius: 8,
-        border: isCancel ? '2px solid #e5e7eb' : '2px solid #037368',
+        border: isCancel ? '2px solid var(--v-border)' : '2px solid #037368',
         background,
-        color: isCancel ? '#374151' : '#fff',
+        color: isCancel ? 'var(--v-text)' : '#fff',
         cursor: isDisabled ? 'not-allowed' : 'pointer',
         fontWeight: isCancel ? 600 : 700,
         fontSize: 14,
@@ -236,6 +252,7 @@ export const ChangePasswordModal: React.FC<ChangePasswordModalProps> = ({
   onSubmit,
   canSubmit,
 }) => {
+  const { theme } = useTheme();
   useModalBodyLock(isOpen);
 
   useEffect(() => {
@@ -264,16 +281,45 @@ export const ChangePasswordModal: React.FC<ChangePasswordModalProps> = ({
       />
       <dialog
         open
+        className="change-password-dialog"
         aria-labelledby="change-password-title"
         style={{
-          background: '#fff', borderRadius: 16, padding: 0, width: '90%', maxWidth: 480,
-          boxShadow: '0 24px 72px rgba(0,0,0,0.3)', overflow: 'hidden', position: 'relative', zIndex: 1,
-          border: 'none', margin: 0,
+          backgroundColor: 'var(--v-surface)',
+          borderRadius: 16,
+          padding: 0,
+          width: '90%',
+          maxWidth: 480,
+          boxShadow: 'var(--v-card-shadow)',
+          overflow: 'hidden',
+          position: 'relative',
+          zIndex: 1,
+          margin: 0,
+          colorScheme: theme,
         }}
       >
-        <div style={{ background: 'linear-gradient(135deg, #049484 0%, #037368 100%)', padding: '28px 32px', color: '#fff' }}>
-          <h2 id="change-password-title" style={{ margin: 0, fontSize: 26, fontWeight: 700 }}>Change Password</h2>
-          <p style={{ margin: '10px 0 0', fontSize: 14, opacity: 0.95 }}>
+        <div style={{
+          background: 'linear-gradient(135deg, #049484 0%, #037368 100%)',
+          padding: '28px 32px',
+          color: '#fff',
+          position: 'relative',
+        }}>
+          <div
+            style={{
+              position: 'absolute',
+              top: 12,
+              right: 12,
+              background: 'rgba(255,255,255,0.14)',
+              border: '1px solid rgba(255,255,255,0.22)',
+              borderRadius: 10,
+              padding: 2,
+            }}
+          >
+            <ThemeToggle tone="onDark" />
+          </div>
+          <h2 id="change-password-title" style={{ margin: 0, fontSize: 26, fontWeight: 700, paddingRight: 44 }}>
+            Change Password
+          </h2>
+          <p style={{ margin: '10px 0 0', fontSize: 14, opacity: 0.95, paddingRight: 44 }}>
             Please create a strong password that meets all security requirements to protect your account.
           </p>
         </div>

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -49,7 +49,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   const themes = {
     danger: {
       accentColor: '#dc2626',
-      iconBg: '#fef2f2',
+      iconBg: 'var(--v-danger-bg)',
       buttonBg: '#dc2626',
       buttonHoverBg: '#b91c1c',
       buttonShadow: 'rgba(220,38,38,0.25)',
@@ -57,7 +57,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
     },
     success: {
       accentColor: '#059669',
-      iconBg: '#f0fdf4',
+      iconBg: 'var(--v-success-bg)',
       buttonBg: '#059669',
       buttonHoverBg: '#047857',
       buttonShadow: 'rgba(5,150,105,0.25)',

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -94,7 +94,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
         aria-describedby="confirm-message"
         style={{
           pointerEvents: 'auto',
-          background: '#ffffff',
+          background: 'var(--v-surface)',
           borderRadius: '14px',
           boxShadow: '0 24px 60px rgba(0,0,0,0.22), 0 4px 16px rgba(0,0,0,0.08)',
           width: '420px',
@@ -145,7 +145,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
             style={{
               fontSize: '19px',
               fontWeight: 700,
-              color: '#111827',
+              color: 'var(--v-text)',
               textAlign: 'center',
               lineHeight: 1.3,
               fontFamily: FONT,
@@ -159,7 +159,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
             id="confirm-message"
             style={{
               fontSize: '14px',
-              color: '#6b7280',
+              color: 'var(--v-text-muted)',
               textAlign: 'center',
               lineHeight: '1.65',
               fontFamily: FONT,
@@ -185,10 +185,10 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
               style={{
                 flex: 1,
                 padding: '11px 16px',
-                background: '#fff',
-                border: '1.5px solid #e5e7eb',
+                background: 'var(--v-surface)',
+                border: '1.5px solid var(--v-border)',
                 borderRadius: '8px',
-                color: '#374151',
+                color: 'var(--v-text-secondary)',
                 cursor: 'pointer',
                 fontSize: '14px',
                 fontWeight: 600,
@@ -196,12 +196,12 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
                 transition: 'all 0.15s ease',
               }}
               onMouseEnter={(e) => {
-                e.currentTarget.style.background = '#f9fafb';
-                e.currentTarget.style.borderColor = '#d1d5db';
+                e.currentTarget.style.background = 'var(--v-surface-hover)';
+                e.currentTarget.style.borderColor = 'var(--v-text-faint)';
               }}
               onMouseLeave={(e) => {
-                e.currentTarget.style.background = '#fff';
-                e.currentTarget.style.borderColor = '#e5e7eb';
+                e.currentTarget.style.background = 'var(--v-surface)';
+                e.currentTarget.style.borderColor = 'var(--v-border)';
               }}
             >
               {cancelText}

--- a/src/components/ui/CreateModelModal.tsx
+++ b/src/components/ui/CreateModelModal.tsx
@@ -131,8 +131,8 @@ const FILE_CARD_DISPLAY_CONFIGS: Array<{
   badgeColor: string;
   defaultHeaderBg: string;
 }> = [
-  { kind: 'ecore',    accentColor: '#049484', hoverBg: '#f0fdff', badgeBg: '#e6f7f5', badgeBorder: '#b2e4df', badgeColor: '#049484', defaultHeaderBg: '#f8fffe' },
-  { kind: 'genmodel', accentColor: '#0B1720', hoverBg: '#f4f6f8', badgeBg: '#eef0f3', badgeBorder: '#c8cdd6', badgeColor: '#0B1720', defaultHeaderBg: '#f8f9fb' },
+  { kind: 'ecore',    accentColor: '#049484', hoverBg: 'var(--v-surface-hover)', badgeBg: 'var(--v-brand-soft)', badgeBorder: 'var(--v-uml-primary-border)', badgeColor: '#049484', defaultHeaderBg: 'var(--v-surface)' },
+  { kind: 'genmodel', accentColor: 'var(--v-text-secondary)', hoverBg: 'var(--v-surface-hover)', badgeBg: 'var(--v-surface-hover)', badgeBorder: 'var(--v-border)', badgeColor: 'var(--v-text)', defaultHeaderBg: 'var(--v-surface)' },
 ];
 
 // ─── Style constants ──────────────────────────────────────────────────────────
@@ -223,11 +223,11 @@ const uploadSectionTitleStyle: React.CSSProperties = {
 const metaModelImportErrorBannerStyle: React.CSSProperties = {
   marginBottom: 12,
   padding: '10px 12px',
-  background: '#fef2f2',
-  border: '1px solid #fecaca',
+  background: 'var(--v-danger-bg)',
+  border: '1px solid var(--v-danger-border)',
   borderRadius: 6,
   fontSize: 13,
-  color: '#991b1b',
+  color: 'var(--v-danger-text)',
   lineHeight: 1.5,
   fontFamily: FONT,
 };
@@ -242,12 +242,12 @@ const fieldInlineErrorStyle: React.CSSProperties = {
 
 const inputErrorOutlineStyle: React.CSSProperties = {
   borderColor: '#fca5a5',
-  background: '#fffafa',
+  background: 'var(--v-danger-bg)',
 };
 
 const fileStatusStyle: React.CSSProperties = {
   fontSize: 11,
-  color: '#9ca3af',
+  color: 'var(--v-text-faint)',
   textAlign: 'center',
   marginTop: 10,
   fontFamily: FONT,
@@ -275,8 +275,8 @@ const primaryButtonStyle: React.CSSProperties = {
 };
 
 const primaryButtonDisabledStyle: React.CSSProperties = {
-  background: '#e5e7eb',
-  color: '#9ca3af',
+  background: 'var(--v-disabled-bg)',
+  color: 'var(--v-disabled-text)',
   cursor: 'not-allowed',
 };
 
@@ -387,7 +387,7 @@ const SubmitProgressOverlay: React.FC<{ progress: number }> = ({ progress }) => 
         <div style={progressBarContainerStyle}>
           <div style={{ ...progressBarStyle, width: `${progress}%` }} />
         </div>
-        <div style={{ fontSize: 12, color: '#6b7280', textAlign: 'center', marginTop: 8, fontFamily: FONT }}>
+        <div style={{ fontSize: 12, color: 'var(--v-text-muted)', textAlign: 'center', marginTop: 8, fontFamily: FONT }}>
           {Math.round(progress)}%
         </div>
       </div>
@@ -428,13 +428,13 @@ const FileDropZone: React.FC<FileDropZoneProps> = ({
     );
   } else if (isUploading) {
     icon = (
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#9ca3af" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ animation: 'spin 1s linear infinite' }}>
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--v-text-faint)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ animation: 'spin 1s linear infinite' }}>
         <path d="M21 12a9 9 0 1 1-6.219-8.56" />
       </svg>
     );
   } else {
     icon = (
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={hov ? accentColor : '#9ca3af'} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={hov ? accentColor : 'var(--v-text-faint)'} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
         <polyline points="17 8 12 3 7 8" />
         <line x1="12" y1="3" x2="12" y2="15" />
@@ -472,7 +472,7 @@ const FileDropZone: React.FC<FileDropZoneProps> = ({
         </div>
       )}
       {!isUploaded && !isUploading && (
-        <div style={{ fontSize: 11, color: '#9ca3af' }}>{ext}</div>
+        <div style={{ fontSize: 11, color: 'var(--v-text-faint)' }}>{ext}</div>
       )}
     </button>
   );
@@ -499,9 +499,9 @@ const UrlImportRow: React.FC<UrlImportRowProps> = ({
   const isDisabled = isUploading || !url.trim();
   return (
     <>
-      <div style={{ fontSize: '11px', color: '#64748b', marginBottom: '6px', fontStyle: 'italic' }}>
+      <div style={{ fontSize: '11px', color: 'var(--v-text-muted)', marginBottom: '6px', fontStyle: 'italic' }}>
         Paste a raw public URL pointing to a{' '}
-        <code style={{ background: '#f1f5f9', padding: '1px 4px', borderRadius: '3px' }}>{ext}</code> file
+        <code style={{ background: 'var(--v-surface-hover)', color: 'var(--v-text)', padding: '1px 4px', borderRadius: '3px' }}>{ext}</code> file
       </div>
       <div style={{ display: 'flex', gap: '8px' }}>
         <input
@@ -607,7 +607,7 @@ const FileUploadCard: React.FC<FileUploadCardProps> = ({
       {/* card header */}
       <div style={{
         display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-        padding: '8px 12px', background: '#f9fafb', borderBottom: '1px solid #f1f5f9',
+        padding: '8px 12px', background: headerBg, borderBottom: '1px solid var(--v-border-subtle)',
       }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <span style={{
@@ -624,14 +624,14 @@ const FileUploadCard: React.FC<FileUploadCardProps> = ({
           )}
           {isUploaded && (
             <button type="button" onClick={onClearUpload} disabled={removeDisabled} style={{
-              fontSize: 11, fontFamily: FONT, border: '1px solid #e5e7eb', borderRadius: 4,
-              background: '#fff', color: '#6b7280', padding: '1px 7px',
+              fontSize: 11, fontFamily: FONT, border: '1px solid var(--v-border)', borderRadius: 4,
+              background: 'var(--v-surface)', color: 'var(--v-text-muted)', padding: '1px 7px',
               cursor: removeDisabled ? 'not-allowed' : 'pointer', opacity: removeDisabled ? 0.4 : 1,
             }}>Remove</button>
           )}
         </div>
         {/* mode toggle */}
-        <div style={{ display: 'flex', background: '#f1f5f9', borderRadius: 5, padding: 2, gap: 2 }}>
+        <div style={{ display: 'flex', background: 'var(--v-input-bg)', borderRadius: 5, padding: 2, gap: 2 }}>
           <button type="button" onClick={() => onModeChange('file')} style={fileModeStyle}>File</button>
           <button type="button" onClick={() => onModeChange('url')}  style={urlModeStyle}>URL</button>
         </div>
@@ -660,7 +660,7 @@ const FileUploadCard: React.FC<FileUploadCardProps> = ({
             <div style={progressBarContainerStyle}>
               <div style={{ ...progressBarStyle, width: `${uploadProgress.progress}%` }} />
             </div>
-            <div style={{ fontSize: 11, color: '#9ca3af', textAlign: 'center', marginTop: 3 }}>
+            <div style={{ fontSize: 11, color: 'var(--v-text-faint)', textAlign: 'center', marginTop: 3 }}>
               {Math.round(uploadProgress.progress)}%
             </div>
           </div>
@@ -668,8 +668,8 @@ const FileUploadCard: React.FC<FileUploadCardProps> = ({
         {uploadError && (
           <div style={{
             marginTop: 8, padding: '8px 10px',
-            background: '#fef2f2', border: '1px solid #fecaca',
-            borderRadius: 5, fontSize: 12, color: '#b91c1c',
+            background: 'var(--v-danger-bg)', border: '1px solid var(--v-danger-border)',
+            borderRadius: 5, fontSize: 12, color: 'var(--v-danger-text)',
             display: 'flex', alignItems: 'flex-start', gap: 6,
           }}>
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, marginTop: 1 }}><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
@@ -732,8 +732,8 @@ const GenModelFixPrompt: React.FC<GenModelFixPromptProps> = ({
   return (
     <div style={{
       marginTop: 16, padding: 14, borderRadius: 6,
-      border: '1px solid #fde68a', background: '#fffbeb',
-      fontSize: 13, color: '#78350f', fontFamily: FONT,
+      border: '1px solid var(--v-warning-border)', background: 'var(--v-warning-bg)',
+      fontSize: 13, color: 'var(--v-warning-text)', fontFamily: FONT,
     }}>
       <div style={{ fontWeight: 600, marginBottom: 6 }}>
         We detected issues in your GenModel.
@@ -1464,7 +1464,7 @@ export const CreateModelModal: React.FC<CreateModelModalProps> = ({
                     badgeBg={badgeBg}
                     badgeBorder={badgeBorder}
                     badgeColor={badgeColor}
-                    headerBg={fileId > 0 ? '#f0fdf4' : defaultHeaderBg}
+                    headerBg={fileId > 0 ? 'var(--v-success-bg)' : defaultHeaderBg}
                     fileId={fileId}
                     inputMode={inputMode}
                     uploadProgress={uploadProgress[kind]}

--- a/src/components/ui/CreateModelModal.tsx
+++ b/src/components/ui/CreateModelModal.tsx
@@ -140,7 +140,7 @@ const FILE_CARD_DISPLAY_CONFIGS: Array<{
 const FONT = 'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif';
 
 const modalStyle: React.CSSProperties = {
-  background: '#ffffff',
+  background: 'var(--v-surface)',
   borderRadius: 8,
   padding: 0,
   width: '540px',
@@ -150,8 +150,9 @@ const modalStyle: React.CSSProperties = {
   flexDirection: 'column',
   overflow: 'hidden',
   boxShadow: '0 8px 40px rgba(0,0,0,0.18), 0 1px 4px rgba(0,0,0,0.06)',
-  border: '1px solid #e2e8f0',
+  border: '1px solid var(--v-border)',
   fontFamily: FONT,
+  color: 'var(--v-text)',
 };
 
 const modalHeaderStyle: React.CSSProperties = {
@@ -199,19 +200,19 @@ const inputFocusStyle: React.CSSProperties = {
   borderColor: '#049484',
   outline: 'none',
   boxShadow: '0 0 0 3px rgba(4,148,132,0.1)',
-  background: '#ffffff',
+  background: 'var(--v-input-bg)',
 };
 
 const uploadSectionStyle: React.CSSProperties = {
   marginTop: '20px',
   paddingTop: '20px',
-  borderTop: '1px solid #f1f5f9',
+  borderTop: '1px solid var(--v-border-subtle)',
 };
 
 const uploadSectionTitleStyle: React.CSSProperties = {
   fontSize: 12,
   fontWeight: 600,
-  color: '#6b7280',
+  color: 'var(--v-text-muted)',
   marginBottom: 12,
   textTransform: 'uppercase',
   letterSpacing: '0.07em',
@@ -282,10 +283,10 @@ const primaryButtonDisabledStyle: React.CSSProperties = {
 const secondaryButtonStyle: React.CSSProperties = {
   flex: '1',
   padding: '10px 18px',
-  border: '1px solid #e5e7eb',
+  border: '1px solid var(--v-border)',
   borderRadius: 6,
-  background: '#ffffff',
-  color: '#374151',
+  background: 'var(--v-surface)',
+  color: 'var(--v-text-secondary)',
   fontSize: 14,
   fontWeight: 500,
   cursor: 'pointer',
@@ -295,7 +296,7 @@ const secondaryButtonStyle: React.CSSProperties = {
 };
 
 const buttonHoverStyle: React.CSSProperties = {
-  background: '#f9fafb',
+  background: 'var(--v-surface-hover)',
 };
 
 const overlayStyle: React.CSSProperties = {
@@ -320,11 +321,11 @@ const overlayStyle: React.CSSProperties = {
 
 const overlayCardStyle: React.CSSProperties = {
   width: 'min(400px, 90vw)',
-  background: '#fff',
+  background: 'var(--v-surface)',
   borderRadius: 12,
   overflow: 'hidden',
   boxShadow: '0 24px 60px rgba(0,0,0,0.28), 0 4px 16px rgba(0,0,0,0.08)',
-  border: '1px solid #e2e8f0',
+  border: '1px solid var(--v-border)',
 };
 
 const overlayTitleStyle: React.CSSProperties = {
@@ -410,13 +411,13 @@ const FileDropZone: React.FC<FileDropZoneProps> = ({
   isUploaded, isUploading, ext, accentColor, label, uploadedFileName, onClick,
 }) => {
   const [hov, setHov] = React.useState(false);
-  let borderColor = '#e5e7eb';
+  let borderColor = 'var(--v-border)';
   if (isUploaded) borderColor = '#bbf7d0';
-  else if (hov) borderColor = '#94a3b8';
+  else if (hov) borderColor = 'var(--v-text-muted)';
 
-  let backgroundColor = '#fafafa';
-  if (isUploaded) backgroundColor = '#f0fdf4';
-  else if (hov) backgroundColor = '#f9fafb';
+  let backgroundColor = 'var(--v-input-bg)';
+  if (isUploaded) backgroundColor = 'rgba(22, 163, 74, 0.12)';
+  else if (hov) backgroundColor = 'var(--v-surface-hover)';
 
   let icon;
   if (isUploaded) {
@@ -460,10 +461,10 @@ const FileDropZone: React.FC<FileDropZoneProps> = ({
     >
       {/* Icon */}
       {icon}
-      <div style={{ fontSize: 13, fontWeight: 500, color: isUploaded ? '#15803d' : '#374151' }}>{label}</div>
+      <div style={{ fontSize: 13, fontWeight: 500, color: isUploaded ? '#15803d' : 'var(--v-text-secondary)' }}>{label}</div>
       {isUploaded && uploadedFileName && (
         <div title={uploadedFileName} style={{
-          fontSize: 11, color: '#6b7280', maxWidth: '100%',
+          fontSize: 11, color: 'var(--v-text-muted)', maxWidth: '100%',
           overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
           fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
         }}>
@@ -584,8 +585,8 @@ const FileUploadCard: React.FC<FileUploadCardProps> = ({
   const { dropLabel, importLabel } = UPLOAD_STATE_LABELS[uploadState];
 
   const cardStyle: React.CSSProperties = {
-    background: '#ffffff',
-    border: `1px solid ${isUploaded ? '#bbf7d0' : '#e5e7eb'}`,
+    background: 'var(--v-surface-muted)',
+    border: `1px solid ${isUploaded ? '#bbf7d0' : 'var(--v-border)'}`,
     borderRadius: 6,
     marginBottom: 10,
     overflow: 'hidden',
@@ -593,12 +594,12 @@ const FileUploadCard: React.FC<FileUploadCardProps> = ({
   const fileModeStyle: React.CSSProperties = {
     ...modeButtonBaseStyle,
     background: inputMode === 'file' ? '#049484' : 'transparent',
-    color:      inputMode === 'file' ? '#ffffff'  : '#6b7280',
+    color:      inputMode === 'file' ? '#ffffff'  : 'var(--v-text-muted)',
   };
   const urlModeStyle: React.CSSProperties = {
     ...modeButtonBaseStyle,
     background: inputMode === 'url' ? '#049484' : 'transparent',
-    color:      inputMode === 'url' ? '#ffffff'  : '#6b7280',
+    color:      inputMode === 'url' ? '#ffffff'  : 'var(--v-text-muted)',
   };
 
   return (

--- a/src/components/ui/CreateVsumModal.tsx
+++ b/src/components/ui/CreateVsumModal.tsx
@@ -25,10 +25,10 @@ const CancelButton: React.FC<{ onClick: () => void; disabled: boolean }> = ({ on
       onMouseLeave={() => setHov(false)}
       style={{
         padding: '9px 18px',
-        border: '1.5px solid rgba(0,0,0,0.10)',
+        border: '1.5px solid var(--v-border)',
         borderRadius: 9,
-        background: hov ? '#f1f5f9' : '#ffffff',
-        color: '#374151',
+        background: hov ? 'var(--v-surface-hover)' : 'var(--v-surface)',
+        color: 'var(--v-text-secondary)',
         fontSize: 13,
         fontWeight: 600,
         cursor: disabled ? 'not-allowed' : 'pointer',
@@ -120,12 +120,12 @@ export const CreateVsumModal: React.FC<CreateVsumModalProps> = ({ isOpen, onClos
   const inputBase: React.CSSProperties = {
     width: '100%',
     padding: '10px 14px',
-    border: '1.5px solid rgba(0,0,0,0.10)',
+    border: '1.5px solid var(--v-border)',
     borderRadius: 9,
     fontSize: 14,
-    color: '#111827',
+    color: 'var(--v-text)',
     fontFamily: FONT,
-    background: '#ffffff',
+    background: 'var(--v-input-bg)',
     outline: 'none',
     boxSizing: 'border-box',
     transition: 'border-color 0.15s, box-shadow 0.15s',
@@ -169,24 +169,25 @@ export const CreateVsumModal: React.FC<CreateVsumModalProps> = ({ isOpen, onClos
           position: 'relative',
           zIndex: 1,
           width: 'min(480px, 94vw)',
-          background: '#ffffff',
+          background: 'var(--v-surface)',
           borderRadius: 14,
-          boxShadow: '0 8px 40px rgba(0,0,0,0.18), 0 0 0 1px rgba(0,0,0,0.07)',
+          boxShadow: 'var(--v-card-shadow)',
           overflow: 'hidden',
           fontFamily: FONT,
+          color: 'var(--v-text)',
         }}
       >
         {/* Header */}
         <div style={{
           display: 'flex', alignItems: 'center', justifyContent: 'space-between',
           padding: '20px 24px 18px',
-          borderBottom: '1px solid rgba(0,0,0,0.07)',
+          borderBottom: '1px solid var(--v-border)',
         }}>
           <div>
-            <h2 id="create-vsum-title" style={{ margin: 0, fontSize: 16, fontWeight: 700, color: '#0f172a', letterSpacing: '-0.01em' }}>
+            <h2 id="create-vsum-title" style={{ margin: 0, fontSize: 16, fontWeight: 700, color: 'var(--v-text)', letterSpacing: '-0.01em' }}>
               New Project
             </h2>
-            <div style={{ fontSize: 13, color: '#6b7280', marginTop: 2 }}>
+            <div style={{ fontSize: 13, color: 'var(--v-text-muted)', marginTop: 2 }}>
               Create a new V-SUM workspace
             </div>
           </div>
@@ -197,12 +198,12 @@ export const CreateVsumModal: React.FC<CreateVsumModalProps> = ({ isOpen, onClos
             style={{
               width: 30, height: 30, borderRadius: 6,
               background: 'transparent',
-              border: '1.5px solid rgba(0,0,0,0.10)',
+              border: '1.5px solid var(--v-border)',
               display: 'flex', alignItems: 'center', justifyContent: 'center',
-              cursor: 'pointer', fontSize: 13, color: '#64748b',
+              cursor: 'pointer', fontSize: 13, color: 'var(--v-text-muted)',
               transition: 'all 0.12s', fontFamily: FONT,
             }}
-            onMouseEnter={e => { e.currentTarget.style.background = '#f1f5f9'; }}
+            onMouseEnter={e => { e.currentTarget.style.background = 'var(--v-surface-hover)'; }}
             onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
             title="Close"
           >
@@ -216,15 +217,15 @@ export const CreateVsumModal: React.FC<CreateVsumModalProps> = ({ isOpen, onClos
           {error && (
             <div style={{
               padding: '10px 14px', borderRadius: 9,
-              background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.25)',
-              fontSize: 13, color: '#dc2626',
+              background: 'var(--v-danger-bg)', border: '1px solid var(--v-danger-border)',
+              fontSize: 13, color: 'var(--v-danger-text)',
             }}>
               {error}
             </div>
           )}
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-            <label htmlFor="vsum-name-input" style={{ fontSize: 11, fontWeight: 700, color: '#6b7280', letterSpacing: '0.05em', textTransform: 'uppercase' }}>
+            <label htmlFor="vsum-name-input" style={{ fontSize: 11, fontWeight: 700, color: 'var(--v-text-muted)', letterSpacing: '0.05em', textTransform: 'uppercase' }}>
               Name <span style={{ color: '#dc2626' }}>*</span>
             </label>
             <input
@@ -234,7 +235,7 @@ export const CreateVsumModal: React.FC<CreateVsumModalProps> = ({ isOpen, onClos
               onChange={e => setName(e.target.value)}
               onKeyDown={e => { if (e.key === 'Enter' && !loading && name.trim()) handleSubmit(); }}
               onFocus={e => { e.currentTarget.style.borderColor = '#049484'; e.currentTarget.style.boxShadow = '0 0 0 3px rgba(4,148,132,0.12)'; }}
-              onBlur={e => { e.currentTarget.style.borderColor = 'rgba(0,0,0,0.10)'; e.currentTarget.style.boxShadow = 'none'; }}
+              onBlur={e => { e.currentTarget.style.borderColor = 'var(--v-border)'; e.currentTarget.style.boxShadow = 'none'; }}
               style={inputBase}
               disabled={loading}
               autoFocus
@@ -242,8 +243,8 @@ export const CreateVsumModal: React.FC<CreateVsumModalProps> = ({ isOpen, onClos
           </div>
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-            <label htmlFor="vsum-description-input" style={{ fontSize: 11, fontWeight: 700, color: '#6b7280', letterSpacing: '0.05em', textTransform: 'uppercase' }}>
-              Description <span style={{ color: '#9ca3af', fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>(optional)</span>
+            <label htmlFor="vsum-description-input" style={{ fontSize: 11, fontWeight: 700, color: 'var(--v-text-muted)', letterSpacing: '0.05em', textTransform: 'uppercase' }}>
+              Description <span style={{ color: 'var(--v-text-faint)', fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>(optional)</span>
             </label>
             <textarea
               id="vsum-description-input"
@@ -251,7 +252,7 @@ export const CreateVsumModal: React.FC<CreateVsumModalProps> = ({ isOpen, onClos
               value={description}
               onChange={e => setDescription(e.target.value)}
               onFocus={e => { e.currentTarget.style.borderColor = '#049484'; e.currentTarget.style.boxShadow = '0 0 0 3px rgba(4,148,132,0.12)'; }}
-              onBlur={e => { e.currentTarget.style.borderColor = 'rgba(0,0,0,0.10)'; e.currentTarget.style.boxShadow = 'none'; }}
+              onBlur={e => { e.currentTarget.style.borderColor = 'var(--v-border)'; e.currentTarget.style.boxShadow = 'none'; }}
               style={{ ...inputBase, minHeight: 80, resize: 'vertical' }}
               disabled={loading}
             />
@@ -262,7 +263,7 @@ export const CreateVsumModal: React.FC<CreateVsumModalProps> = ({ isOpen, onClos
         <div style={{
           display: 'flex', justifyContent: 'flex-end', gap: 10,
           padding: '14px 24px 20px',
-          borderTop: '1px solid rgba(0,0,0,0.07)',
+          borderTop: '1px solid var(--v-border)',
         }}>
           <CancelButton onClick={handleClose} disabled={loading} />
           <SubmitButton onClick={handleSubmit} disabled={loading || !name.trim()} loading={loading} />

--- a/src/components/ui/EditMetaModelModal.tsx
+++ b/src/components/ui/EditMetaModelModal.tsx
@@ -80,29 +80,30 @@ export const EditMetaModelModal: React.FC<EditMetaModelModalProps> = ({
     >
       <div
         style={{
-          background: '#fff', borderRadius: 10, width: 480, maxWidth: '92vw',
+          background: 'var(--v-surface)', borderRadius: 10, width: 480, maxWidth: '92vw',
           maxHeight: '88vh', overflow: 'hidden', display: 'flex', flexDirection: 'column',
-          boxShadow: '0 24px 64px rgba(0,0,0,0.22), 0 4px 16px rgba(0,0,0,0.10)',
-          border: '1px solid #e2e8f0',
+          boxShadow: 'var(--v-card-shadow)',
+          border: '1px solid var(--v-border)',
           pointerEvents: 'auto',
+          color: 'var(--v-text)',
         }}
       >
         {/* Header */}
         <div style={{
-          padding: '14px 18px', borderBottom: '1px solid #f1f5f9',
+          padding: '14px 18px', borderBottom: '1px solid var(--v-border)',
           display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0,
         }}>
           <div>
-            <div style={{ fontSize: 15, fontWeight: 700, color: '#0f172a', letterSpacing: '-0.01em' }}>Edit Meta-Model</div>
+            <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--v-text)', letterSpacing: '-0.01em' }}>Edit Meta-Model</div>
             {metaModel?.name && (
-              <div style={{ fontSize: 12, color: '#94a3b8', marginTop: 1 }}>{metaModel.name}</div>
+              <div style={{ fontSize: 12, color: 'var(--v-text-muted)', marginTop: 1 }}>{metaModel.name}</div>
             )}
           </div>
           <button
             onClick={onClose}
-            style={{ border: 'none', background: 'transparent', cursor: 'pointer', color: '#94a3b8', fontSize: 16, width: 30, height: 30, borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'all 0.1s' }}
-            onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = '#f1f5f9'; (e.currentTarget as HTMLButtonElement).style.color = '#374151'; }}
-            onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; (e.currentTarget as HTMLButtonElement).style.color = '#94a3b8'; }}
+            style={{ border: 'none', background: 'transparent', cursor: 'pointer', color: 'var(--v-text-muted)', fontSize: 16, width: 30, height: 30, borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'all 0.1s' }}
+            onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--v-chrome-hover)'; (e.currentTarget as HTMLButtonElement).style.color = 'var(--v-text)'; }}
+            onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; (e.currentTarget as HTMLButtonElement).style.color = 'var(--v-text-muted)'; }}
           >✕</button>
         </div>
 
@@ -114,7 +115,7 @@ export const EditMetaModelModal: React.FC<EditMetaModelModalProps> = ({
               onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
               style={inputSt}
               onFocus={e => (e.currentTarget.style.borderColor = '#049484')}
-              onBlur={e => (e.currentTarget.style.borderColor = '#e2e8f0')}
+              onBlur={e => (e.currentTarget.style.borderColor = 'var(--v-border)')}
               required
             />
           </Field>
@@ -126,7 +127,7 @@ export const EditMetaModelModal: React.FC<EditMetaModelModalProps> = ({
               rows={3}
               style={{ ...inputSt, resize: 'vertical', minHeight: 80 }}
               onFocus={e => (e.currentTarget.style.borderColor = '#049484')}
-              onBlur={e => (e.currentTarget.style.borderColor = '#e2e8f0')}
+              onBlur={e => (e.currentTarget.style.borderColor = 'var(--v-border)')}
               required
             />
           </Field>
@@ -137,7 +138,7 @@ export const EditMetaModelModal: React.FC<EditMetaModelModalProps> = ({
               onChange={e => setForm(f => ({ ...f, domain: e.target.value }))}
               style={inputSt}
               onFocus={e => (e.currentTarget.style.borderColor = '#049484')}
-              onBlur={e => (e.currentTarget.style.borderColor = '#e2e8f0')}
+              onBlur={e => (e.currentTarget.style.borderColor = 'var(--v-border)')}
               required
             />
           </Field>
@@ -151,18 +152,18 @@ export const EditMetaModelModal: React.FC<EditMetaModelModalProps> = ({
         </form>
 
         {/* Footer */}
-        <div style={{ padding: '16px 20px', borderTop: '1px solid #f1f5f9', display: 'flex', gap: 10, flexShrink: 0 }}>
+        <div style={{ padding: '16px 20px', borderTop: '1px solid var(--v-border)', display: 'flex', gap: 10, flexShrink: 0 }}>
           <button
             type="button" onClick={onClose}
-            style={{ flex: 1, padding: '9px 0', border: '1px solid #e2e8f0', borderRadius: 8, background: '#fff', color: '#374151', fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: FONT, transition: 'all 0.15s' }}
-            onMouseEnter={e => (e.currentTarget.style.background = '#f8fafc')}
-            onMouseLeave={e => (e.currentTarget.style.background = '#fff')}
+            style={{ flex: 1, padding: '9px 0', border: '1px solid var(--v-border)', borderRadius: 8, background: 'var(--v-surface)', color: 'var(--v-text-secondary)', fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: FONT, transition: 'all 0.15s' }}
+            onMouseEnter={e => (e.currentTarget.style.background = 'var(--v-surface-hover)')}
+            onMouseLeave={e => (e.currentTarget.style.background = 'var(--v-surface)')}
           >Cancel</button>
           <button
             type="submit"
             onClick={handleSubmit as any}
             disabled={disabled}
-            style={{ flex: 1, padding: '9px 0', border: 'none', borderRadius: 8, background: disabled ? '#94a3b8' : DARK, color: '#fff', fontSize: 13, fontWeight: 600, cursor: disabled ? 'not-allowed' : 'pointer', fontFamily: FONT, transition: 'background 0.15s' }}
+            style={{ flex: 1, padding: '9px 0', border: 'none', borderRadius: 8, background: disabled ? 'var(--v-disabled-bg)' : DARK, color: '#fff', fontSize: 13, fontWeight: 600, cursor: disabled ? 'not-allowed' : 'pointer', fontFamily: FONT, transition: 'background 0.15s' }}
             onMouseEnter={e => { if (!disabled) (e.currentTarget.style.background = '#1e293b'); }}
             onMouseLeave={e => { if (!disabled) (e.currentTarget.style.background = DARK); }}
           >{isLoading ? 'Saving…' : 'Save changes'}</button>
@@ -178,15 +179,15 @@ export const EditMetaModelModal: React.FC<EditMetaModelModalProps> = ({
 
 const inputSt: React.CSSProperties = {
   width: '100%', padding: '9px 12px',
-  border: '1.5px solid #e2e8f0', borderRadius: 8,
-  fontSize: 13, color: '#0f172a', background: '#f8fafc',
+  border: '1.5px solid var(--v-border)', borderRadius: 8,
+  fontSize: 13, color: 'var(--v-text)', background: 'var(--v-input-bg)',
   boxSizing: 'border-box', outline: 'none',
   fontFamily: FONT, transition: 'border-color 0.15s',
 };
 
 const Field: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
   <div style={{ marginBottom: 16 }}>
-    <label style={{ display: 'block', fontSize: 12, fontWeight: 600, color: '#374151', marginBottom: 5, letterSpacing: '0.01em', fontFamily: FONT }}>{label}</label>
+    <label style={{ display: 'block', fontSize: 12, fontWeight: 600, color: 'var(--v-text-secondary)', marginBottom: 5, letterSpacing: '0.01em', fontFamily: FONT }}>{label}</label>
     {children}
   </div>
 );
@@ -194,8 +195,8 @@ const Field: React.FC<{ label: string; children: React.ReactNode }> = ({ label, 
 const Msg: React.FC<{ type: 'error' | 'success'; children: React.ReactNode }> = ({ type, children }) => (
   <div style={{
     padding: '9px 12px', borderRadius: 8, fontSize: 12, fontWeight: 500, marginBottom: 12,
-    background: type === 'error' ? '#fef2f2' : '#f0fdf4',
-    border: `1px solid ${type === 'error' ? '#fecaca' : '#86efac'}`,
-    color: type === 'error' ? '#dc2626' : '#15803d',
+    background: type === 'error' ? 'var(--v-danger-bg)' : 'var(--v-success-bg)',
+    border: `1px solid ${type === 'error' ? 'var(--v-danger-border)' : 'var(--v-success-border)'}`,
+    color: type === 'error' ? 'var(--v-danger-text)' : 'var(--v-success-text)',
   }}>{children}</div>
 );

--- a/src/components/ui/KeywordTagsInput.tsx
+++ b/src/components/ui/KeywordTagsInput.tsx
@@ -11,10 +11,10 @@ interface KeywordTagsInputProps {
 const containerStyle: React.CSSProperties = {
   width: '100%',
   minHeight: '48px',
-  border: '2px solid #d1ecf1',
+  border: '2px solid var(--v-border)',
   borderRadius: '8px',
   padding: '8px',
-  background: '#f8f9fa',
+  background: 'var(--v-input-bg)',
   display: 'flex',
   flexWrap: 'wrap',
   alignItems: 'center',
@@ -28,7 +28,7 @@ const containerFocusStyle: React.CSSProperties = {
   borderColor: '#049484',
   outline: 'none',
   boxShadow: '0 0 0 3px rgba(4, 148, 132, 0.1)',
-  background: '#ffffff',
+  background: 'var(--v-surface)',
 };
 
 const tagStyle: React.CSSProperties = {
@@ -64,7 +64,7 @@ const inputStyle: React.CSSProperties = {
   flex: '1',
   minWidth: '120px',
   padding: '4px',
-  color: '#333',
+  color: 'var(--v-text)',
 };
 
 export const KeywordTagsInput: React.FC<KeywordTagsInputProps> = ({

--- a/src/components/ui/LandingView.tsx
+++ b/src/components/ui/LandingView.tsx
@@ -36,10 +36,10 @@ const FeaturePill: React.FC<{ icon: React.ReactNode; label: string }> = ({ icon,
   <div style={{
     display: 'flex', alignItems: 'center', gap: 7,
     padding: '7px 14px',
-    background: '#ffffff',
-    border: '1px solid rgba(0,0,0,0.10)',
+    background: 'var(--v-overlay)',
+    border: '1px solid var(--v-card-border)',
     borderRadius: 20,
-    fontSize: 13, fontWeight: 500, color: '#1f2937',
+    fontSize: 13, fontWeight: 500, color: 'var(--v-text)',
   }}>
     <span style={{ color: '#049484', display: 'flex' }}>{icon}</span>
     {label}
@@ -67,8 +67,8 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ title, subtitle, items, cta, 
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{
-        background: 'rgba(255,255,255,0.88)',
-        border: `1.5px solid ${hovered ? accent : 'rgba(0,0,0,0.07)'}`,
+        background: 'var(--v-overlay)',
+        border: `1.5px solid ${hovered ? accent : 'var(--v-card-border)'}`,
         borderRadius: 14,
         padding: '22px 24px 20px',
         display: 'flex',
@@ -84,8 +84,8 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ title, subtitle, items, cta, 
     >
       {/* Header */}
       <div>
-        <div style={{ fontSize: 15, fontWeight: 700, color: '#111827' }}>{title}</div>
-        <div style={{ fontSize: 12, color: '#9ca3af', marginTop: 2 }}>{subtitle}</div>
+        <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--v-text)' }}>{title}</div>
+        <div style={{ fontSize: 12, color: 'var(--v-text-faint)', marginTop: 2 }}>{subtitle}</div>
       </div>
 
       {/* Preview items */}
@@ -95,8 +95,8 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ title, subtitle, items, cta, 
             key={item.name}
             style={{
               flex: '1 1 140px',
-              background: '#f8f9fb',
-              border: '1px solid rgba(0,0,0,0.06)',
+              background: 'var(--v-surface-muted)',
+              border: '1px solid var(--v-card-border)',
               borderRadius: 10,
               padding: '12px 14px',
               display: 'flex',
@@ -109,14 +109,14 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ title, subtitle, items, cta, 
               {[60, 90, 50, 70].map((w) => (
                 <div key={w} style={{
                   height: 5, borderRadius: 3,
-                  background: w === 60 ? `${accent}55` : 'rgba(0,0,0,0.08)',
+                  background: w === 60 ? `${accent}55` : 'var(--v-border)',
                   width: `${w}%`,
                 }} />
               ))}
             </div>
             <div>
-              <div style={{ fontSize: 12, fontWeight: 600, color: '#374151' }}>{item.name}</div>
-              <div style={{ fontSize: 11, color: '#9ca3af', marginTop: 1 }}>{item.meta}</div>
+              <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--v-text-secondary)' }}>{item.name}</div>
+              <div style={{ fontSize: 11, color: 'var(--v-text-faint)', marginTop: 1 }}>{item.meta}</div>
             </div>
             <div style={{
               display: 'flex', alignItems: 'center', gap: 4,
@@ -194,25 +194,25 @@ export const LandingView: React.FC<LandingViewProps> = ({ userName, onNavigate }
             margin: 0,
             fontSize: 'clamp(24px, 2.6vw, 36px)',
             fontWeight: 800,
-            color: '#0f172a',
+            color: 'var(--v-text)',
             lineHeight: 1.18,
             letterSpacing: '-0.02em',
           }}>
             {firstName ? `Welcome back, ${firstName}:` : 'Welcome to Vitruvius:'}{' '}
-            <span style={{ color: '#0f172a' }}>View-based Software Development</span>
+            <span style={{ color: 'var(--v-text)' }}>View-based Software Development</span>
           </h1>
 
           {/* Description */}
-          <p style={{ margin: 0, fontSize: 14, color: '#4b5563', lineHeight: 1.75 }}>
+          <p style={{ margin: 0, fontSize: 14, color: 'var(--v-text-secondary)', lineHeight: 1.75 }}>
             Vitruvius is a framework for{' '}
-            <strong style={{ color: '#111827', fontWeight: 600 }}>view-based software development</strong>.
+            <strong style={{ color: 'var(--v-text)', fontWeight: 600 }}>view-based software development</strong>.
             It maintains a Virtual Single Underlying Model (V-SUM) — a set of heterogeneous models kept automatically
             consistent through defined consistency rules. Models are never edited directly; all changes flow through
             typed <em>views</em> that project the relevant parts of the V-SUM.
           </p>
 
-          <p style={{ margin: 0, fontSize: 14, color: '#4b5563', lineHeight: 1.75 }}>
-            The name stands for <strong style={{ color: '#111827' }}>VI</strong>ew-cen<strong style={{ color: '#111827' }}>TR</strong>ic engineering Us<strong style={{ color: '#111827' }}>I</strong>ng a <strong style={{ color: '#111827' }}>V</strong>irtual <strong style={{ color: '#111827' }}>U</strong>nderlying <strong style={{ color: '#111827' }}>S</strong>ingle model. Developed at the <strong style={{ color: '#111827' }}>Dependability of Software-intensive Systems (DSiS)</strong> at the <strong style={{ color: '#111827' }}>Karlsruhe Institute of Technology (KIT)</strong>. V-SUM extends the classical Single Underlying Model concept by tolerating redundancy across models and enforcing consistency through explicit propagation rules rather than a single shared representation.
+          <p style={{ margin: 0, fontSize: 14, color: 'var(--v-text-secondary)', lineHeight: 1.75 }}>
+            The name stands for <strong style={{ color: 'var(--v-text)' }}>VI</strong>ew-cen<strong style={{ color: 'var(--v-text)' }}>TR</strong>ic engineering Us<strong style={{ color: 'var(--v-text)' }}>I</strong>ng a <strong style={{ color: 'var(--v-text)' }}>V</strong>irtual <strong style={{ color: 'var(--v-text)' }}>U</strong>nderlying <strong style={{ color: 'var(--v-text)' }}>S</strong>ingle model. Developed at the <strong style={{ color: 'var(--v-text)' }}>Dependability of Software-intensive Systems (DSiS)</strong> at the <strong style={{ color: 'var(--v-text)' }}>Karlsruhe Institute of Technology (KIT)</strong>. V-SUM extends the classical Single Underlying Model concept by tolerating redundancy across models and enforcing consistency through explicit propagation rules rather than a single shared representation.
           </p>
 
           {/* Feature pills */}
@@ -224,8 +224,8 @@ export const LandingView: React.FC<LandingViewProps> = ({ userName, onNavigate }
 
         {/* ── RIGHT / TOP: vitruvius1 image ────────────────────────────── */}
         <div style={{
-          background: 'rgba(255,255,255,0.88)',
-          border: '1.5px solid rgba(0,0,0,0.07)',
+          background: 'var(--v-overlay)',
+          border: '1.5px solid var(--v-card-border)',
           borderRadius: 14,
           overflow: 'hidden',
           boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
@@ -249,7 +249,7 @@ export const LandingView: React.FC<LandingViewProps> = ({ userName, onNavigate }
         {/* ── LEFT / BOTTOM: GET STARTED label + Projects card ─────────── */}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
           <div style={{
-            fontSize: 11, fontWeight: 700, color: '#9ca3af',
+            fontSize: 11, fontWeight: 700, color: 'var(--v-text-faint)',
             letterSpacing: '0.08em', textTransform: 'uppercase',
           }}>
             Get Started
@@ -293,22 +293,22 @@ export const LandingView: React.FC<LandingViewProps> = ({ userName, onNavigate }
       {/* ── About strip ───────────────────────────────────────────────────── */}
       <div style={{
         marginTop: 28,
-        background: '#ffffff',
-        border: '1px solid rgba(0,0,0,0.08)',
+        background: 'var(--v-surface)',
+        border: '1px solid var(--v-card-border)',
         borderRadius: 14,
         padding: '22px 28px',
         maxWidth: 1200,
         boxShadow: '0 1px 4px rgba(0,0,0,0.05)',
       }}>
         <div style={{
-          fontSize: 11, fontWeight: 700, color: '#6b7280',
+          fontSize: 11, fontWeight: 700, color: 'var(--v-text-muted)',
           letterSpacing: '0.08em', marginBottom: 10, textTransform: 'uppercase',
         }}>
           About the Framework
         </div>
-        <p style={{ margin: 0, fontSize: 14, color: '#1e293b', lineHeight: 1.8 }}>
+        <p style={{ margin: 0, fontSize: 14, color: 'var(--v-text-secondary)', lineHeight: 1.8 }}>
           Vitruvius is developed at the{' '}
-          <strong style={{ color: '#0f172a' }}>Dependability of Software-intensive Systems (DSiS)</strong> group
+          <strong style={{ color: 'var(--v-text)' }}>Dependability of Software-intensive Systems (DSiS)</strong> group
           at KIT. It is built on the idea of a Virtual Single Underlying Model (V-SUM) which behaves like a
           consistent SUM without being free of redundancies — instead, explicit consistency rules propagate changes
           between heterogeneous models automatically whenever a view is modified.

--- a/src/components/ui/LinkMetaModelsPanel.tsx
+++ b/src/components/ui/LinkMetaModelsPanel.tsx
@@ -17,7 +17,7 @@ interface Props {
 const sectionLabel: React.CSSProperties = {
   fontSize: 13,
   fontWeight: 700,
-  color: '#2c3e50',
+  color: 'var(--v-text)',
   marginTop: 16,
   marginBottom: 8,
   fontFamily: 'Georgia, serif',
@@ -30,17 +30,18 @@ const relationRow: React.CSSProperties = {
   gap: 8,
   padding: '8px 12px',
   borderRadius: 8,
-  border: '1px solid #e9ecef',
-  background: '#f8f9fa',
+  border: '1px solid var(--v-border)',
+  background: 'var(--v-surface-muted)',
   fontSize: 13,
   marginBottom: 6,
+  color: 'var(--v-text)',
 };
 
 const addButton: React.CSSProperties = {
   padding: '8px 16px',
   borderRadius: 8,
   border: '1px dashed #049484',
-  background: '#f0faf8',
+  background: 'var(--v-brand-soft)',
   color: '#049484',
   fontWeight: 600,
   fontSize: 13,
@@ -53,17 +54,18 @@ const formBox: React.CSSProperties = {
   padding: 16,
   borderRadius: 10,
   border: '2px dashed #049484',
-  background: '#f8fcff',
+  background: 'var(--v-brand-soft)',
 };
 
 const selectStyle: React.CSSProperties = {
   width: '100%',
   padding: '10px 12px',
-  border: '2px solid #e9ecef',
+  border: '2px solid var(--v-border)',
   borderRadius: 8,
   fontSize: 14,
   fontFamily: 'Georgia, serif',
-  background: '#fff',
+  background: 'var(--v-input-bg)',
+  color: 'var(--v-text)',
   marginBottom: 12,
 };
 
@@ -71,8 +73,8 @@ const fileButton: React.CSSProperties = {
   padding: '10px 14px',
   border: '2px solid #049484',
   borderRadius: 8,
-  background: '#fff',
-  color: '#2c3e50',
+  background: 'var(--v-surface)',
+  color: 'var(--v-text)',
   fontSize: 13,
   fontWeight: 600,
   cursor: 'pointer',
@@ -194,11 +196,11 @@ export const LinkMetaModelsPanel: React.FC<Props> = ({
           <div style={sectionLabel}>Meta Model Relations</div>
           {existingRelations.map((r) => (
             <div key={r.id} style={relationRow}>
-              <span style={{ fontWeight: 700, color: '#2c3e50' }}>{nameFor(r.sourceId)}</span>
+              <span style={{ fontWeight: 700, color: 'var(--v-text)' }}>{nameFor(r.sourceId)}</span>
               <span style={{ color: '#049484' }}>→</span>
-              <span style={{ fontWeight: 700, color: '#2c3e50' }}>{nameFor(r.targetId)}</span>
+              <span style={{ fontWeight: 700, color: 'var(--v-text)' }}>{nameFor(r.targetId)}</span>
               {(r.reactionFileId ?? r.reactionFileStorageId) && (
-                <span style={{ marginLeft: 'auto', color: '#6c757d', fontStyle: 'italic' }}>
+                <span style={{ marginLeft: 'auto', color: 'var(--v-text-muted)', fontStyle: 'italic' }}>
                   reactions linked
                 </span>
               )}
@@ -216,12 +218,12 @@ export const LinkMetaModelsPanel: React.FC<Props> = ({
       {showForm && (
         <div style={formBox}>
           {optionsLoading && (
-            <div style={{ fontSize: 13, color: '#6c757d', fontStyle: 'italic', marginBottom: 12 }}>
+            <div style={{ fontSize: 13, color: 'var(--v-text-muted)', fontStyle: 'italic', marginBottom: 12 }}>
               Loading meta models…
             </div>
           )}
           {optionsError && (
-            <div style={{ fontSize: 13, color: '#721c24', marginBottom: 12 }}>{optionsError}</div>
+            <div style={{ fontSize: 13, color: 'var(--v-danger-text)', marginBottom: 12 }}>{optionsError}</div>
           )}
 
           <div style={sectionLabel}>Source Meta Model</div>
@@ -265,7 +267,7 @@ export const LinkMetaModelsPanel: React.FC<Props> = ({
           </button>
 
           {linkError && (
-            <div style={{ marginTop: 12, fontSize: 13, color: '#721c24' }}>{linkError}</div>
+            <div style={{ marginTop: 12, fontSize: 13, color: 'var(--v-danger-text)' }}>{linkError}</div>
           )}
 
           <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
@@ -294,9 +296,9 @@ export const LinkMetaModelsPanel: React.FC<Props> = ({
               style={{
                 padding: '10px 20px',
                 borderRadius: 8,
-                border: '1px solid #dee2e6',
-                background: '#fff',
-                color: '#495057',
+                border: '1px solid var(--v-border)',
+                background: 'var(--v-surface)',
+                color: 'var(--v-text-secondary)',
                 fontWeight: 600,
                 fontSize: 14,
                 cursor: 'pointer',

--- a/src/components/ui/MetaModelFileDownloads.tsx
+++ b/src/components/ui/MetaModelFileDownloads.tsx
@@ -38,9 +38,9 @@ const DownloadButton: React.FC<DownloadButtonProps> = ({ kind, downloading, onDo
     onClick={onDownload}
     style={{
       ...btnBase,
-      border: '1px solid #e2e8f0',
-      background: downloading === kind ? '#f8fafc' : '#fff',
-      color: '#374151',
+      border: '1px solid var(--v-border)',
+      background: downloading === kind ? 'var(--v-surface-muted)' : 'var(--v-surface)',
+      color: 'var(--v-text-secondary)',
       cursor: downloading ? 'wait' : 'pointer',
     }}
   >
@@ -77,7 +77,7 @@ export const MetaModelFileDownloads: React.FC<MetaModelFileDownloadsProps> = ({
   const label = labelStyle ?? {
     fontSize: 11,
     fontWeight: 700,
-    color: '#374151',
+    color: 'var(--v-text-secondary)',
     marginBottom: 8,
     letterSpacing: '0.01em',
   };

--- a/src/components/ui/ModelLibraryTable.tsx
+++ b/src/components/ui/ModelLibraryTable.tsx
@@ -73,8 +73,8 @@ const DARK = '#0B1720';
 
 const detailInputSt: React.CSSProperties = {
   width: '100%', padding: '9px 12px',
-  border: '1.5px solid #e2e8f0', borderRadius: 8,
-  fontSize: 13, color: '#0f172a', background: '#f8fafc',
+  border: '1.5px solid var(--v-border)', borderRadius: 8,
+  fontSize: 13, color: 'var(--v-text)', background: 'var(--v-input-bg)',
   boxSizing: 'border-box', outline: 'none',
   fontFamily: FONT, transition: 'border-color 0.15s',
 };
@@ -108,16 +108,16 @@ function getDTheme(domain?: string): DomainTheme {
 }
 
 const DFieldLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <div style={{ fontSize: 11, fontWeight: 700, color: '#374151', marginBottom: 5, letterSpacing: '0.01em', fontFamily: FONT }}>{children}</div>
+  <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--v-text-secondary)', marginBottom: 5, letterSpacing: '0.01em', fontFamily: FONT }}>{children}</div>
 );
 
-const detailFieldLabelSt: React.CSSProperties = { display: 'block', fontSize: 11, fontWeight: 700, color: '#374151', marginBottom: 5, fontFamily: FONT };
+const detailFieldLabelSt: React.CSSProperties = { display: 'block', fontSize: 11, fontWeight: 700, color: 'var(--v-text-secondary)', marginBottom: 5, fontFamily: FONT };
 
 const DPreviewBtn: React.FC<{ title: string; onClick: () => void; children: React.ReactNode }> = ({ title, onClick, children }) => {
   const [hov, setHov] = React.useState(false);
   return (
     <button type="button" title={title} onClick={onClick} onMouseEnter={() => setHov(true)} onMouseLeave={() => setHov(false)}
-      style={{ width: 24, height: 24, border: '1px solid #e2e8f0', borderRadius: 6, background: hov ? '#f1f5f9' : '#fff', color: hov ? '#0f172a' : '#64748b', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'all 0.12s' }}>
+      style={{ width: 24, height: 24, border: '1px solid var(--v-border)', borderRadius: 6, background: hov ? 'var(--v-chrome-hover)' : 'var(--v-surface)', color: hov ? 'var(--v-text)' : 'var(--v-text-muted)', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'all 0.12s' }}>
       {children}
     </button>
   );
@@ -191,10 +191,10 @@ export const ModelDetailModal: React.FC<ModelDetailModalProps> = ({
         aria-label={`Model Preview: ${displayModel.name}`}
         onClose={onClose}
         onCancel={onClose}
-        style={{ position: 'relative', background: '#fff', borderRadius: 10, width: '80vw', height: '80vh', overflow: 'hidden', display: 'flex', flexDirection: 'column', boxShadow: '0 24px 64px rgba(0,0,0,0.22), 0 4px 16px rgba(0,0,0,0.10)', border: '1px solid #e2e8f0', fontFamily: FONT, pointerEvents: 'auto', margin: 0, padding: 0 }}
+        style={{ position: 'relative', background: 'var(--v-surface)', borderRadius: 10, width: '80vw', height: '80vh', overflow: 'hidden', display: 'flex', flexDirection: 'column', boxShadow: 'var(--v-card-shadow)', border: '1px solid var(--v-border)', fontFamily: FONT, pointerEvents: 'auto', margin: 0, padding: 0, color: 'var(--v-text)' }}
       >
         {/* ── Header ── */}
-        <div style={{ padding: '14px 20px', background: '#ffffff', borderBottom: '1px solid #f1f5f9', flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ padding: '14px 20px', background: 'var(--v-surface)', borderBottom: '1px solid var(--v-border)', flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0, overflow: 'hidden' }}>
             {/* BoxIcon — same as model cards */}
             <svg width="28" height="28" viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
@@ -203,8 +203,8 @@ export const ModelDetailModal: React.FC<ModelDetailModalProps> = ({
               <path d="M5 11L27 11" stroke="#049484" strokeWidth="1.3" strokeLinecap="round" />
               <path d="M16 5L5 11L16 17L27 11L16 5Z" stroke="#049484" strokeWidth="1.3" fill="#04948418" strokeLinejoin="round" />
             </svg>
-            <div style={{ fontSize: 16, fontWeight: 700, color: '#0f172a', letterSpacing: '-0.01em', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-              Model Preview: <span style={{ color: '#374151', fontWeight: 600 }}>{displayModel.name}</span>
+            <div style={{ fontSize: 16, fontWeight: 700, color: 'var(--v-text)', letterSpacing: '-0.01em', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+              Model Preview: <span style={{ color: 'var(--v-text-secondary)', fontWeight: 600 }}>{displayModel.name}</span>
             </div>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
@@ -215,9 +215,9 @@ export const ModelDetailModal: React.FC<ModelDetailModalProps> = ({
                   setEditing(true);
                 }}
                 title="Edit meta-model"
-                style={{ height: 30, padding: '0 12px', border: '1px solid #e2e8f0', borderRadius: 7, background: '#f8fafc', color: '#374151', fontSize: 12, fontWeight: 600, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5, transition: 'all 0.12s', fontFamily: FONT }}
+                style={{ height: 30, padding: '0 12px', border: '1px solid var(--v-border)', borderRadius: 7, background: 'var(--v-surface-muted)', color: 'var(--v-text-secondary)', fontSize: 12, fontWeight: 600, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5, transition: 'all 0.12s', fontFamily: FONT }}
                 onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = DARK; (e.currentTarget as HTMLButtonElement).style.color = '#fff'; (e.currentTarget as HTMLButtonElement).style.borderColor = DARK; }}
-                onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = '#f8fafc'; (e.currentTarget as HTMLButtonElement).style.color = '#374151'; (e.currentTarget as HTMLButtonElement).style.borderColor = '#e2e8f0'; }}
+                onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--v-surface-muted)'; (e.currentTarget as HTMLButtonElement).style.color = 'var(--v-text-secondary)'; (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--v-border)'; }}
               >
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
@@ -228,9 +228,9 @@ export const ModelDetailModal: React.FC<ModelDetailModalProps> = ({
             )}
             <button type="button"
               onClick={onClose}
-              style={{ border: 'none', background: 'transparent', cursor: 'pointer', color: '#94a3b8', fontSize: 16, width: 30, height: 30, borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'all 0.1s' }}
-              onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = '#f1f5f9'; (e.currentTarget as HTMLButtonElement).style.color = '#374151'; }}
-              onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; (e.currentTarget as HTMLButtonElement).style.color = '#94a3b8'; }}
+              style={{ border: 'none', background: 'transparent', cursor: 'pointer', color: 'var(--v-text-muted)', fontSize: 16, width: 30, height: 30, borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'all 0.1s' }}
+              onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--v-chrome-hover)'; (e.currentTarget as HTMLButtonElement).style.color = 'var(--v-text)'; }}
+              onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; (e.currentTarget as HTMLButtonElement).style.color = 'var(--v-text-muted)'; }}
             >✕</button>
           </div>
         </div>
@@ -239,12 +239,12 @@ export const ModelDetailModal: React.FC<ModelDetailModalProps> = ({
         <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
 
           {/* Left — fields */}
-          <div style={{ width: 280, flexShrink: 0, borderRight: '1px solid #f1f5f9', overflowY: 'auto', padding: '20px 22px', display: 'flex', flexDirection: 'column', gap: 20 }}>
+          <div style={{ width: 280, flexShrink: 0, borderRight: '1px solid var(--v-border)', overflowY: 'auto', padding: '20px 22px', display: 'flex', flexDirection: 'column', gap: 20, background: 'var(--v-surface)' }}>
             {editing ? (
               <form onSubmit={handleSave} style={{ display: 'flex', flexDirection: 'column', gap: 14, flex: 1 }}>
                 <div>
                   <label htmlFor="model-detail-name" style={detailFieldLabelSt}>Name</label>
-                  <input id="model-detail-name" value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} style={detailInputSt} onFocus={e => (e.currentTarget.style.borderColor = '#049484')} onBlur={e => (e.currentTarget.style.borderColor = '#e2e8f0')} />
+                  <input id="model-detail-name" value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} style={detailInputSt} onFocus={e => (e.currentTarget.style.borderColor = '#049484')} onBlur={e => (e.currentTarget.style.borderColor = 'var(--v-border)')} />
                 </div>
                 <div>
                   <label htmlFor="model-detail-keywords" style={detailFieldLabelSt}>Keywords</label>
@@ -252,18 +252,18 @@ export const ModelDetailModal: React.FC<ModelDetailModalProps> = ({
                 </div>
                 <div>
                   <label htmlFor="model-detail-description" style={detailFieldLabelSt}>Description</label>
-                  <textarea id="model-detail-description" value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))} rows={3} style={{ ...detailInputSt, resize: 'vertical', minHeight: 72 }} onFocus={e => (e.currentTarget.style.borderColor = '#049484')} onBlur={e => (e.currentTarget.style.borderColor = '#e2e8f0')} />
+                  <textarea id="model-detail-description" value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))} rows={3} style={{ ...detailInputSt, resize: 'vertical', minHeight: 72 }} onFocus={e => (e.currentTarget.style.borderColor = '#049484')} onBlur={e => (e.currentTarget.style.borderColor = 'var(--v-border)')} />
                 </div>
                 <div>
                   <label htmlFor="model-detail-domain" style={detailFieldLabelSt}>Domain</label>
-                  <input id="model-detail-domain" value={form.domain} onChange={e => setForm(f => ({ ...f, domain: e.target.value }))} style={detailInputSt} onFocus={e => (e.currentTarget.style.borderColor = '#049484')} onBlur={e => (e.currentTarget.style.borderColor = '#e2e8f0')} />
+                  <input id="model-detail-domain" value={form.domain} onChange={e => setForm(f => ({ ...f, domain: e.target.value }))} style={detailInputSt} onFocus={e => (e.currentTarget.style.borderColor = '#049484')} onBlur={e => (e.currentTarget.style.borderColor = 'var(--v-border)')} />
                 </div>
-                {error   && <div style={{ padding: '8px 12px', background: '#fef2f2', border: '1px solid #fecaca', borderRadius: 8, fontSize: 12, color: '#dc2626' }}>{error}</div>}
-                {success && <div style={{ padding: '8px 12px', background: '#f0fdf4', border: '1px solid #86efac', borderRadius: 8, fontSize: 12, color: '#15803d' }}>{success}</div>}
+                {error   && <div style={{ padding: '8px 12px', background: 'var(--v-danger-bg)', border: '1px solid var(--v-danger-border)', borderRadius: 8, fontSize: 12, color: 'var(--v-danger-text)' }}>{error}</div>}
+                {success && <div style={{ padding: '8px 12px', background: 'var(--v-success-bg)', border: '1px solid var(--v-success-border)', borderRadius: 8, fontSize: 12, color: 'var(--v-success-text)' }}>{success}</div>}
                 <div style={{ marginTop: 'auto', paddingTop: 8, display: 'flex', gap: 8 }}>
                   <button type="button" onClick={() => setEditing(false)}
-                    style={{ flex: 1, padding: '8px 0', border: '1px solid #e2e8f0', borderRadius: 8, background: '#fff', color: '#374151', fontSize: 12, fontWeight: 600, cursor: 'pointer', fontFamily: FONT }}
-                    onMouseEnter={e => (e.currentTarget.style.background = '#f8fafc')} onMouseLeave={e => (e.currentTarget.style.background = '#fff')}>
+                    style={{ flex: 1, padding: '8px 0', border: '1px solid var(--v-border)', borderRadius: 8, background: 'var(--v-surface)', color: 'var(--v-text-secondary)', fontSize: 12, fontWeight: 600, cursor: 'pointer', fontFamily: FONT }}
+                    onMouseEnter={e => (e.currentTarget.style.background = 'var(--v-surface-hover)')} onMouseLeave={e => (e.currentTarget.style.background = 'var(--v-surface)')}>
                     Cancel
                   </button>
                   <button type="submit" disabled={!canSave}
@@ -278,7 +278,7 @@ export const ModelDetailModal: React.FC<ModelDetailModalProps> = ({
               <>
                 <div>
                   <DFieldLabel>Name</DFieldLabel>
-                  <div style={{ fontSize: 14, fontWeight: 600, color: '#0f172a', fontFamily: FONT, lineHeight: 1.4 }}>{displayModel.name}</div>
+                  <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--v-text)', fontFamily: FONT, lineHeight: 1.4 }}>{displayModel.name}</div>
                 </div>
                 {displayModel.keyword?.length > 0 && (
                   <div>
@@ -292,27 +292,27 @@ export const ModelDetailModal: React.FC<ModelDetailModalProps> = ({
                 )}
                 <div style={{ flex: 1 }}>
                   <DFieldLabel>Description</DFieldLabel>
-                  <div style={{ fontSize: 13, color: '#374151', fontFamily: FONT, lineHeight: 1.7 }}>
-                    {displayModel.description || <span style={{ color: '#cbd5e1' }}>—</span>}
+                  <div style={{ fontSize: 13, color: 'var(--v-text-secondary)', fontFamily: FONT, lineHeight: 1.7 }}>
+                    {displayModel.description || <span style={{ color: 'var(--v-text-faint)' }}>—</span>}
                   </div>
                 </div>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginTop: 'auto', paddingTop: 8, borderTop: '1px solid #f1f5f9' }}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginTop: 'auto', paddingTop: 8, borderTop: '1px solid var(--v-border)' }}>
                   <MetaModelFileDownloads
                     modelName={displayModel.name}
                     ecoreFileId={displayModel.ecoreFileId}
                     genModelFileId={displayModel.genModelFileId}
-                    labelStyle={{ fontSize: 11, fontWeight: 700, color: '#374151', marginBottom: 5, letterSpacing: '0.01em', fontFamily: FONT }}
+                    labelStyle={{ fontSize: 11, fontWeight: 700, color: 'var(--v-text-secondary)', marginBottom: 5, letterSpacing: '0.01em', fontFamily: FONT }}
                   />
                   {model.createdAt && (
                     <div>
                       <DFieldLabel>Created</DFieldLabel>
-                      <div style={{ fontSize: 13, color: '#64748b', fontFamily: FONT }}>{formatDate(model.createdAt)}</div>
+                      <div style={{ fontSize: 13, color: 'var(--v-text-muted)', fontFamily: FONT }}>{formatDate(model.createdAt)}</div>
                     </div>
                   )}
                   {model.updatedAt && (
                     <div>
                       <DFieldLabel>Updated</DFieldLabel>
-                      <div style={{ fontSize: 13, color: '#64748b', fontFamily: FONT }}>{formatDate(model.updatedAt)}</div>
+                      <div style={{ fontSize: 13, color: 'var(--v-text-muted)', fontFamily: FONT }}>{formatDate(model.updatedAt)}</div>
                     </div>
                   )}
                 </div>
@@ -321,10 +321,10 @@ export const ModelDetailModal: React.FC<ModelDetailModalProps> = ({
           </div>
 
           {/* Right — UML preview */}
-          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', background: '#ffffff' }}>
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', background: 'var(--v-workspace-bg)' }}>
             {/* Label + zoom controls */}
             <div style={{ padding: '14px 18px 10px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
-              <span style={{ fontSize: 13, fontWeight: 600, color: '#374151', fontFamily: FONT }}>UML</span>
+              <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--v-text-secondary)', fontFamily: FONT }}>UML</span>
               {ecoreContent && (
                 <div style={{ display: 'flex', gap: 4 }}>
                   <DPreviewBtn title="Open full-screen UML view" onClick={() => setUmlExpanded(true)}>
@@ -351,18 +351,18 @@ export const ModelDetailModal: React.FC<ModelDetailModalProps> = ({
 
             {/* Diagram card */}
             <div style={{ flex: 1, padding: '0 18px 18px', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-              <div style={{ flex: 1, position: 'relative', background: '#ffffff', borderRadius: 10, border: '1px solid #e2e8f0', overflow: 'hidden', boxShadow: '0 1px 4px rgba(0,0,0,0.04)' }}>
+              <div style={{ flex: 1, position: 'relative', background: 'var(--v-workspace-bg)', borderRadius: 10, border: '1px solid var(--v-border)', overflow: 'hidden', boxShadow: 'var(--v-card-shadow)' }}>
                 {fetchingUml && (
-                  <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 10, color: '#94a3b8' }}>
-                    <div style={{ width: 24, height: 24, border: '2.5px solid #e2e8f0', borderTop: `2.5px solid ${theme.icon}`, borderRadius: '50%', animation: 'spin 0.8s linear infinite' }} />
+                  <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 10, color: 'var(--v-text-muted)' }}>
+                    <div style={{ width: 24, height: 24, border: '2.5px solid var(--v-border)', borderTop: `2.5px solid ${theme.icon}`, borderRadius: '50%', animation: 'spin 0.8s linear infinite' }} />
                     <span style={{ fontSize: 12, fontFamily: FONT }}>Loading preview…</span>
                   </div>
                 )}
                 {!fetchingUml && fetchError && (
-                  <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#cbd5e1', fontSize: 12, fontFamily: FONT }}>Could not load UML preview</div>
+                  <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--v-text-faint)', fontSize: 12, fontFamily: FONT }}>Could not load UML preview</div>
                 )}
                 {!fetchingUml && !fetchError && !ecoreContent && (
-                  <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#cbd5e1', fontSize: 12, fontFamily: FONT }}>No diagram available</div>
+                  <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--v-text-faint)', fontSize: 12, fontFamily: FONT }}>No diagram available</div>
                 )}
                 {ecoreContent && (
                   <UMLDiagram
@@ -459,7 +459,7 @@ const filterRowStyle: React.CSSProperties = {
 const filterLabelStyle: React.CSSProperties = {
   fontSize: 13,
   fontWeight: 600,
-  color: '#374151',
+  color: 'var(--v-text-secondary)',
   minWidth: 76,
   flexShrink: 0,
   fontFamily: APP_FONT,
@@ -471,7 +471,7 @@ const filterFieldStyle: React.CSSProperties = {
   width: 'auto',
   padding: '9px 12px',
   fontSize: 13,
-  background: '#ffffff',
+  background: 'var(--v-input-bg)',
 };
 
 const filterTagStyle: React.CSSProperties = {
@@ -479,7 +479,7 @@ const filterTagStyle: React.CSSProperties = {
   alignItems: 'center',
   padding: '4px 10px',
   borderRadius: 999,
-  background: '#f0faf8',
+  background: 'var(--v-brand-soft)',
   border: `1px solid ${BRAND_COLOR}33`,
   color: BRAND_COLOR,
   fontSize: 12,
@@ -554,11 +554,11 @@ const AdvancedSearchModal: React.FC<AdvancedSearchModalProps> = ({
         transform: 'translate(-50%, -50%)',
         margin: 0,
         padding: 0,
-        border: '1px solid #e2e8f0',
+        border: '1px solid var(--v-border)',
         width: 'min(480px, calc(100vw - 48px))',
         maxHeight: 'min(85vh, 640px)',
         overflowY: 'auto',
-        background: '#ffffff',
+        background: 'var(--v-surface)',
         borderRadius: 12,
         boxShadow: '0 20px 50px rgba(11, 23, 32, 0.18), 0 4px 14px rgba(11, 23, 32, 0.08)',
         fontFamily: APP_FONT,
@@ -927,10 +927,10 @@ export const ModelLibraryTable: React.FC<ModelLibraryTableProps> = ({ onModelOpe
               gap: 8,
               padding: '8px 14px',
               border: '1px solid',
-              borderColor: hasActiveFilters ? '#049484' : '#e5e7eb',
+              borderColor: hasActiveFilters ? '#049484' : 'var(--v-border)',
               borderRadius: 8,
-              background: hasActiveFilters ? '#f0faf8' : '#ffffff',
-              color: hasActiveFilters ? '#049484' : '#374151',
+              background: hasActiveFilters ? 'var(--v-brand-soft)' : 'var(--v-surface)',
+              color: hasActiveFilters ? '#049484' : 'var(--v-text-secondary)',
               fontSize: 13,
               fontWeight: 600,
               cursor: 'pointer',
@@ -967,10 +967,10 @@ export const ModelLibraryTable: React.FC<ModelLibraryTableProps> = ({ onModelOpe
               }}
               style={{
                 padding: '8px 12px',
-                border: '1px solid #e5e7eb',
+                border: '1px solid var(--v-border)',
                 borderRadius: 8,
-                background: '#fff',
-                color: '#6b7280',
+                background: 'var(--v-surface)',
+                color: 'var(--v-text-muted)',
                 fontSize: 13,
                 cursor: 'pointer',
               }}
@@ -980,7 +980,7 @@ export const ModelLibraryTable: React.FC<ModelLibraryTableProps> = ({ onModelOpe
           )}
 
           {search.trim() && (
-            <span style={{ fontSize: 13, color: '#6b7280', maxWidth: 420, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            <span style={{ fontSize: 13, color: 'var(--v-text-muted)', maxWidth: 420, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
               Active: {search.trim()}
             </span>
           )}
@@ -1003,7 +1003,7 @@ export const ModelLibraryTable: React.FC<ModelLibraryTableProps> = ({ onModelOpe
       {/* Table area */}
       <div style={{ flex: 1, padding: '16px 40px 24px', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
         {error && (
-          <div style={{ padding: '10px 14px', background: '#fef2f2', border: '1px solid #fecaca', borderRadius: 8, fontSize: 13, color: '#dc2626', marginBottom: 12 }}>
+          <div style={{ padding: '10px 14px', background: 'var(--v-danger-bg)', border: '1px solid var(--v-danger-border)', borderRadius: 8, fontSize: 13, color: 'var(--v-danger-text)', marginBottom: 12 }}>
             {error}
           </div>
         )}
@@ -1131,7 +1131,7 @@ const TableRow: React.FC<TableRowProps> = ({ model, onView, onDelete }) => {
             Projects
           </span>
         ) : (
-          <span style={{ color: '#d1d5db', fontSize: 14 }}>--</span>
+          <span style={{ color: 'var(--v-text-faint)', fontSize: 14 }}>--</span>
         )}
       </td>
       <td style={{ padding: '13px 16px' }}>

--- a/src/components/ui/ModelLibraryTable.tsx
+++ b/src/components/ui/ModelLibraryTable.tsx
@@ -903,7 +903,7 @@ export const ModelLibraryTable: React.FC<ModelLibraryTableProps> = ({ onModelOpe
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
       {/* Page header */}
       <div style={{ padding: '32px 40px 0', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
-        <h1 style={{ margin: 0, fontSize: 26, fontWeight: 700, color: '#111827', letterSpacing: '-0.02em' }}>Model Library</h1>
+        <h1 style={{ margin: 0, fontSize: 26, fontWeight: 700, color: 'var(--v-text)', letterSpacing: '-0.02em' }}>Model Library</h1>
         <button type="button"
           onClick={() => setShowCreate(true)}
           style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '9px 18px', background: '#0B1720', color: '#fff', border: 'none', borderRadius: 9, fontSize: 14, fontWeight: 600, cursor: 'pointer', boxShadow: '0 1px 4px rgba(11,23,32,0.25)', transition: 'background 0.15s', fontFamily: 'ui-sans-serif, system-ui, sans-serif' }}
@@ -1008,10 +1008,10 @@ export const ModelLibraryTable: React.FC<ModelLibraryTableProps> = ({ onModelOpe
           </div>
         )}
 
-        <div style={{ flex: 1, background: '#fff', border: '1px solid #e5e7eb', borderRadius: 12, overflow: 'auto', boxShadow: '0 1px 4px rgba(0,0,0,0.04)' }}>
+        <div style={{ flex: 1, background: 'var(--v-surface)', border: '1px solid var(--v-border)', borderRadius: 12, overflow: 'auto', boxShadow: '0 1px 4px rgba(0,0,0,0.04)' }}>
           <table style={{ width: '100%', borderCollapse: 'collapse' }}>
             <thead>
-              <tr style={{ borderBottom: '1px solid #f3f4f6' }}>
+              <tr style={{ borderBottom: '1px solid var(--v-border-subtle)' }}>
                 {['Name', 'Created', 'Projects', 'Actions'].map((col, i) => (
                   <th
                     key={col}
@@ -1020,11 +1020,11 @@ export const ModelLibraryTable: React.FC<ModelLibraryTableProps> = ({ onModelOpe
                       textAlign: 'left',
                       fontSize: 12,
                       fontWeight: 600,
-                      color: '#6b7280',
+                      color: 'var(--v-text-muted)',
                       letterSpacing: '0.04em',
                       textTransform: 'uppercase',
-                      background: '#fafafa',
-                      borderBottom: '1px solid #f3f4f6',
+                      background: 'var(--v-table-header)',
+                      borderBottom: '1px solid var(--v-border-subtle)',
                       whiteSpace: 'nowrap',
                       width: i === 3 ? 80 : undefined,
                     }}
@@ -1043,7 +1043,7 @@ export const ModelLibraryTable: React.FC<ModelLibraryTableProps> = ({ onModelOpe
         {/* Pagination */}
         {totalPages > 1 && (
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', paddingTop: 14 }}>
-            <span style={{ fontSize: 13, color: '#6b7280' }}>
+            <span style={{ fontSize: 13, color: 'var(--v-text-muted)' }}>
               {(currentPage - 1) * itemsPerPage + 1}–{Math.min(currentPage * itemsPerPage, models.length)} of {models.length}
             </span>
             <div style={{ display: 'flex', gap: 4 }}>
@@ -1121,13 +1121,13 @@ const TableRow: React.FC<TableRowProps> = ({ model, onView, onDelete }) => {
         }
       }}
       tabIndex={0}
-      style={{ borderBottom: '1px solid #f9fafb', background: hovered ? '#fafafa' : '#fff', cursor: 'pointer', transition: 'background 0.1s' }}
+      style={{ borderBottom: '1px solid var(--v-border-subtle)', background: hovered ? 'var(--v-surface-hover)' : 'var(--v-surface)', cursor: 'pointer', transition: 'background 0.1s' }}
     >
-      <td style={{ padding: '13px 16px', fontSize: 14, fontWeight: 500, color: '#111827' }}>{model.name}</td>
-      <td style={{ padding: '13px 16px', fontSize: 14, color: '#6b7280' }}>{formatDate(model.createdAt)}</td>
+      <td style={{ padding: '13px 16px', fontSize: 14, fontWeight: 500, color: 'var(--v-text)' }}>{model.name}</td>
+      <td style={{ padding: '13px 16px', fontSize: 14, color: 'var(--v-text-muted)' }}>{formatDate(model.createdAt)}</td>
       <td style={{ padding: '13px 16px' }}>
         {hasProjects ? (
-          <span style={{ padding: '3px 10px', background: '#f3f4f6', border: '1px solid #e5e7eb', borderRadius: 20, fontSize: 12, color: '#374151', fontWeight: 500 }}>
+          <span style={{ padding: '3px 10px', background: 'var(--v-surface-muted)', border: '1px solid var(--v-border)', borderRadius: 20, fontSize: 12, color: 'var(--v-text-secondary)', fontWeight: 500 }}>
             Projects
           </span>
         ) : (
@@ -1159,11 +1159,11 @@ interface PageBtnProps {
 }
 
 const PageBtn: React.FC<PageBtnProps> = ({ children, active, disabled, onClick }) => {
-  let color = '#374151';
+  let color = 'var(--v-text)';
   if (active) {
     color = '#fff';
   } else if (disabled) {
-    color = '#d1d5db';
+    color = 'var(--v-text-faint)';
   }
 
   return (
@@ -1173,9 +1173,9 @@ const PageBtn: React.FC<PageBtnProps> = ({ children, active, disabled, onClick }
     style={{
       padding: '6px 11px',
       border: '1px solid',
-      borderColor: active ? '#049484' : '#e5e7eb',
+      borderColor: active ? '#049484' : 'var(--v-border)',
       borderRadius: 7,
-      background: active ? '#049484' : '#fff',
+      background: active ? '#049484' : 'var(--v-surface)',
       color,
       fontSize: 13,
       fontWeight: active ? 600 : 400,

--- a/src/components/ui/PortalRowActionsMenu.tsx
+++ b/src/components/ui/PortalRowActionsMenu.tsx
@@ -57,13 +57,13 @@ const PortalMenuItem: React.FC<{ label: string; onSelect: () => void; danger?: b
       border: 'none',
       background: 'transparent',
       fontSize: 13,
-      color: danger ? '#dc2626' : '#374151',
+      color: danger ? '#dc2626' : 'var(--v-text-secondary)',
       cursor: 'pointer',
       textAlign: 'left',
       pointerEvents: 'auto',
     }}
     onMouseEnter={e => {
-      (e.currentTarget as HTMLButtonElement).style.background = danger ? '#fef2f2' : '#f9fafb';
+      (e.currentTarget as HTMLButtonElement).style.background = danger ? '#fef2f2' : 'var(--v-surface-hover)';
     }}
     onMouseLeave={e => {
       (e.currentTarget as HTMLButtonElement).style.background = 'transparent';
@@ -155,8 +155,8 @@ export const PortalRowActionsMenu: React.FC<PortalRowActionsMenuProps> = ({
         top: menuPos.top,
         left: menuPos.left,
         transform: 'translateX(-100%)',
-        background: '#fff',
-        border: '1px solid #e5e7eb',
+        background: 'var(--v-surface)',
+        border: '1px solid var(--v-border)',
         borderRadius: 10,
         boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
         zIndex: ACTIONS_MENU_Z_INDEX,
@@ -168,7 +168,7 @@ export const PortalRowActionsMenu: React.FC<PortalRowActionsMenuProps> = ({
       {actions.map(action => (
         <React.Fragment key={action.label}>
           {action.dividerBefore && (
-            <div style={{ height: 1, background: '#f3f4f6', margin: '2px 0' }} />
+            <div style={{ height: 1, background: 'var(--v-border-subtle)', margin: '2px 0' }} />
           )}
           <PortalMenuItem
             label={action.label}
@@ -192,22 +192,22 @@ export const PortalRowActionsMenu: React.FC<PortalRowActionsMenuProps> = ({
         onMouseDown={e => e.stopPropagation()}
         style={{
           padding: '4px 8px',
-          border: '1px solid #e5e7eb',
+          border: '1px solid var(--v-border)',
           borderRadius: 6,
-          background: '#fff',
+          background: 'var(--v-surface)',
           cursor: 'pointer',
-          color: '#6b7280',
+          color: 'var(--v-text-muted)',
           display: 'flex',
           alignItems: 'center',
           transition: 'all 0.15s',
         }}
         onMouseEnter={e => {
-          (e.currentTarget as HTMLButtonElement).style.background = '#f9fafb';
-          (e.currentTarget as HTMLButtonElement).style.borderColor = '#d1d5db';
+          (e.currentTarget as HTMLButtonElement).style.background = 'var(--v-surface-hover)';
+          (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--v-text-faint)';
         }}
         onMouseLeave={e => {
-          (e.currentTarget as HTMLButtonElement).style.background = '#fff';
-          (e.currentTarget as HTMLButtonElement).style.borderColor = '#e5e7eb';
+          (e.currentTarget as HTMLButtonElement).style.background = 'var(--v-surface)';
+          (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--v-border)';
         }}
       >
         <DotsIcon />

--- a/src/components/ui/ProfileModal.tsx
+++ b/src/components/ui/ProfileModal.tsx
@@ -46,9 +46,10 @@ export const ProfileModal: React.FC<ProfileModalProps> = ({ user, onClose, onNam
           zIndex: 1,
           width: 'min(760px, 94vw)',
           maxHeight: '88vh',
-          background: '#ffffff',
+          background: 'var(--v-surface)',
           borderRadius: 12,
-          boxShadow: '0 8px 40px rgba(0,0,0,0.18), 0 0 0 1px rgba(0,0,0,0.07)',
+          boxShadow: 'var(--v-card-shadow)',
+          border: '1px solid var(--v-card-border)',
           display: 'flex',
           flexDirection: 'column',
           overflow: 'hidden',
@@ -62,24 +63,24 @@ export const ProfileModal: React.FC<ProfileModalProps> = ({ user, onClose, onNam
             position: 'absolute', top: 12, right: 12, zIndex: 10,
             width: 30, height: 30, borderRadius: 6,
             background: 'transparent',
-            border: '1.5px solid rgba(0,0,0,0.10)',
+            border: '1.5px solid var(--v-border)',
             display: 'flex', alignItems: 'center', justifyContent: 'center',
-            cursor: 'pointer', fontSize: 13, color: '#64748b',
+            cursor: 'pointer', fontSize: 13, color: 'var(--v-text-muted)',
             transition: 'all 0.12s',
           }}
           onMouseEnter={e => {
-            e.currentTarget.style.background = '#f1f5f9';
-            e.currentTarget.style.borderColor = 'rgba(0,0,0,0.18)';
+            e.currentTarget.style.background = 'var(--v-chrome-hover)';
+            e.currentTarget.style.color = 'var(--v-text)';
           }}
           onMouseLeave={e => {
             e.currentTarget.style.background = 'transparent';
-            e.currentTarget.style.borderColor = 'rgba(0,0,0,0.10)';
+            e.currentTarget.style.color = 'var(--v-text-muted)';
           }}
           title="Close"
         >
           ✕
         </button>
-        <div style={{ overflowY: 'auto', flex: 1, background: '#f8fafc' }}>
+        <div style={{ overflowY: 'auto', flex: 1, background: 'var(--v-page-bg)' }}>
           <ProfileView
             user={user}
             userRole="Methodologist"

--- a/src/components/ui/ProfileView.tsx
+++ b/src/components/ui/ProfileView.tsx
@@ -172,7 +172,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
 
   return (
     <div style={{ flex: 1, overflowY: 'auto', padding: '44px 48px 48px' }}>
-      <div style={{ maxWidth: 680 }}>
+      <div style={{ maxWidth: 680, width: '100%', margin: '0 auto' }}>
 
         {/* Header */}
         <div style={{ marginBottom: 32 }}>

--- a/src/components/ui/ProfileView.tsx
+++ b/src/components/ui/ProfileView.tsx
@@ -4,6 +4,7 @@ import { apiService } from '../../services/api';
 import { USER_PROFILE_LABEL, USER_PROFILE_PAGE_SUBTITLE } from '../../constants/accountLabels';
 import { getUserInitials } from '../../utils/userInitials';
 import { BoundChangePasswordModal } from './BoundChangePasswordModal';
+import { ThemeToggle } from './ThemeToggle';
 import { useChangePassword } from '../../hooks/useChangePassword';
 
 interface ProfileViewProps {
@@ -44,16 +45,16 @@ const XIcon = () => (
 
 const ReadField: React.FC<{ label: string; value?: string; placeholder?: string }> = ({ label, value, placeholder }) => (
   <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-    <label style={{ fontSize: 11, fontWeight: 700, color: '#6b7280', letterSpacing: '0.05em', textTransform: 'uppercase' }}>
+    <label style={{ fontSize: 11, fontWeight: 700, color: 'var(--v-text-muted)', letterSpacing: '0.05em', textTransform: 'uppercase' }}>
       {label}
     </label>
     <div style={{
       padding: '10px 14px',
-      background: value ? '#ffffff' : '#f9fafb',
-      border: '1.5px solid rgba(0,0,0,0.08)',
+      background: value ? 'var(--v-surface)' : 'var(--v-surface-muted)',
+      border: '1.5px solid var(--v-card-border)',
       borderRadius: 9,
       fontSize: 14,
-      color: value ? '#111827' : '#9ca3af',
+      color: value ? 'var(--v-text)' : 'var(--v-text-faint)',
     }}>
       {value || placeholder || '—'}
     </div>
@@ -69,7 +70,7 @@ const EditInput: React.FC<{
   placeholder?: string;
 }> = ({ label, value, onChange, placeholder }) => (
   <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-    <label style={{ fontSize: 11, fontWeight: 700, color: '#6b7280', letterSpacing: '0.05em', textTransform: 'uppercase' }}>
+    <label style={{ fontSize: 11, fontWeight: 700, color: 'var(--v-text-muted)', letterSpacing: '0.05em', textTransform: 'uppercase' }}>
       {label}
     </label>
     <input
@@ -78,11 +79,11 @@ const EditInput: React.FC<{
       placeholder={placeholder}
       style={{
         padding: '10px 14px',
-        background: '#ffffff',
+        background: 'var(--v-surface)',
         border: '1.5px solid #049484',
         borderRadius: 9,
         fontSize: 14,
-        color: '#111827',
+        color: 'var(--v-text)',
         outline: 'none',
         boxShadow: '0 0 0 3px rgba(4,148,132,0.12)',
         transition: 'border-color 0.15s, box-shadow 0.15s',
@@ -175,13 +176,13 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
 
         {/* Header */}
         <div style={{ marginBottom: 32 }}>
-          <div style={{ fontSize: 11, fontWeight: 700, color: '#9ca3af', letterSpacing: '0.08em', textTransform: 'uppercase', marginBottom: 10 }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--v-text-faint)', letterSpacing: '0.08em', textTransform: 'uppercase', marginBottom: 10 }}>
             Account
           </div>
-          <h1 style={{ margin: 0, fontSize: 28, fontWeight: 800, color: '#0f172a', letterSpacing: '-0.02em', lineHeight: 1.2 }}>
+          <h1 style={{ margin: 0, fontSize: 28, fontWeight: 800, color: 'var(--v-text)', letterSpacing: '-0.02em', lineHeight: 1.2 }}>
             {USER_PROFILE_LABEL}
           </h1>
-          <p style={{ margin: '8px 0 0', fontSize: 14, color: '#6b7280' }}>
+          <p style={{ margin: '8px 0 0', fontSize: 14, color: 'var(--v-text-muted)' }}>
             {USER_PROFILE_PAGE_SUBTITLE}
           </p>
           {loadError && (
@@ -197,8 +198,8 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
 
         {/* Avatar card */}
         <div style={{
-          background: 'rgba(255,255,255,0.88)',
-          border: '1.5px solid rgba(0,0,0,0.07)',
+          background: 'var(--v-surface)',
+          border: '1.5px solid var(--v-card-border)',
           borderRadius: 14,
           padding: '24px 28px',
           display: 'flex',
@@ -216,16 +217,16 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
             {initials}
           </div>
           <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 18, fontWeight: 700, color: '#111827' }}>{displayName}</div>
+            <div style={{ fontSize: 18, fontWeight: 700, color: 'var(--v-text)' }}>{displayName}</div>
             <div style={{ fontSize: 13, color: '#049484', fontWeight: 600, marginTop: 2 }}>{userRole}</div>
-            {email && <div style={{ fontSize: 13, color: '#6b7280', marginTop: 2 }}>{email}</div>}
+            {email && <div style={{ fontSize: 13, color: 'var(--v-text-muted)', marginTop: 2 }}>{email}</div>}
           </div>
         </div>
 
         {/* Name edit card */}
         <div style={{
-          background: 'rgba(255,255,255,0.88)',
-          border: '1.5px solid rgba(0,0,0,0.07)',
+          background: 'var(--v-surface)',
+          border: '1.5px solid var(--v-card-border)',
           borderRadius: 14,
           padding: '24px 28px',
           display: 'flex',
@@ -236,15 +237,15 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
         }}>
           {/* Card header row */}
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <div style={{ fontSize: 14, fontWeight: 700, color: '#111827' }}>Account Details</div>
+            <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--v-text)' }}>Account Details</div>
             {!editing && (
               <button type="button"
                 onClick={handleEditOpen}
                 style={{
                   display: 'flex', alignItems: 'center', gap: 6,
-                  background: 'none', border: '1.5px solid rgba(0,0,0,0.10)',
+                  background: 'none', border: '1.5px solid var(--v-card-border)',
                   borderRadius: 8, padding: '6px 12px',
-                  fontSize: 13, fontWeight: 600, color: '#374151',
+                  fontSize: 13, fontWeight: 600, color: 'var(--v-text-secondary)',
                   cursor: 'pointer', transition: 'all 0.15s',
                 }}
                 onMouseEnter={e => {
@@ -252,8 +253,8 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
                   e.currentTarget.style.color = '#049484';
                 }}
                 onMouseLeave={e => {
-                  e.currentTarget.style.borderColor = 'rgba(0,0,0,0.10)';
-                  e.currentTarget.style.color = '#374151';
+                  e.currentTarget.style.borderColor = 'var(--v-card-border)';
+                  e.currentTarget.style.color = 'var(--v-text-secondary)';
                 }}
               >
                 <EditIcon /> Edit name
@@ -298,9 +299,9 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
                   disabled={saving}
                   style={{
                     display: 'flex', alignItems: 'center', gap: 6,
-                    background: 'none', border: '1.5px solid rgba(0,0,0,0.10)',
+                    background: 'none', border: '1.5px solid var(--v-border)',
                     borderRadius: 9, padding: '9px 16px',
-                    fontSize: 13, fontWeight: 600, color: '#6b7280',
+                    fontSize: 13, fontWeight: 600, color: 'var(--v-text-muted)',
                     cursor: 'pointer',
                   }}
                 >
@@ -342,8 +343,8 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
 
         {/* Change password card */}
         <div style={{
-          background: 'rgba(255,255,255,0.88)',
-          border: '1.5px solid rgba(0,0,0,0.07)',
+          background: 'var(--v-surface)',
+          border: '1.5px solid var(--v-card-border)',
           borderRadius: 14,
           padding: '20px 28px',
           display: 'flex',
@@ -352,8 +353,8 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
           boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
         }}>
           <div>
-            <div style={{ fontSize: 14, fontWeight: 700, color: '#111827' }}>Password</div>
-            <div style={{ fontSize: 13, color: '#6b7280', marginTop: 2 }}>
+            <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--v-text)' }}>Password</div>
+            <div style={{ fontSize: 13, color: 'var(--v-text-muted)', marginTop: 2 }}>
               Min. 8 characters · uppercase · lowercase · digit · special character
             </div>
           </div>
@@ -361,9 +362,9 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
             onClick={changePassword.open}
             style={{
               display: 'flex', alignItems: 'center', gap: 7,
-              background: 'none', border: '1.5px solid rgba(0,0,0,0.10)',
+              background: 'none', border: '1.5px solid var(--v-card-border)',
               borderRadius: 9, padding: '9px 16px',
-              fontSize: 13, fontWeight: 600, color: '#374151',
+              fontSize: 13, fontWeight: 600, color: 'var(--v-text-secondary)',
               cursor: 'pointer', flexShrink: 0, transition: 'all 0.15s',
             }}
             onMouseEnter={e => {
@@ -371,12 +372,36 @@ export const ProfileView: React.FC<ProfileViewProps> = ({ user, userRole = 'Meth
               e.currentTarget.style.color = '#049484';
             }}
             onMouseLeave={e => {
-              e.currentTarget.style.borderColor = 'rgba(0,0,0,0.10)';
-              e.currentTarget.style.color = '#374151';
+              e.currentTarget.style.borderColor = 'var(--v-card-border)';
+              e.currentTarget.style.color = 'var(--v-text-secondary)';
             }}
           >
             <LockIcon /> Change password
           </button>
+        </div>
+
+        {/* Appearance */}
+        <div style={{
+          background: 'var(--v-surface)',
+          border: '1.5px solid var(--v-card-border)',
+          borderRadius: 14,
+          padding: '20px 28px',
+          marginTop: 16,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 20,
+          boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+        }}>
+          <div>
+            <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--v-text)' }}>Appearance</div>
+            <div style={{ fontSize: 13, color: 'var(--v-text-muted)', marginTop: 2 }}>
+              Stay in the current light theme, or continue in dark mode. Your choice is saved on this device.
+            </div>
+          </div>
+          <div style={{ width: 200, flexShrink: 0 }}>
+            <ThemeToggle variant="segmented" />
+          </div>
         </div>
 
       </div>

--- a/src/components/ui/ProjectsView.tsx
+++ b/src/components/ui/ProjectsView.tsx
@@ -131,7 +131,7 @@ const ProjectRow: React.FC<ProjectRowProps> = ({
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onDoubleClick={showDeleted ? undefined : openVsum}
-      style={{ borderBottom: '1px solid #f9fafb', background: hovered ? '#fafafa' : '#fff', transition: 'background 0.1s', cursor: showDeleted ? 'default' : 'pointer' }}
+      style={{ borderBottom: '1px solid var(--v-border-subtle)', background: hovered ? 'var(--v-surface-hover)' : 'var(--v-surface)', transition: 'background 0.1s', cursor: showDeleted ? 'default' : 'pointer' }}
     >
       {/* Name */}
       <td style={{ padding: '13px 16px' }}>
@@ -148,7 +148,7 @@ const ProjectRow: React.FC<ProjectRowProps> = ({
               }}
             />
           )}
-          <span style={{ fontSize: 14, fontWeight: 500, color: '#111827' }}>{item.name}</span>
+          <span style={{ fontSize: 14, fontWeight: 500, color: 'var(--v-text)' }}>{item.name}</span>
           {role && (
             <span style={{
               padding: '2px 7px', borderRadius: 5, fontSize: 11, fontWeight: 700,
@@ -162,7 +162,7 @@ const ProjectRow: React.FC<ProjectRowProps> = ({
       </td>
 
       {/* Date */}
-      <td style={{ padding: '13px 16px', fontSize: 14, color: '#6b7280', whiteSpace: 'nowrap' }}>
+      <td style={{ padding: '13px 16px', fontSize: 14, color: 'var(--v-text-muted)', whiteSpace: 'nowrap' }}>
         {showDeleted
           ? formatDate(item.removedAt || item.updatedAt)
           : formatDate(item.createdAt)}
@@ -411,7 +411,7 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({
           overflow-x: hidden;
           scrollbar-gutter: stable;
           scrollbar-width: thin;
-          scrollbar-color: #cbd5e1 #f1f5f9;
+          scrollbar-color: var(--v-scrollbar-thumb) var(--v-scrollbar-track);
         }
         .projects-table-scroll::-webkit-scrollbar {
           width: 10px;
@@ -432,7 +432,7 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({
 
       {/* Page header */}
       <div style={{ padding: '32px 40px 0', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
-        <h1 style={{ margin: 0, fontSize: 26, fontWeight: 700, color: '#111827', letterSpacing: '-0.02em' }}>Dashboard / Projects</h1>
+        <h1 style={{ margin: 0, fontSize: 26, fontWeight: 700, color: 'var(--v-text)', letterSpacing: '-0.02em' }}>Dashboard / Projects</h1>
         <button type="button"
           onClick={() => setShowCreate(true)}
           disabled={projectView === 'shared' || projectView === 'deleted'}
@@ -463,14 +463,14 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({
             onChange={e => setSearch(e.target.value)}
             onKeyDown={e => { if (e.key === 'Enter') loadFirstPage(); }}
             placeholder="Search projects..."
-            style={{ width: '100%', padding: '8px 12px 8px 34px', border: '1px solid #e5e7eb', borderRadius: 8, fontSize: 13, color: '#374151', outline: 'none', boxSizing: 'border-box', background: '#fff', transition: 'border-color 0.15s' }}
+            style={{ width: '100%', padding: '8px 12px 8px 34px', border: '1px solid var(--v-border)', borderRadius: 8, fontSize: 13, color: 'var(--v-text-secondary)', outline: 'none', boxSizing: 'border-box', background: 'var(--v-input-bg)', transition: 'border-color 0.15s' }}
             onFocus={e => { (e.target as HTMLInputElement).style.borderColor = '#049484'; }}
-            onBlur={e => { (e.target as HTMLInputElement).style.borderColor = '#e5e7eb'; }}
+            onBlur={e => { (e.target as HTMLInputElement).style.borderColor = 'var(--v-border)'; }}
           />
         </div>
 
         {/* Active / Deleted tabs */}
-        <div style={{ display: 'flex', gap: 0, border: '1px solid #e5e7eb', borderRadius: 8, overflow: 'hidden', flexShrink: 0, flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', gap: 0, border: '1px solid var(--v-border)', borderRadius: 8, overflow: 'hidden', flexShrink: 0, flexWrap: 'wrap' }}>
           {([
             { key: 'mine' as const, label: 'My projects' },
             { key: 'shared' as const, label: 'Shared with me' },
@@ -481,8 +481,8 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({
               onClick={() => setProjectView(key)}
               style={{
                 padding: '7px 14px', border: 'none', fontSize: 13, fontWeight: projectView === key ? 600 : 400,
-                background: projectView === key ? '#f0faf8' : '#fff',
-                color: projectView === key ? '#049484' : '#6b7280',
+                background: projectView === key ? 'var(--v-uml-primary-soft)' : 'var(--v-surface)',
+                color: projectView === key ? '#049484' : 'var(--v-text-muted)',
                 cursor: 'pointer', transition: 'all 0.15s', whiteSpace: 'nowrap',
                 display: 'inline-flex',
                 alignItems: 'center',
@@ -537,12 +537,12 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({
         className="projects-table-scroll"
         style={{ flex: 1, minHeight: 0, padding: '16px 40px 24px' }}
       >
-        <div style={{ background: '#fff', border: '1px solid #e5e7eb', borderRadius: 12, overflow: 'hidden', boxShadow: '0 1px 4px rgba(0,0,0,0.04)' }}>
+        <div style={{ background: 'var(--v-surface)', border: '1px solid var(--v-border)', borderRadius: 12, overflow: 'hidden', boxShadow: '0 1px 4px rgba(0,0,0,0.04)' }}>
           <table style={{ width: '100%', borderCollapse: 'collapse' }}>
             <thead>
-              <tr style={{ borderBottom: '1px solid #f3f4f6' }}>
+              <tr style={{ borderBottom: '1px solid var(--v-border-subtle)' }}>
                 {['Name', showDeleted ? 'Deleted on' : 'Created on', 'Status', 'Actions'].map((col, i) => (
-                  <th key={col} style={{ padding: '12px 16px', textAlign: 'left', fontSize: 12, fontWeight: 600, color: '#6b7280', letterSpacing: '0.04em', textTransform: 'uppercase', background: '#fafafa', borderBottom: '1px solid #f3f4f6', whiteSpace: 'nowrap', width: i === 3 ? 120 : undefined }}>
+                  <th key={col} style={{ padding: '12px 16px', textAlign: 'left', fontSize: 12, fontWeight: 600, color: 'var(--v-text-muted)', letterSpacing: '0.04em', textTransform: 'uppercase', background: 'var(--v-table-header)', borderBottom: '1px solid var(--v-border-subtle)', whiteSpace: 'nowrap', width: i === 3 ? 120 : undefined }}>
                     {col}
                   </th>
                 ))}
@@ -552,9 +552,9 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({
               {sorted.length === 0 && !loading ? (
                 <tr>
                   <td colSpan={4} style={{ padding: '56px 16px' }}>
-                    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, color: '#9ca3af' }}>
+                    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, color: 'var(--v-text-faint)' }}>
                       <FolderIcon />
-                      <div style={{ fontSize: 15, fontWeight: 600, color: '#374151' }}>
+                      <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--v-text-secondary)' }}>
                         {emptyTitle}
                       </div>
                       <div style={{ fontSize: 13 }}>

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { useTheme, type ThemeMode } from '../../theme/theme';
+
+const SunIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+  </svg>
+);
+
+const MoonIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+    <path d="M21 14.5A8.5 8.5 0 0 1 9.5 3 7 7 0 1 0 21 14.5z" />
+  </svg>
+);
+
+interface ThemeToggleProps {
+  variant?: 'icon' | 'segmented';
+  tone?: 'adaptive' | 'onDark';
+}
+
+function getSegmentedButtonStyle(
+  active: boolean,
+  tone: 'adaptive' | 'onDark',
+): React.CSSProperties {
+  if (tone === 'onDark') {
+    return {
+      background: active ? 'rgba(4,148,132,0.28)' : 'transparent',
+      color: active ? '#ffffff' : 'rgba(255,255,255,0.62)',
+    };
+  }
+  return {
+    background: active ? 'var(--v-chrome-hover)' : 'transparent',
+    color: active ? 'var(--v-text)' : 'var(--v-text-muted)',
+  };
+}
+
+export const ThemeToggle: React.FC<ThemeToggleProps> = ({
+  variant = 'icon',
+  tone = 'adaptive',
+}) => {
+  const { theme, setTheme, toggleTheme, isDark } = useTheme();
+
+  if (variant === 'segmented') {
+    const options: Array<{ mode: ThemeMode; label: string; icon: React.ReactNode }> = [
+      { mode: 'light', label: 'Light', icon: <SunIcon /> },
+      { mode: 'dark', label: 'Dark', icon: <MoonIcon /> },
+    ];
+
+    return (
+      <div
+        role="group"
+        aria-label="Color theme"
+        style={{
+          display: 'flex',
+          width: '100%',
+          padding: 3,
+          borderRadius: 8,
+          background: tone === 'onDark' ? 'rgba(255,255,255,0.06)' : 'var(--v-surface-muted)',
+          border: tone === 'onDark' ? '1px solid rgba(255,255,255,0.10)' : '1px solid var(--v-border)',
+          boxSizing: 'border-box',
+        }}
+      >
+        {options.map(option => {
+          const active = theme === option.mode;
+          return (
+            <button
+              key={option.mode}
+              type="button"
+              aria-pressed={active}
+              aria-label={`${option.label} theme`}
+              onClick={() => setTheme(option.mode)}
+              style={{
+                flex: 1,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 6,
+                border: 'none',
+                borderRadius: 6,
+                padding: '7px 8px',
+                fontSize: 12,
+                fontWeight: active ? 700 : 500,
+                cursor: 'pointer',
+                transition: 'background 0.12s, color 0.12s',
+                ...getSegmentedButtonStyle(active, tone),
+              }}
+            >
+              {option.icon}
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  const nextLabel = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+
+  return (
+    <button
+      type="button"
+      aria-label={nextLabel}
+      title={nextLabel}
+      onClick={toggleTheme}
+      style={{
+        width: 34,
+        height: 34,
+        border: 'none',
+        borderRadius: 6,
+        background: 'transparent',
+        color: tone === 'onDark' ? 'rgba(255,255,255,0.78)' : 'var(--v-chrome-icon)',
+        cursor: 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+        transition: 'background 0.12s, color 0.12s',
+      }}
+      onMouseEnter={event => {
+        event.currentTarget.style.background = tone === 'onDark' ? 'rgba(255,255,255,0.08)' : 'var(--v-chrome-hover)';
+        event.currentTarget.style.color = tone === 'onDark' ? '#ffffff' : 'var(--v-chrome-icon-hover)';
+      }}
+      onMouseLeave={event => {
+        event.currentTarget.style.background = 'transparent';
+        event.currentTarget.style.color = tone === 'onDark' ? 'rgba(255,255,255,0.78)' : 'var(--v-chrome-icon)';
+      }}
+    >
+      {isDark ? <SunIcon /> : <MoonIcon />}
+    </button>
+  );
+};

--- a/src/components/ui/VsumDetailsModal.tsx
+++ b/src/components/ui/VsumDetailsModal.tsx
@@ -26,9 +26,9 @@ const TabButton: React.FC<TabButtonProps> = ({ label, isActive, onClick }) => (
   <button
     onClick={onClick}
     style={{
-      border: isActive ? 'none' : '1px solid #dee2e6',
-      background: isActive ? '#049484' : '#fff',
-      color: isActive ? '#fff' : '#495057',
+      background: isActive ? '#049484' : 'var(--v-surface)',
+      color: isActive ? '#fff' : 'var(--v-text-secondary)',
+      border: isActive ? 'none' : '1px solid var(--v-border)',
       borderRadius: 8,
       padding: '8px 16px',
       cursor: 'pointer',
@@ -82,15 +82,15 @@ const ActionButton: React.FC<ActionButtonProps> = ({
       case 'danger':
         return {
           ...baseStyle,
-          border: '1px solid #dc2626',
-          background: '#fef2f2',
-          color: '#dc2626',
+          border: '1px solid var(--v-danger-text)',
+          background: 'var(--v-danger-bg)',
+          color: 'var(--v-danger-text)',
         };
       case 'success':
         return {
           ...baseStyle,
           border: '1px solid #10b981',
-          background: disabled ? '#d1fae5' : 'linear-gradient(135deg, #10b981 0%, #059669 100%)',
+          background: disabled ? 'var(--v-success-bg)' : 'linear-gradient(135deg, #10b981 0%, #059669 100%)',
           color: '#fff',
           boxShadow: disabled ? 'none' : '0 2px 8px rgba(16, 185, 129, 0.3)',
         };
@@ -98,9 +98,9 @@ const ActionButton: React.FC<ActionButtonProps> = ({
       default:
         return {
           ...baseStyle,
-          border: '1px solid #dee2e6',
-          background: '#fff',
-          color: '#495057',
+          border: '1px solid var(--v-border)',
+          background: 'var(--v-surface)',
+          color: 'var(--v-text-secondary)',
         };
     }
   };
@@ -118,8 +118,8 @@ const ActionButton: React.FC<ActionButtonProps> = ({
         e.currentTarget.style.color = '#fff';
         break;
       case 'secondary':
-        e.currentTarget.style.background = '#f8f9fa';
-        e.currentTarget.style.borderColor = '#adb5bd';
+        e.currentTarget.style.background = 'var(--v-surface-hover)';
+        e.currentTarget.style.borderColor = 'var(--v-text-muted)';
         break;
     }
   };
@@ -133,12 +133,12 @@ const ActionButton: React.FC<ActionButtonProps> = ({
         e.currentTarget.style.boxShadow = '0 2px 8px rgba(4, 148, 132, 0.3)';
         break;
       case 'danger':
-        e.currentTarget.style.background = '#fef2f2';
-        e.currentTarget.style.color = '#dc2626';
+        e.currentTarget.style.background = 'var(--v-danger-bg)';
+        e.currentTarget.style.color = 'var(--v-danger-text)';
         break;
       case 'secondary':
-        e.currentTarget.style.background = '#fff';
-        e.currentTarget.style.borderColor = '#dee2e6';
+        e.currentTarget.style.background = 'var(--v-surface)';
+        e.currentTarget.style.borderColor = 'var(--v-border)';
         break;
     }
   };
@@ -174,7 +174,7 @@ const ConfirmButton: React.FC<ConfirmButtonProps> = ({ label, onClick, variant, 
   const isConfirm = variant === 'confirm';
   
   const getBackgroundColor = () => {
-    if (!isConfirm) return '#fff';
+    if (!isConfirm) return 'var(--v-surface)';
     return disabled ? accent.disabledBg : accent.gradient;
   };
 
@@ -186,9 +186,9 @@ const ConfirmButton: React.FC<ConfirmButtonProps> = ({ label, onClick, variant, 
   const style: React.CSSProperties = {
     padding: '10px 24px',
     borderRadius: 8,
-    border: isConfirm ? 'none' : '1px solid #dee2e6',
+    border: isConfirm ? 'none' : '1px solid var(--v-border)',
     background: getBackgroundColor(),
-    color: isConfirm ? '#fff' : '#495057',
+    color: isConfirm ? '#fff' : 'var(--v-text-secondary)',
     fontWeight: 600,
     cursor: disabled ? 'not-allowed' : 'pointer',
     fontSize: 14,
@@ -203,7 +203,7 @@ const ConfirmButton: React.FC<ConfirmButtonProps> = ({ label, onClick, variant, 
       e.currentTarget.style.transform = 'translateY(-1px)';
       e.currentTarget.style.boxShadow = accent.shadowHover;
     } else {
-      e.currentTarget.style.background = '#f8f9fa';
+      e.currentTarget.style.background = 'var(--v-surface-hover)';
     }
   };
 
@@ -212,7 +212,7 @@ const ConfirmButton: React.FC<ConfirmButtonProps> = ({ label, onClick, variant, 
       e.currentTarget.style.transform = 'translateY(0)';
       e.currentTarget.style.boxShadow = accent.shadow;
     } else {
-      e.currentTarget.style.background = '#fff';
+      e.currentTarget.style.background = 'var(--v-surface)';
     }
   };
 
@@ -266,14 +266,15 @@ const dialog: React.CSSProperties = {
   width: 900,
   maxWidth: '95vw',
   maxHeight: '90vh',
-  background: '#fff',
+  background: 'var(--v-surface)',
   borderRadius: 12,
-  boxShadow: '0 20px 60px rgba(4, 148, 132, 0.15), 0 10px 30px rgba(0, 0, 0, 0.1)',
+  boxShadow: 'var(--v-card-shadow)',
   overflow: 'hidden',
   display: 'flex',
   flexDirection: 'column',
   fontFamily: 'Georgia, serif',
-  border: '1px solid #e3f2fd',
+  border: '1px solid var(--v-border)',
+  color: 'var(--v-text)',
 };
 const header: React.CSSProperties = {
   padding: '20px 24px',
@@ -281,16 +282,16 @@ const header: React.CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  background: 'linear-gradient(135deg, #f8fcff 0%, #e8f4f8 100%)',
+  background: 'var(--v-surface-muted)',
 };
-const title: React.CSSProperties = { margin: 0, fontSize: 20, fontWeight: 700, color: '#2c3e50', letterSpacing: '0.01em' };
-const closeBtn: React.CSSProperties = { border: 'none', background: 'transparent', fontSize: 22, cursor: 'pointer', color: '#6c757d' };
-const body: React.CSSProperties = { padding: 20, overflowY: 'auto' };
-const footer: React.CSSProperties = { padding: '12px 20px', borderTop: '1px solid #e9ecef', display: 'flex', justifyContent: 'space-between', gap: 8 };
+const title: React.CSSProperties = { margin: 0, fontSize: 20, fontWeight: 700, color: 'var(--v-text)', letterSpacing: '0.01em' };
+const closeBtn: React.CSSProperties = { border: 'none', background: 'transparent', fontSize: 22, cursor: 'pointer', color: 'var(--v-text-muted)' };
+const body: React.CSSProperties = { padding: 20, overflowY: 'auto', color: 'var(--v-text)' };
+const footer: React.CSSProperties = { padding: '12px 20px', borderTop: '1px solid var(--v-border)', display: 'flex', justifyContent: 'space-between', gap: 8, background: 'var(--v-surface)' };
 const label: React.CSSProperties = { 
   fontSize: 13, 
   fontWeight: 700, 
-  color: '#2c3e50', 
+  color: 'var(--v-text)', 
   marginTop: 16, 
   marginBottom: 8,
   fontFamily: 'Georgia, serif',
@@ -299,13 +300,14 @@ const label: React.CSSProperties = {
 const textInput: React.CSSProperties = { 
   width: '100%', 
   padding: '12px 14px', 
-  border: '2px solid #e9ecef', 
+  border: '2px solid var(--v-border)', 
   borderRadius: 8, 
   fontSize: 14,
   outline: 'none',
   transition: 'all 0.2s ease',
   fontFamily: 'Georgia, serif',
-  background: '#f8f9fa',
+  background: 'var(--v-input-bg)',
+  color: 'var(--v-text)',
 };
 
 const confirmOverlay: React.CSSProperties = {
@@ -330,34 +332,35 @@ const confirmOverlay: React.CSSProperties = {
 const confirmBox: React.CSSProperties = {
   width: 460,
   maxWidth: '90vw',
-  background: '#fff',
+  background: 'var(--v-surface)',
   borderRadius: 12,
-  boxShadow: '0 20px 60px rgba(4, 148, 132, 0.15), 0 10px 30px rgba(0, 0, 0, 0.1)',
+  boxShadow: 'var(--v-card-shadow)',
   overflow: 'hidden',
   fontFamily: 'Georgia, serif',
-  border: '1px solid #e3f2fd',
+  border: '1px solid var(--v-border)',
+  color: 'var(--v-text)',
 };
 const confirmHeader: React.CSSProperties = {
   padding: '16px 20px',
   borderBottom: '2px solid #049484',
   fontWeight: 700,
-  color: '#2c3e50',
+  color: 'var(--v-text)',
   fontSize: 18,
-  background: 'linear-gradient(135deg, #f8fcff 0%, #e8f4f8 100%)',
+  background: 'var(--v-surface-muted)',
 };
 const confirmBody: React.CSSProperties = {
   padding: '20px',
-  color: '#495057',
+  color: 'var(--v-text-secondary)',
   fontSize: 14,
   lineHeight: 1.6,
 };
 const confirmFooter: React.CSSProperties = {
   padding: '16px 20px',
-  borderTop: '1px solid #e9ecef',
+  borderTop: '1px solid var(--v-border)',
   display: 'flex',
   justifyContent: 'flex-end',
   gap: 10,
-  background: '#f8f9fa',
+  background: 'var(--v-surface-muted)',
 };
 
 // Error Message Component
@@ -371,9 +374,9 @@ const ErrorMessage: React.FC<ErrorMessageProps> = ({ message, onDismiss }) => (
     style={{
       marginBottom: 12,
       padding: onDismiss ? 12 : 10,
-      border: '1px solid #f5c6cb',
-      background: '#f8d7da',
-      color: '#721c24',
+      border: '1px solid var(--v-danger-border)',
+      background: 'var(--v-danger-bg)',
+      color: 'var(--v-danger-text)',
       borderRadius: 8,
       fontSize: onDismiss ? 13 : 12,
       display: 'flex',
@@ -390,7 +393,7 @@ const ErrorMessage: React.FC<ErrorMessageProps> = ({ message, onDismiss }) => (
           marginLeft: 'auto',
           border: 'none',
           background: 'transparent',
-          color: '#721c24',
+          color: 'var(--v-danger-text)',
           cursor: 'pointer',
           fontSize: 18,
           lineHeight: 1,
@@ -522,10 +525,10 @@ const VersionCard: React.FC<VersionCardProps> = ({
     <div
       className={isCurrent ? 'version-card-current' : 'version-card-hover'}
       style={{
-        border: isCurrent ? '2px solid #049484' : '1px solid #e9ecef',
+        border: isCurrent ? '2px solid #049484' : '1px solid var(--v-border)',
         borderRadius: 10,
         padding: 16,
-        background: isCurrent ? '#f0f7ff' : '#ffffff',
+        background: isCurrent ? 'var(--v-brand-soft)' : 'var(--v-surface)',
         boxShadow: isCurrent
           ? '0 2px 8px rgba(52, 152, 219, 0.15)'
           : '0 1px 3px rgba(0, 0, 0, 0.08)',
@@ -552,7 +555,7 @@ const VersionCard: React.FC<VersionCardProps> = ({
             </div>
             <div>
               <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
-                <span style={{ fontWeight: 700, fontSize: 15, color: '#2c3e50' }}>
+                <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v-text)' }}>
                   Version #{version.id}
                 </span>
                 {isCurrent && (
@@ -570,7 +573,7 @@ const VersionCard: React.FC<VersionCardProps> = ({
                   </span>
                 )}
               </div>
-              <div style={{ fontSize: 13, color: '#6c757d', marginBottom: 4 }}>
+              <div style={{ fontSize: 13, color: 'var(--v-text-muted)', marginBottom: 4 }}>
                 {formatRelativeTime(version.createdAt)}
               </div>
               <div style={{ fontSize: 12, color: '#9ca3af', fontFamily: 'monospace' }}>
@@ -717,12 +720,12 @@ export const VsumDetailsModal: React.FC<Props> = ({ isOpen, vsumId, onClose, onS
 
   const renderDetailsContent = (): React.ReactNode => {
     if (loading || !details) {
-      return <div style={{ fontStyle: 'italic', color: '#6c757d' }}>Loading…</div>;
+      return <div style={{ fontStyle: 'italic', color: 'var(--v-text-muted)' }}>Loading…</div>;
     }
 
     return (
       <>
-        <div style={{ fontSize: 12, color: '#6c757d', marginBottom: 10 }}>
+        <div style={{ fontSize: 12, color: 'var(--v-text-muted)', marginBottom: 10 }}>
           <strong>Updated:</strong> {updatedDateOnly}
         </div>
 
@@ -735,12 +738,12 @@ export const VsumDetailsModal: React.FC<Props> = ({ isOpen, vsumId, onClose, onS
           disabled={!canManage}
           onFocus={(e) => {
             e.currentTarget.style.borderColor = '#049484';
-            e.currentTarget.style.background = '#ffffff';
+            e.currentTarget.style.background = 'var(--v-input-bg)';
             e.currentTarget.style.boxShadow = '0 0 0 3px rgba(4, 148, 132, 0.1)';
           }}
           onBlur={(e) => {
-            e.currentTarget.style.borderColor = '#e9ecef';
-            e.currentTarget.style.background = '#f8f9fa';
+            e.currentTarget.style.borderColor = 'var(--v-border)';
+            e.currentTarget.style.background = 'var(--v-input-bg)';
             e.currentTarget.style.boxShadow = 'none';
           }}
         />
@@ -750,14 +753,14 @@ export const VsumDetailsModal: React.FC<Props> = ({ isOpen, vsumId, onClose, onS
           <ul style={{ margin: 0, paddingLeft: 18 }}>
             {details.metaModels.map((mm) => (
               <li key={mm.id} style={{ marginBottom: 6 }}>
-                <span style={{ fontWeight: 700, color: '#2c3e50' }}>
+                <span style={{ fontWeight: 700, color: 'var(--v-text)' }}>
                   {mm.name}
                 </span>
               </li>
             ))}
           </ul>
         ) : (
-          <div style={{ fontSize: 12, color: '#6c757d', fontStyle: 'italic', marginBottom: 8 }}>
+          <div style={{ fontSize: 12, color: 'var(--v-text-muted)', fontStyle: 'italic', marginBottom: 8 }}>
             No meta models linked.
           </div>
         )}
@@ -847,12 +850,12 @@ export const VsumDetailsModal: React.FC<Props> = ({ isOpen, vsumId, onClose, onS
           alignItems: 'center', 
           justifyContent: 'center', 
           padding: '40px 20px',
-          color: '#6c757d' 
+          color: 'var(--v-text-muted)' 
         }}>
           <div style={{ 
             width: 40, 
             height: 40, 
-            border: '3px solid #e9ecef', 
+            border: '3px solid var(--v-border)', 
             borderTop: '3px solid #049484', 
             borderRadius: '50%', 
             animation: 'spin 1s linear infinite',
@@ -875,11 +878,11 @@ export const VsumDetailsModal: React.FC<Props> = ({ isOpen, vsumId, onClose, onS
           alignItems: 'center', 
           justifyContent: 'center', 
           padding: '40px 20px',
-          color: '#6c757d',
+          color: 'var(--v-text-muted)',
           textAlign: 'center'
         }}>
           <div style={{ fontSize: 48, marginBottom: 16, opacity: 0.5 }}>📋</div>
-          <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 8, color: '#495057' }}>No versions found</div>
+          <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 8, color: 'var(--v-text-secondary)' }}>No versions found</div>
           <div style={{ fontSize: 13 }}>Version history will appear here once versions are created.</div>
         </div>
       );
@@ -897,12 +900,12 @@ export const VsumDetailsModal: React.FC<Props> = ({ isOpen, vsumId, onClose, onS
 
         <div style={{ 
           fontSize: 12, 
-          color: '#6c757d', 
+          color: 'var(--v-text-muted)', 
           marginBottom: 8,
           padding: '8px 12px',
-          background: '#f8f9fa',
+          background: 'var(--v-surface-muted)',
           borderRadius: 8,
-          border: '1px solid #e9ecef'
+          border: '1px solid var(--v-border)'
         }}>
           <strong>Total versions:</strong> {versions.length} • <strong>Current:</strong> Version #{currentVersionId}
         </div>

--- a/src/components/ui/VsumUsersTab.tsx
+++ b/src/components/ui/VsumUsersTab.tsx
@@ -22,8 +22,8 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
 const wrap: React.CSSProperties = { display: 'grid', gap: 16, fontFamily: APP_FONT };
 const row: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' };
 const table: React.CSSProperties = { width: '100%', borderCollapse: 'collapse', userSelect: 'text' };
-const thtdBase: React.CSSProperties = { border: '1px solid #e9ecef', padding: '8px 10px', fontSize: 13 };
-const th: React.CSSProperties = { ...thtdBase, fontWeight: 700, textAlign: 'left', background: '#f8fafc' };
+const thtdBase: React.CSSProperties = { border: '1px solid var(--v-border)', padding: '8px 10px', fontSize: 13, color: 'var(--v-text)' };
+const th: React.CSSProperties = { ...thtdBase, fontWeight: 700, textAlign: 'left', background: 'var(--v-table-header)' };
 const td: React.CSSProperties = { ...thtdBase, userSelect: 'text' };
 const tdCenter: React.CSSProperties = { ...td, textAlign: 'center', userSelect: 'none' };
 const dangerBtn: React.CSSProperties = {
@@ -32,16 +32,16 @@ const dangerBtn: React.CSSProperties = {
   cursor: 'pointer',
   fontWeight: 600,
   fontSize: 12,
-  border: '1.5px solid #fecaca',
-  background: '#fff5f5',
-  color: '#dc2626',
+  border: '1.5px solid var(--v-danger-border)',
+  background: 'var(--v-danger-bg)',
+  color: 'var(--v-danger-text)',
   fontFamily: APP_FONT,
 };
 const sectionCard: React.CSSProperties = {
   padding: 14,
   borderRadius: 10,
-  border: '1px solid #e2e8f0',
-  background: '#fafafa',
+  border: '1px solid var(--v-border)',
+  background: 'var(--v-surface-muted)',
   display: 'grid',
   gap: 10,
 };
@@ -49,12 +49,12 @@ const sectionTitle: React.CSSProperties = {
   margin: 0,
   fontSize: 14,
   fontWeight: 700,
-  color: '#0f172a',
+  color: 'var(--v-text)',
 };
 const sectionHint: React.CSSProperties = {
   margin: 0,
   fontSize: 12,
-  color: '#64748b',
+  color: 'var(--v-text-muted)',
   lineHeight: 1.45,
 };
 const pendingBadge: React.CSSProperties = {
@@ -66,19 +66,19 @@ const pendingBadge: React.CSSProperties = {
   borderRadius: 20,
   fontSize: 10,
   fontWeight: 700,
-  background: '#fff7ed',
-  color: '#c2410c',
-  border: '1px solid #fed7aa',
+  background: 'var(--v-warning-bg)',
+  color: 'var(--v-warning-text)',
+  border: '1px solid var(--v-warning-border)',
   verticalAlign: 'middle',
 };
 const roleBadge = (role: string): React.CSSProperties => {
   if (role === 'Owner') {
-    return { background: '#ecfdf5', color: '#065f46', border: '1px solid #a7f3d0' };
+    return { background: 'var(--v-success-bg)', color: 'var(--v-success-text)', border: '1px solid var(--v-success-border)' };
   }
   if (role === 'Viewer') {
-    return { background: '#eff6ff', color: '#1d4ed8', border: '1px solid #bfdbfe' };
+    return { background: 'var(--v-info-bg)', color: 'var(--v-info-text)', border: '1px solid var(--v-info-border)' };
   }
-  return { background: '#f3f4f6', color: '#374151', border: '1px solid #e5e7eb' };
+  return { background: 'var(--v-surface-hover)', color: 'var(--v-text-secondary)', border: '1px solid var(--v-border)' };
 };
 
 const isOwnerRole = (role?: string, roleEn?: string) =>
@@ -327,12 +327,12 @@ export const VsumUsersTab: React.FC<Props> = ({ vsumId, onChanged, canManage = t
         </div>
 
         {query && (
-          <div style={{ border: '1px solid #e2e8f0', borderRadius: 8, overflow: 'hidden', background: '#fff' }}>
+          <div style={{ border: '1px solid var(--v-border)', borderRadius: 8, overflow: 'hidden', background: 'var(--v-surface)' }}>
             {searching && (
-              <div style={{ padding: 10, fontStyle: 'italic', color: '#64748b', fontSize: 13 }}>Searching…</div>
+              <div style={{ padding: 10, fontStyle: 'italic', color: 'var(--v-text-muted)', fontSize: 13 }}>Searching…</div>
             )}
             {!searching && searchResults.length === 0 && (
-              <div style={{ padding: 10, fontStyle: 'italic', color: '#64748b', fontSize: 13 }}>No users found</div>
+              <div style={{ padding: 10, fontStyle: 'italic', color: 'var(--v-text-muted)', fontSize: 13 }}>No users found</div>
             )}
             {!searching && searchResults.length > 0 && (
               <select
@@ -364,8 +364,8 @@ export const VsumUsersTab: React.FC<Props> = ({ vsumId, onChanged, canManage = t
         )}
 
         {selectedUser && (
-          <div style={{ fontSize: 12, color: '#64748b' }}>
-            Selected: <strong style={{ color: '#0f172a' }}>{userDisplayName(selectedUser)}</strong> ({selectedUser.email})
+          <div style={{ fontSize: 12, color: 'var(--v-text-muted)' }}>
+            Selected: <strong style={{ color: 'var(--v-text)' }}>{userDisplayName(selectedUser)}</strong> ({selectedUser.email})
           </div>
         )}
       </section>}
@@ -384,10 +384,10 @@ export const VsumUsersTab: React.FC<Props> = ({ vsumId, onChanged, canManage = t
           </thead>
           <tbody>
             {loading && (
-              <tr><td colSpan={canManage ? 4 : 3} style={{ ...td, fontStyle: 'italic', color: '#64748b' }}>Loading…</td></tr>
+              <tr><td colSpan={canManage ? 4 : 3} style={{ ...td, fontStyle: 'italic', color: 'var(--v-text-muted)' }}>Loading…</td></tr>
             )}
             {!loading && members.length === 0 && (
-              <tr><td colSpan={canManage ? 4 : 3} style={{ ...td, fontStyle: 'italic', color: '#64748b' }}>No members yet.</td></tr>
+              <tr><td colSpan={canManage ? 4 : 3} style={{ ...td, fontStyle: 'italic', color: 'var(--v-text-muted)' }}>No members yet.</td></tr>
             )}
             {!loading && members.length > 0 && members.map(m => {
               const displayName = memberDisplayName(m);

--- a/src/components/ui/sharedStyles.ts
+++ b/src/components/ui/sharedStyles.ts
@@ -18,7 +18,7 @@ export const DANGER_COLOR_HOVER = '#b91c1c';
 
 /** Large modal panel (code editor, UML viewer, etc.) */
 export const largeModalPanelStyle: React.CSSProperties = {
-  backgroundColor: '#ffffff',
+  backgroundColor: 'var(--v-surface)',
   borderRadius: '12px',
   width: '90%',
   maxWidth: '1200px',
@@ -36,8 +36,8 @@ export const largeModalPanelStyle: React.CSSProperties = {
 
 export const modalPanelHeaderStyle: React.CSSProperties = {
   padding: '14px 20px',
-  borderBottom: '1px solid #f1f5f9',
-  background: '#fafafa',
+  borderBottom: '1px solid var(--v-border-subtle)',
+  background: 'var(--v-table-header)',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
@@ -46,8 +46,8 @@ export const modalPanelHeaderStyle: React.CSSProperties = {
 
 export const modalPanelToolbarStyle: React.CSSProperties = {
   padding: '10px 20px',
-  borderBottom: '1px solid #f1f5f9',
-  background: '#ffffff',
+  borderBottom: '1px solid var(--v-border-subtle)',
+  background: 'var(--v-surface)',
   display: 'flex',
   gap: '8px',
   flexWrap: 'wrap',
@@ -57,8 +57,8 @@ export const modalPanelToolbarStyle: React.CSSProperties = {
 
 export const modalPanelFooterStyle: React.CSSProperties = {
   padding: '10px 20px',
-  borderTop: '1px solid #f1f5f9',
-  background: '#f8fafc',
+  borderTop: '1px solid var(--v-border-subtle)',
+  background: 'var(--v-surface-muted)',
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
@@ -103,7 +103,7 @@ export const labelStyle: React.CSSProperties = {
   display: 'block',
   fontSize: '13px',
   fontWeight: 600,
-  color: '#374151',
+  color: 'var(--v-text-secondary)',
   marginBottom: '6px',
   fontFamily: 'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
   letterSpacing: '0.01em',
@@ -112,13 +112,13 @@ export const labelStyle: React.CSSProperties = {
 export const inputStyle: React.CSSProperties = {
   width: '100%',
   padding: '10px 12px',
-  border: '1.5px solid #e2e8f0',
+  border: '1.5px solid var(--v-border)',
   borderRadius: '8px',
   fontSize: '14px',
   boxSizing: 'border-box',
   transition: 'all 0.2s ease',
-  background: '#f8fafc',
-  color: '#0f172a',
+  background: 'var(--v-surface-muted)',
+  color: 'var(--v-text)',
   fontFamily: 'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
 };
 

--- a/src/components/ui/sharedStyles.ts
+++ b/src/components/ui/sharedStyles.ts
@@ -27,7 +27,7 @@ export const largeModalPanelStyle: React.CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
   boxShadow: '0 24px 64px rgba(0, 0, 0, 0.22), 0 4px 16px rgba(0, 0, 0, 0.08)',
-  border: '1px solid #e2e8f0',
+  border: '1px solid var(--v-border)',
   overflow: 'hidden',
   position: 'relative',
   zIndex: 1,
@@ -69,7 +69,7 @@ export const modalCloseButtonStyle: React.CSSProperties = {
   border: 'none',
   background: 'transparent',
   cursor: 'pointer',
-  color: '#94a3b8',
+  color: 'var(--v-text-muted)',
   fontSize: '18px',
   width: '32px',
   height: '32px',
@@ -128,9 +128,9 @@ export const errorMessageStyle: React.CSSProperties = {
   borderRadius: '8px',
   fontSize: '13px',
   fontWeight: '500',
-  backgroundColor: '#f8d7da',
-  color: '#721c24',
-  border: '1px solid #f5c6cb',
+  backgroundColor: 'var(--v-danger-bg)',
+  color: 'var(--v-danger-text)',
+  border: '1px solid var(--v-danger-border)',
 };
 
 export const successMessageStyle: React.CSSProperties = {
@@ -139,9 +139,9 @@ export const successMessageStyle: React.CSSProperties = {
   borderRadius: '8px',
   fontSize: '13px',
   fontWeight: '500',
-  backgroundColor: '#d4edda',
-  color: '#155724',
-  border: '1px solid #c3e6cb',
+  backgroundColor: 'var(--v-success-bg)',
+  color: 'var(--v-success-text)',
+  border: '1px solid var(--v-success-border)',
 };
 
 export const fileInputStyle: React.CSSProperties = { display: 'none' };
@@ -149,7 +149,7 @@ export const fileInputStyle: React.CSSProperties = { display: 'none' };
 export const progressBarContainerStyle: React.CSSProperties = {
   width: '100%',
   height: '8px',
-  backgroundColor: '#e0e0e0',
+  backgroundColor: 'var(--v-border)',
   borderRadius: '4px',
   overflow: 'hidden',
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './styles/global.css';
+import './styles/theme.css';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -7,6 +7,7 @@ import { ProfileView } from '../components/ui/ProfileView';
 import { useAuth } from '../contexts/AuthContext';
 import { AuthService } from '../services/auth';
 import { useSharedProjectNotifications } from '../hooks/useSharedProjectNotifications';
+import { themeVars } from '../theme/theme';
 
 export const HomePage: React.FC = () => {
   const [activeView, setActiveView] = useState<SidebarView>('home');
@@ -28,7 +29,7 @@ export const HomePage: React.FC = () => {
   const userEmail = user?.email;
 
   return (
-    <div style={{ width: '100vw', height: '100vh', display: 'flex', overflow: 'hidden', background: '#f7f8fa' }}>
+    <div style={{ width: '100vw', height: '100vh', display: 'flex', overflow: 'hidden', background: themeVars.pageBg }}>
       <AppSidebar
         activeView={activeView}
         onViewChange={setActiveView}
@@ -40,8 +41,8 @@ export const HomePage: React.FC = () => {
       />
       <main style={{
         flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', position: 'relative',
-        backgroundColor: '#f3f4f6',
-        backgroundImage: 'radial-gradient(circle, #d1d5db 0.75px, transparent 0.75px)',
+        backgroundColor: themeVars.workspaceBg,
+        backgroundImage: `radial-gradient(circle, ${themeVars.workspaceDot} 0.75px, transparent 0.75px)`,
         backgroundSize: '24px 24px',
       }}>
         <div style={{ position: 'relative', flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,8 +3,10 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import { act } from '@testing-library/react';
 import './__mocks__/resizeObserverMock';
 import { deserialize, serialize } from 'node:v8';
+import { resetThemeStore } from './theme/theme';
 
 // Set up environment variables for tests
 process.env.REACT_APP_API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:9811';
@@ -16,3 +18,9 @@ globalThis.structuredClone = (val: any) => {
   }
   return deserialize(serialize(val));
 };
+
+afterEach(() => {
+  act(() => {
+    resetThemeStore();
+  });
+});

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -10,8 +10,8 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f5f5f5;
-  
+  background-color: var(--v-page-bg, #f5f5f5);
+  color: var(--v-text, #0f172a);
 }
 
 code {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -36,6 +36,23 @@
   --v-uml-box-text: #0f172a;
   --v-uml-box-text-muted: #64748b;
   --v-uml-box-border: #cbd5e1;
+  --v-uml-separator: #b8d0e2;
+  --v-uml-package-bg: #f9f4f7;
+  --v-danger-bg: #fef2f2;
+  --v-danger-border: #fecaca;
+  --v-danger-text: #991b1b;
+  --v-success-bg: #f0fdf4;
+  --v-success-border: #bbf7d0;
+  --v-success-text: #15803d;
+  --v-warning-bg: #fffbeb;
+  --v-warning-border: #fde68a;
+  --v-warning-text: #78350f;
+  --v-info-bg: #eff6ff;
+  --v-info-border: #bfdbfe;
+  --v-info-text: #1d4ed8;
+  --v-disabled-bg: #e5e7eb;
+  --v-disabled-text: #9ca3af;
+  --v-brand-soft: #f0faf8;
 }
 
 [data-theme="dark"] {
@@ -69,12 +86,29 @@
   --v-uml-edge: #5eead4;
   --v-uml-edge-halo: #0f172a;
   --v-uml-circle: #5eead4;
-  --v-uml-box-bg: #e8eef6;
-  --v-uml-box-muted: #d7e0ec;
-  --v-uml-box-hover: #c9d4e2;
-  --v-uml-box-text: #0f172a;
-  --v-uml-box-text-muted: #334155;
-  --v-uml-box-border: #94a3b8;
+  --v-uml-box-bg: #1e293b;
+  --v-uml-box-muted: #162032;
+  --v-uml-box-hover: #243044;
+  --v-uml-box-text: #e2e8f0;
+  --v-uml-box-text-muted: #94a3b8;
+  --v-uml-box-border: #64748b;
+  --v-uml-separator: #334155;
+  --v-uml-package-bg: #2a1b28;
+  --v-danger-bg: rgba(220, 38, 38, 0.16);
+  --v-danger-border: rgba(248, 113, 113, 0.35);
+  --v-danger-text: #fca5a5;
+  --v-success-bg: rgba(22, 163, 74, 0.16);
+  --v-success-border: rgba(74, 222, 128, 0.28);
+  --v-success-text: #86efac;
+  --v-warning-bg: rgba(245, 158, 11, 0.14);
+  --v-warning-border: rgba(251, 191, 36, 0.28);
+  --v-warning-text: #fcd34d;
+  --v-info-bg: rgba(59, 130, 246, 0.16);
+  --v-info-border: rgba(147, 197, 253, 0.32);
+  --v-info-text: #93c5fd;
+  --v-disabled-bg: #334155;
+  --v-disabled-text: #64748b;
+  --v-brand-soft: rgba(4, 148, 132, 0.16);
 }
 
 html,

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,131 @@
+:root,
+[data-theme="light"] {
+  color-scheme: light;
+  --v-page-bg: #f7f8fa;
+  --v-workspace-bg: #f3f4f6;
+  --v-workspace-dot: #d1d5db;
+  --v-surface: #ffffff;
+  --v-surface-muted: #f8fafc;
+  --v-surface-hover: #fafafa;
+  --v-text: #0f172a;
+  --v-text-secondary: #4b5563;
+  --v-text-muted: #6b7280;
+  --v-text-faint: #9ca3af;
+  --v-border: #e5e7eb;
+  --v-border-subtle: #f3f4f6;
+  --v-card-border: rgba(0, 0, 0, 0.07);
+  --v-card-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  --v-overlay: rgba(255, 255, 255, 0.88);
+  --v-chrome-bg: #ffffff;
+  --v-chrome-hover: #f1f5f9;
+  --v-chrome-icon: #475569;
+  --v-chrome-icon-hover: #1e293b;
+  --v-chrome-divider: #e2e8f0;
+  --v-table-header: #fafafa;
+  --v-input-bg: #ffffff;
+  --v-scrollbar-track: #f1f5f9;
+  --v-scrollbar-thumb: #cbd5e1;
+  --v-uml-primary-soft: #ecfdf5;
+  --v-uml-primary-border: #a7f3d0;
+  --v-uml-edge: #0c436e;
+  --v-uml-edge-halo: #ffffff;
+  --v-uml-circle: #0c436e;
+  --v-uml-box-bg: #ffffff;
+  --v-uml-box-muted: #f8fafc;
+  --v-uml-box-hover: #f1f5f9;
+  --v-uml-box-text: #0f172a;
+  --v-uml-box-text-muted: #64748b;
+  --v-uml-box-border: #cbd5e1;
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+  --v-page-bg: #0b1220;
+  --v-workspace-bg: #0f172a;
+  --v-workspace-dot: #475569;
+  --v-surface: #1e293b;
+  --v-surface-muted: #162032;
+  --v-surface-hover: #243044;
+  --v-text: #f1f5f9;
+  --v-text-secondary: #cbd5e1;
+  --v-text-muted: #94a3b8;
+  --v-text-faint: #64748b;
+  --v-border: #334155;
+  --v-border-subtle: #1e293b;
+  --v-card-border: rgba(255, 255, 255, 0.08);
+  --v-card-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  --v-overlay: rgba(30, 41, 59, 0.92);
+  --v-chrome-bg: #1e293b;
+  --v-chrome-hover: #334155;
+  --v-chrome-icon: #cbd5e1;
+  --v-chrome-icon-hover: #f8fafc;
+  --v-chrome-divider: #334155;
+  --v-table-header: #162032;
+  --v-input-bg: #0f172a;
+  --v-scrollbar-track: #1e293b;
+  --v-scrollbar-thumb: #475569;
+  --v-uml-primary-soft: rgba(4, 148, 132, 0.18);
+  --v-uml-primary-border: #0f766e;
+  --v-uml-edge: #5eead4;
+  --v-uml-edge-halo: #0f172a;
+  --v-uml-circle: #5eead4;
+  --v-uml-box-bg: #e8eef6;
+  --v-uml-box-muted: #d7e0ec;
+  --v-uml-box-hover: #c9d4e2;
+  --v-uml-box-text: #0f172a;
+  --v-uml-box-text-muted: #334155;
+  --v-uml-box-border: #94a3b8;
+}
+
+html,
+body,
+#root {
+  background-color: var(--v-page-bg);
+  color: var(--v-text);
+}
+
+.react-flow,
+.react-flow__renderer,
+.react-flow__pane,
+.react-flow__container {
+  background-color: var(--v-workspace-bg) !important;
+}
+
+.react-flow__controls {
+  background: var(--v-chrome-bg) !important;
+  border: 1px solid var(--v-border) !important;
+  box-shadow: var(--v-card-shadow) !important;
+}
+
+.react-flow__controls-button {
+  background: var(--v-chrome-bg) !important;
+  border-bottom: 1px solid var(--v-border) !important;
+  fill: var(--v-chrome-icon) !important;
+}
+
+.react-flow__controls-button:hover {
+  background: var(--v-chrome-hover) !important;
+}
+
+.react-flow__minimap {
+  background: var(--v-surface) !important;
+}
+
+.change-password-dialog {
+  background-color: var(--v-surface);
+  color: var(--v-text);
+  border: 1px solid var(--v-card-border);
+}
+
+.projects-table-scroll {
+  scrollbar-color: var(--v-scrollbar-thumb) var(--v-scrollbar-track);
+}
+
+.projects-table-scroll::-webkit-scrollbar-track {
+  background: var(--v-scrollbar-track) !important;
+}
+
+.projects-table-scroll::-webkit-scrollbar-thumb {
+  background: var(--v-scrollbar-thumb) !important;
+  border-color: var(--v-scrollbar-track) !important;
+}

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,0 +1,146 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+export const THEME_STORAGE_KEY = 'vitruv.theme';
+export type ThemeMode = 'light' | 'dark';
+
+const listeners = new Set<() => void>();
+
+let currentTheme: ThemeMode = 'light';
+
+export const themeVars = {
+  pageBg: 'var(--v-page-bg)',
+  workspaceBg: 'var(--v-workspace-bg)',
+  workspaceDot: 'var(--v-workspace-dot)',
+  surface: 'var(--v-surface)',
+  surfaceMuted: 'var(--v-surface-muted)',
+  surfaceHover: 'var(--v-surface-hover)',
+  text: 'var(--v-text)',
+  textSecondary: 'var(--v-text-secondary)',
+  textMuted: 'var(--v-text-muted)',
+  textFaint: 'var(--v-text-faint)',
+  border: 'var(--v-border)',
+  borderSubtle: 'var(--v-border-subtle)',
+  cardBorder: 'var(--v-card-border)',
+  cardShadow: 'var(--v-card-shadow)',
+  overlay: 'var(--v-overlay)',
+  chromeBg: 'var(--v-chrome-bg)',
+  chromeHover: 'var(--v-chrome-hover)',
+  chromeIcon: 'var(--v-chrome-icon)',
+  chromeIconHover: 'var(--v-chrome-icon-hover)',
+  chromeDivider: 'var(--v-chrome-divider)',
+  tableHeader: 'var(--v-table-header)',
+  inputBg: 'var(--v-input-bg)',
+  scrollbarTrack: 'var(--v-scrollbar-track)',
+  scrollbarThumb: 'var(--v-scrollbar-thumb)',
+  umlEdge: 'var(--v-uml-edge)',
+  umlEdgeHalo: 'var(--v-uml-edge-halo)',
+  umlCircle: 'var(--v-uml-circle)',
+  umlBoxBg: 'var(--v-uml-box-bg)',
+  umlBoxMuted: 'var(--v-uml-box-muted)',
+  umlBoxHover: 'var(--v-uml-box-hover)',
+  umlBoxText: 'var(--v-uml-box-text)',
+  umlBoxTextMuted: 'var(--v-uml-box-text-muted)',
+  umlBoxBorder: 'var(--v-uml-box-border)',
+} as const;
+
+export function isThemeMode(value: unknown): value is ThemeMode {
+  return value === 'light' || value === 'dark';
+}
+
+export function readStoredTheme(): ThemeMode {
+  try {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    if (isThemeMode(stored)) return stored;
+  } catch {
+    // private mode / unavailable storage
+  }
+  return 'light';
+}
+
+export function applyDocumentTheme(theme: ThemeMode): void {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  root.setAttribute('data-theme', theme);
+  root.style.colorScheme = theme;
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if (meta) {
+    meta.setAttribute('content', theme === 'dark' ? '#0b1220' : '#f7f8fa');
+  }
+}
+
+function emitThemeChange(): void {
+  listeners.forEach(listener => listener());
+}
+
+export function getTheme(): ThemeMode {
+  return currentTheme;
+}
+
+export function getServerThemeSnapshot(): ThemeMode {
+  return 'light';
+}
+
+export function setTheme(theme: ThemeMode): void {
+  currentTheme = theme;
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    // ignore persistence failures
+  }
+  applyDocumentTheme(theme);
+  emitThemeChange();
+}
+
+export function toggleTheme(): void {
+  setTheme(currentTheme === 'dark' ? 'light' : 'dark');
+}
+
+export function subscribeTheme(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function initTheme(): ThemeMode {
+  currentTheme = readStoredTheme();
+  applyDocumentTheme(currentTheme);
+  return currentTheme;
+}
+
+export function resetThemeStore(): void {
+  currentTheme = 'light';
+  try {
+    localStorage.removeItem(THEME_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+  applyDocumentTheme('light');
+  emitThemeChange();
+}
+
+if (typeof document !== 'undefined') {
+  initTheme();
+}
+
+export function useTheme(): {
+  theme: ThemeMode;
+  isDark: boolean;
+  setTheme: (theme: ThemeMode) => void;
+  toggleTheme: () => void;
+} {
+  const theme = useSyncExternalStore(subscribeTheme, getTheme, getServerThemeSnapshot);
+  const setThemeMode = useCallback((next: ThemeMode) => {
+    setTheme(next);
+  }, []);
+  const toggle = useCallback(() => {
+    toggleTheme();
+  }, []);
+
+  return {
+    theme,
+    isDark: theme === 'dark',
+    setTheme: setThemeMode,
+    toggleTheme: toggle,
+  };
+}

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -41,6 +41,18 @@ export const themeVars = {
   umlBoxText: 'var(--v-uml-box-text)',
   umlBoxTextMuted: 'var(--v-uml-box-text-muted)',
   umlBoxBorder: 'var(--v-uml-box-border)',
+  dangerBg: 'var(--v-danger-bg)',
+  dangerBorder: 'var(--v-danger-border)',
+  dangerText: 'var(--v-danger-text)',
+  successBg: 'var(--v-success-bg)',
+  successBorder: 'var(--v-success-border)',
+  successText: 'var(--v-success-text)',
+  warningBg: 'var(--v-warning-bg)',
+  warningBorder: 'var(--v-warning-border)',
+  warningText: 'var(--v-warning-text)',
+  disabledBg: 'var(--v-disabled-bg)',
+  disabledText: 'var(--v-disabled-text)',
+  brandSoft: 'var(--v-brand-soft)',
 } as const;
 
 export function isThemeMode(value: unknown): value is ThemeMode {


### PR DESCRIPTION
Summary
- Adds a user-controlled light/dark theme (default stays light). The choice is stored in localStorage as `vitruv.theme` and is not tied to the OS color scheme.
- Places the toggle in the home sidebar, canvas chrome, UML fullscreen toolbar, sign-in/sign-up card, profile Appearance section, and Change Password dialog.
- Updates main surfaces (home, canvas, UML, constraints, model library, profile, auth, and dialogs) to use shared CSS theme tokens so dark mode does not leave mixed white panels or low-contrast text.
